### PR TITLE
docs: remove Azure from documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python SDK with `run_simulation()` and `run_evaluation()`
 - Parallel execution with configurable worker count
 - Example setups for e-commerce and bank insurance use cases
-- OpenAI, Anthropic, Google Gemini, and Azure OpenAI provider support
+- OpenAI, Anthropic, and Google Gemini provider support
 - HTML report generation for evaluation results
 
 [Unreleased]: https://github.com/arklexai/arksim/compare/v0.0.1...HEAD

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -6,7 +6,7 @@ title: "Installation"
 ## Requirements
 
 - Python 3.10 or later (up to 3.13)
-- An API key from a supported LLM provider ([OpenAI](https://developers.openai.com/api/docs), [Anthropic](https://platform.claude.com/docs/en/home), [Gemini](https://ai.google.dev/gemini-api/docs/api-key), or Azure OpenAI)
+- An API key from a supported LLM provider ([OpenAI](https://developers.openai.com/api/docs), [Anthropic](https://platform.claude.com/docs/en/home), or [Gemini](https://ai.google.dev/gemini-api/docs/api-key))
 
 ## Install from PyPI
 
@@ -19,9 +19,6 @@ pip install arksim
 Arksim uses OpenAI by default. To use other providers, install the corresponding extra:
 
 ```bash
-# Azure OpenAI
-pip install arksim[azure]
-
 # Anthropic (Claude)
 pip install arksim[anthropic]
 

--- a/docs/simulate-conversation.mdx
+++ b/docs/simulate-conversation.mdx
@@ -141,7 +141,7 @@ Arksim supports two agent protocols:
 
 | Protocol                                                                            | When to use                                                                            |
 | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [**Chat Completions**](https://developers.openai.com/api/reference/resources/chat/) | Any agent that accepts OpenAI-compatible requests (OpenAI, Azure, or a custom wrapper) |
+| [**Chat Completions**](https://developers.openai.com/api/reference/resources/chat/) | Any agent that accepts OpenAI-compatible requests (OpenAI or a custom wrapper) |
 | [**A2A**](https://a2a-protocol.org/latest/)                                         | Agents exposed via the Agent-to-Agent protocol                                         |
 
 <Tabs>


### PR DESCRIPTION
## Summary

Removes all Azure references from docs so the documented supported providers are OpenAI, Anthropic, and Gemini. No code or runtime behavior is changed.

Closes #

## Changes

- **docs/simulate-conversation.mdx**: Chat Completions table: "OpenAI, Azure, or a custom wrapper" → "OpenAI or a custom wrapper".
- **docs/installation.mdx**: Requirements: dropped "or Azure OpenAI" from the API key sentence; removed the "Azure OpenAI" optional extra and `pip install arksim[azure]` from the install examples.
- **CHANGELOG.md**: Unreleased feature list: "OpenAI, Anthropic, Google Gemini, and Azure OpenAI" → "OpenAI, Anthropic, and Google Gemini".

## Documentation and Changelog

- [x] Added an entry to `CHANGELOG.md` under the `[Unreleased]` section *(updated existing Unreleased bullet to drop Azure)*
- [x] Updated relevant docs in `docs/` (if behavior, config, or API changed)
- [ ] Updated `README.md` (if installation, quickstart, or usage changed)
- [ ] No docs or changelog needed (explain why below)

## How to Test

- [ ] `ruff check .` passes
- [ ] `ruff format --check .` passes
- [ ] `pytest tests/` passes
- [ ] Manual verification: Skim `docs/installation.mdx`, `docs/simulate-conversation.mdx`, and `CHANGELOG.md` to confirm no Azure mentions remain and wording reads correctly.

## Notes

Azure provider code, `arksim[azure]` extra, and UI references are unchanged; only documentation was updated. If you later remove Azure from the codebase, that can be a separate PR.

## Reviewers

/cc @arklexai/arksim-maintainers