### PR TITLE
chore: add OSS release readiness improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,10 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
       - name: Test
-        run: pytest tests/ -v --tb=short
+        run: pytest tests/ -v --tb=short --cov=arksim --cov-report=xml --cov-report=term-missing
+      - name: Upload coverage
+        if: matrix.python-version == '3.13'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,22 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # Weekly on Monday at 6:00 UTC
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - GitHub Actions workflow to build, release, and publish `arksim` to PyPI on `v*` tag pushes, with dynamic VCS-based versioning via `hatch-vcs`
+- SPDX license headers (`Apache-2.0`) to all Python source files
+- Test coverage reporting with `pytest-cov` and Codecov integration
+- Coverage badge in README
+- CodeQL security scanning workflow (on push, PR, and weekly schedule)
+- Apache `NOTICE` file for third-party dependency attributions
 
 ### Changed
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,20 @@
+Arksim
+Copyright 2025 Arklex, Inc.
+
+Licensed under the Apache License, Version 2.0.
+
+This product includes software developed by third parties:
+
+- FastAPI (MIT License) - https://github.com/fastapi/fastapi
+- Uvicorn (BSD 3-Clause License) - https://github.com/encode/uvicorn
+- Pydantic (MIT License) - https://github.com/pydantic/pydantic
+- PyYAML (MIT License) - https://github.com/yaml/pyyaml
+- Jinja2 (BSD 3-Clause License) - https://github.com/pallets/jinja
+- OpenAI Python SDK (Apache 2.0 License) - https://github.com/openai/openai-python
+- tqdm (MIT License) - https://github.com/tqdm/tqdm
+- A2A SDK (Apache 2.0 License) - https://github.com/google-a2a/a2a-python
+
+Optional dependencies:
+- Azure Identity (MIT License) - https://github.com/Azure/azure-sdk-for-python
+- Anthropic Python SDK (MIT License) - https://github.com/anthropics/anthropic-sdk-python
+- Google GenAI (Apache 2.0 License) - https://github.com/googleapis/python-genai

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   </p>
   <p align="center">
     <a href="https://github.com/arklexai/arksim/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/arklexai/arksim/actions/workflows/ci.yml/badge.svg"></a>
+    <a href="https://codecov.io/gh/arklexai/arksim"><img alt="Coverage" src="https://codecov.io/gh/arklexai/arksim/branch/main/graph/badge.svg"></a>
     <a href="https://pypi.org/project/arksim/"><img alt="PyPI" src="https://img.shields.io/pypi/v/arksim.svg"></a>
     <a href="https://www.python.org/downloads/"><img alt="Python" src="https://img.shields.io/pypi/pyversions/arksim.svg"></a>
     <a href="https://github.com/arklexai/arksim/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>

--- a/arksim/__init__.py
+++ b/arksim/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Arksim: open-source agent simulation and evaluation toolkit."""
 
 import importlib

--- a/arksim/cli.py
+++ b/arksim/cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import argparse

--- a/arksim/config/__init__.py
+++ b/arksim/config/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Configuration module for the simulator."""
 
 from .core.agent import A2AConfig, AgentConfig, ChatCompletionsConfig

--- a/arksim/config/core/__init__.py
+++ b/arksim/config/core/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/arksim/config/core/agent.py
+++ b/arksim/config/core/agent.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import json
 import sys
 from pathlib import Path

--- a/arksim/config/types.py
+++ b/arksim/config/types.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 
 

--- a/arksim/config/utils.py
+++ b/arksim/config/utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import logging
 import os
 import re

--- a/arksim/constants.py
+++ b/arksim/constants.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Shared constants for the arksim package."""
 
 DEFAULT_MODEL = "gpt-5.1"

--- a/arksim/evaluator/__init__.py
+++ b/arksim/evaluator/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Evaluator package for agent and user evaluation.
 """

--- a/arksim/evaluator/base_metric.py
+++ b/arksim/evaluator/base_metric.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Provides the abstract base for all evaluation metrics, both built-in and user-defined custom metrics.
 """

--- a/arksim/evaluator/builtin_metrics.py
+++ b/arksim/evaluator/builtin_metrics.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Built-in evaluation metrics implemented as QuantitativeMetric subclasses."""
 
 from arksim.llms.chat import LLM

--- a/arksim/evaluator/entities.py
+++ b/arksim/evaluator/entities.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import sys

--- a/arksim/evaluator/error_detection.py
+++ b/arksim/evaluator/error_detection.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import contextlib
 import logging
 import uuid

--- a/arksim/evaluator/evaluate.py
+++ b/arksim/evaluator/evaluate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import logging
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/arksim/evaluator/evaluator.py
+++ b/arksim/evaluator/evaluator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import importlib.util
 import inspect
 import logging

--- a/arksim/evaluator/prompt_registry.py
+++ b/arksim/evaluator/prompt_registry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Central registry of all evaluation and simulation prompts.
 
 Provides a single lookup for every prompt used in the arksim

--- a/arksim/evaluator/utils/__init__.py
+++ b/arksim/evaluator/utils/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/arksim/evaluator/utils/constants.py
+++ b/arksim/evaluator/utils/constants.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Quantitative Metric Threshold (1-5 scale)
 METRIC_THRESHOLD = 3
 

--- a/arksim/evaluator/utils/enums.py
+++ b/arksim/evaluator/utils/enums.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 
 

--- a/arksim/evaluator/utils/error_messages.py
+++ b/arksim/evaluator/utils/error_messages.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 SKIPPED_GOOD_PERFORMANCE_REASON = (
     "All metrics passed threshold, qualitative evaluation skipped"
 )

--- a/arksim/evaluator/utils/prompts.py
+++ b/arksim/evaluator/utils/prompts.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #### Agent Performance Metrics Prompt ####
 helpfulness_system_prompt = """
 You are given a conversation between user and AI assistant. Please evaluate the last message from the AI assistant based on the following criteria, assigning a score from 1 to 5. Use the detailed descriptions below to guide your assessment:

--- a/arksim/evaluator/utils/schema.py
+++ b/arksim/evaluator/utils/schema.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pydantic import BaseModel
 
 

--- a/arksim/llms/__init__.py
+++ b/arksim/llms/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/arksim/llms/chat/__init__.py
+++ b/arksim/llms/chat/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from .llm import LLM
 
 __all__ = ["LLM"]

--- a/arksim/llms/chat/base/__init__.py
+++ b/arksim/llms/chat/base/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/arksim/llms/chat/base/base_llm.py
+++ b/arksim/llms/chat/base/base_llm.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from abc import ABC, abstractmethod
 from typing import TypeVar, overload
 

--- a/arksim/llms/chat/base/types.py
+++ b/arksim/llms/chat/base/types.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from typing import Literal
 
 from pydantic import BaseModel

--- a/arksim/llms/chat/llm.py
+++ b/arksim/llms/chat/llm.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from typing import cast
 
 from typing_extensions import Self

--- a/arksim/llms/chat/providers/azure_openai.py
+++ b/arksim/llms/chat/providers/azure_openai.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 from typing import Any, TypeVar, overload
 

--- a/arksim/llms/chat/providers/claude.py
+++ b/arksim/llms/chat/providers/claude.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, TypeVar, overload
 
 import anthropic

--- a/arksim/llms/chat/providers/gemini.py
+++ b/arksim/llms/chat/providers/gemini.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, TypeVar, overload
 
 from google import genai

--- a/arksim/llms/chat/providers/openai.py
+++ b/arksim/llms/chat/providers/openai.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, TypeVar, overload
 
 from openai import AsyncOpenAI, OpenAI

--- a/arksim/llms/chat/utils.py
+++ b/arksim/llms/chat/utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import functools
 import inspect

--- a/arksim/llms/embedding/__init__.py
+++ b/arksim/llms/embedding/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/arksim/llms/utils/__init__.py
+++ b/arksim/llms/utils/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from .azure import check_azure_env_vars, get_azure_token_provider
 
 __all__ = ["check_azure_env_vars", "get_azure_token_provider"]

--- a/arksim/llms/utils/azure.py
+++ b/arksim/llms/utils/azure.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 from collections.abc import Callable
 

--- a/arksim/scenario/__init__.py
+++ b/arksim/scenario/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from .entities import KnowledgeItem, Scenario, Scenarios
 
 __all__ = [

--- a/arksim/scenario/entities.py
+++ b/arksim/scenario/entities.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pydantic import BaseModel
 
 from arksim.utils.output import load_json_file

--- a/arksim/simulation_engine/__init__.py
+++ b/arksim/simulation_engine/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from .core import combine_knowledge
 from .entities import (
     Conversation,

--- a/arksim/simulation_engine/agent/__init__.py
+++ b/arksim/simulation_engine/agent/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from .factory import create_agent
 
 __all__ = [

--- a/arksim/simulation_engine/agent/base.py
+++ b/arksim/simulation_engine/agent/base.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from arksim.config import AgentConfig
 
 

--- a/arksim/simulation_engine/agent/clients/a2a.py
+++ b/arksim/simulation_engine/agent/clients/a2a.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import logging
 import uuid
 

--- a/arksim/simulation_engine/agent/clients/chat_completions.py
+++ b/arksim/simulation_engine/agent/clients/chat_completions.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import copy
 import logging
 import uuid

--- a/arksim/simulation_engine/agent/factory.py
+++ b/arksim/simulation_engine/agent/factory.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from arksim.config import AgentConfig, AgentType
 
 from .base import BaseAgent

--- a/arksim/simulation_engine/agent/utils.py
+++ b/arksim/simulation_engine/agent/utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import logging
 import time

--- a/arksim/simulation_engine/core/__init__.py
+++ b/arksim/simulation_engine/core/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from arksim.simulation_engine.core.multi_knowledge_handling import (
     TURN_KNOWLEDGE_FN,
     combine_knowledge,

--- a/arksim/simulation_engine/core/multi_knowledge_handling.py
+++ b/arksim/simulation_engine/core/multi_knowledge_handling.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import logging
 import random
 from enum import Enum

--- a/arksim/simulation_engine/core/profile.py
+++ b/arksim/simulation_engine/core/profile.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import logging
 
 from arksim.llms.chat import LLM

--- a/arksim/simulation_engine/entities.py
+++ b/arksim/simulation_engine/entities.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
 import sys

--- a/arksim/simulation_engine/simulator.py
+++ b/arksim/simulation_engine/simulator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import logging
 import traceback

--- a/arksim/simulation_engine/utils/prompts.py
+++ b/arksim/simulation_engine/utils/prompts.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 DEFAULT_SIMULATED_USER_PROMPT_TEMPLATE = """\
 You are a user interacting with an agent through multiple turns.
 The agent is supplied by the following conversation context:

--- a/arksim/simulation_engine/utils/schema.py
+++ b/arksim/simulation_engine/utils/schema.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from pydantic import BaseModel
 
 

--- a/arksim/simulation_engine/utils/utils.py
+++ b/arksim/simulation_engine/utils/utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any
 
 

--- a/arksim/ui/__init__.py
+++ b/arksim/ui/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/arksim/ui/api/__init__.py
+++ b/arksim/ui/api/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/arksim/ui/api/routes_evaluate.py
+++ b/arksim/ui/api/routes_evaluate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Evaluation API endpoints."""
 
 import threading

--- a/arksim/ui/api/routes_filesystem.py
+++ b/arksim/ui/api/routes_filesystem.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Filesystem browsing API endpoints."""
 
 import glob

--- a/arksim/ui/api/routes_results.py
+++ b/arksim/ui/api/routes_results.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Results API endpoints."""
 
 import os

--- a/arksim/ui/api/routes_simulate.py
+++ b/arksim/ui/api/routes_simulate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Simulation API endpoints."""
 
 import asyncio

--- a/arksim/ui/api/state.py
+++ b/arksim/ui/api/state.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Server-side state manager for arksim UI jobs."""
 
 import asyncio

--- a/arksim/ui/api/ws_logs.py
+++ b/arksim/ui/api/ws_logs.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """WebSocket endpoint for real-time log streaming."""
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect

--- a/arksim/ui/app.py
+++ b/arksim/ui/app.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Arksim Control Plane — FastAPI application."""
 
 import asyncio

--- a/arksim/utils/concurrency/__init__.py
+++ b/arksim/utils/concurrency/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from .workers import resolve_num_workers, validate_num_workers
 
 __all__ = [

--- a/arksim/utils/concurrency/workers.py
+++ b/arksim/utils/concurrency/workers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 def validate_num_workers(num_workers: int | str) -> None:
     """Validate that num_workers is an integer or the string 'auto'."""
     if isinstance(num_workers, str):

--- a/arksim/utils/html_report/__init__.py
+++ b/arksim/utils/html_report/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """HTML report generation module for simulator."""
 
 from .generate_html_report import generate_html_report

--- a/arksim/utils/html_report/generate_html_report.py
+++ b/arksim/utils/html_report/generate_html_report.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #!/usr/bin/env python3
 """
 Generate a standalone HTML report by embedding data into the template.

--- a/arksim/utils/logger/__init__.py
+++ b/arksim/utils/logger/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from .logging import get_logger
 
 __all__ = [

--- a/arksim/utils/logger/logging.py
+++ b/arksim/utils/logger/logging.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import logging
 import os
 import sys

--- a/arksim/utils/output/__init__.py
+++ b/arksim/utils/output/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from .utils import (
     load_json_file,
     resolve_output_dir,

--- a/arksim/utils/output/types.py
+++ b/arksim/utils/output/types.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 
 

--- a/arksim/utils/output/utils.py
+++ b/arksim/utils/output/utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import asyncio
 import json
 import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ all = [
 dev = [
     "pytest",
     "pytest-asyncio>=0.24.0",
+    "pytest-cov",
     "pre-commit",
     "ruff",
 ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Pytest configuration and fixtures for simulator tests."""
 
 import os

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit/test_agent_config.py
+++ b/tests/unit/test_agent_config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for agent configuration models."""
 
 import os

--- a/tests/unit/test_agent_factory.py
+++ b/tests/unit/test_agent_factory.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for simulation engine agent factory."""
 
 import pytest

--- a/tests/unit/test_error_detection.py
+++ b/tests/unit/test_error_detection.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for error_detection: collect_agent_behavior_failure_reasoning.
 
 Uses importlib to load modules directly from file paths, bypassing

--- a/tests/unit/test_evaluator_entities.py
+++ b/tests/unit/test_evaluator_entities.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for evaluator entities and enums."""
 
 import pytest

--- a/tests/unit/test_html_report_integration.py
+++ b/tests/unit/test_html_report_integration.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Integration test for HTML report generation.
 
 Uses importlib to load modules directly from file paths, bypassing

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for LLM provider abstraction."""
 
 import os

--- a/tests/unit/test_output_utils.py
+++ b/tests/unit/test_output_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for output utilities."""
 
 import json

--- a/tests/unit/test_simulation_engine_entities.py
+++ b/tests/unit/test_simulation_engine_entities.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for simulation engine entities."""
 
 import pytest


### PR DESCRIPTION
## Summary
- Add SPDX-License-Identifier (`Apache-2.0`) headers to all 82 Python source files
- Add `pytest-cov` and Codecov integration for test coverage reporting with README badge
- Add CodeQL security scanning workflow (push/PR/weekly schedule)
- Add Apache `NOTICE` file for third-party dependency attributions

## Test plan
- [ ] CI passes (lint + tests across Python 3.10-3.13)
- [ ] CodeQL workflow appears in Actions tab
- [ ] Coverage report generates in CI output
- [ ] Verify SPDX headers present in all `.py` files