### PR TITLE
ci: add Codecov token to coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,5 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - SPDX license headers (`Apache-2.0`) to all Python source files
-- Test coverage reporting with `pytest-cov` and Codecov integration
+- Test coverage reporting with `pytest-cov` and Codecov integration (with token authentication)
 - Coverage badge in README
 - CodeQL security scanning workflow (on push, PR, and weekly schedule)
 - Apache `NOTICE` file for third-party dependency attributions


### PR DESCRIPTION
## Summary
- Add `token: ${{ secrets.CODECOV_TOKEN }}` to the Codecov upload step in CI
- Without this, uploads fail with `Token required because branch is protected`

## Test plan
- [x] CI passes
- [x] Coverage upload step shows `Token length: 36` (not 0)
- [x] Upload completes successfully (`Process Upload complete`)
- [ ] Coverage appears on [app.codecov.io/gh/arklexai/arksim](https://app.codecov.io/gh/arklexai/arksim) (will populate after merge to main)