### PR TITLE
ci: add automated TestPyPI publishing on version tags

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,42 @@
+name: Publish to TestPyPI
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Build sdist and wheel
+        run: |
+          pip install build
+          python -m build
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Makefile` with common dev commands
 - Issue template chooser linking to docs and discussions
 - Documentation and Changelog checklist in PR template
+- Automated TestPyPI publishing on version tag push via trusted publishing (OIDC)
 
 - CI restructured: separate Lint job, test matrix on Python 3.10 through 3.13, PR checks (title, description, changelog) in one job
 - Dependabot PRs now auto-labeled `skip-changelog` to bypass changelog CI check


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically builds and publishes arksim to TestPyPI when a version tag (`v*`) is pushed. Uses PyPA trusted publishing (OIDC) so no API tokens are needed in secrets.

## Changes

- New workflow `.github/workflows/publish-testpypi.yml` with separate build and publish jobs
- Created `testpypi` GitHub environment for deployment audit trail
- Build job produces sdist + wheel via `python -m build` (hatchling backend)
- Publish job uses `pypa/gh-action-pypi-publish` with OIDC trusted publishing

The workflow is structured so a production PyPI publish job can be added later as a second downstream job reusing the same build artifact.

## Documentation and Changelog

- [x] Added an entry to `CHANGELOG.md` under the `[Unreleased]` section
- [x] No docs or changelog needed (explain why below)

CI workflow only, no user-facing behavior change.

## How to Test

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `pytest tests/` passes

After merge: tag a test release (`v0.0.1-rc1`), verify workflow runs and package appears on TestPyPI.

## Manual Setup Required

Configure trusted publisher on TestPyPI at https://test.pypi.org/manage/project/arksim/settings/publishing/:
- Owner: `arklexai`
- Repository: `arksim`
- Workflow: `publish-testpypi.yml`
- Environment: `testpypi`

## Reviewers

/cc @arklexai/arksim-maintainers