### PR TITLE
chore: add OSS hardening for security, coverage, and annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,19 @@ jobs:
           ruff check .
           ruff format --check .
 
+  security:
+    name: Security scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Bandit
+        run: |
+          pip install bandit[toml]
+          bandit -r arksim/ -c pyproject.toml
+
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
@@ -39,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
       - name: Test
-        run: pytest tests/ -v --tb=short --cov=arksim --cov-report=xml --cov-report=term-missing
+        run: pytest tests/ -v --tb=short --cov=arksim --cov-report=xml --cov-report=term-missing --cov-fail-under=30
       - name: Upload coverage
         if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- Add your changes here under the appropriate heading. -->
 <!-- Use: Added, Changed, Deprecated, Removed, Fixed, Security -->
 
+### Added
+
+- Bandit security scanning in CI pipeline
+- Test coverage threshold (30% minimum) enforced in CI
+- `from __future__ import annotations` to all source files for consistent typing
+
+### Changed
+
+- Coverage badge switched from Codecov-hosted to shields.io for reliability
+- Expanded SECURITY.md with response process, scope, and disclosure guidelines
+
 ## [0.0.4] - 2026-03-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </p>
   <p align="center">
     <a href="https://github.com/arklexai/arksim/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/arklexai/arksim/actions/workflows/ci.yml/badge.svg"></a>
-    <a href="https://codecov.io/gh/arklexai/arksim"><img alt="Coverage" src="https://codecov.io/gh/arklexai/arksim/branch/main/graph/badge.svg"></a>
+    <a href="https://app.codecov.io/gh/arklexai/arksim"><img alt="Coverage" src="https://img.shields.io/codecov/c/github/arklexai/arksim?token=90b886a9-5e88-4abf-a64e-8618c3c04677"></a>
     <a href="https://pypi.org/project/arksim/"><img alt="PyPI" src="https://img.shields.io/pypi/v/arksim.svg?cacheSeconds=300"></a>
     <a href="https://www.python.org/downloads/"><img alt="Python" src="https://img.shields.io/pypi/pyversions/arksim.svg?cacheSeconds=300"></a>
     <a href="https://github.com/arklexai/arksim/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,5 +17,27 @@ Instead, email **support@arklex.ai** with:
 - A description of the vulnerability
 - Steps to reproduce
 - Potential impact
+- Any suggested fixes (optional)
 
-We will acknowledge your report within 48 hours and provide a timeline for a fix.
+## Response Process
+
+1. **Acknowledgment** — We will acknowledge your report within 48 hours.
+2. **Assessment** — We will assess the severity and impact within 5 business days.
+3. **Fix** — We will work on a fix and coordinate disclosure with you.
+4. **Release** — Security fixes are released as patch versions (e.g., 0.0.x).
+5. **Disclosure** — We will credit reporters in the release notes unless anonymity is requested.
+
+## Scope
+
+The following are in scope for security reports:
+
+- Vulnerabilities in the `arksim` Python package
+- Security issues in example code that could mislead users
+- CI/CD pipeline security weaknesses
+- Dependency vulnerabilities with known exploits
+
+The following are out of scope:
+
+- Vulnerabilities in third-party dependencies without a known exploit
+- Issues requiring physical access to the machine
+- Social engineering attacks

--- a/arksim/config/core/agent.py
+++ b/arksim/config/core/agent.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import json
 import sys
 from pathlib import Path
@@ -114,7 +116,7 @@ class AgentConfig(BaseModel):
         return data
 
     @classmethod
-    def load(cls, path: str | Path) -> "AgentConfig":
+    def load(cls, path: str | Path) -> AgentConfig:
         """Load agent configuration from a JSON file."""
         path = Path(path)
         if not path.exists():

--- a/arksim/config/types.py
+++ b/arksim/config/types.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from enum import Enum
 
 

--- a/arksim/config/utils.py
+++ b/arksim/config/utils.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 import os
 import re

--- a/arksim/constants.py
+++ b/arksim/constants.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Shared constants for the arksim package."""
 
+from __future__ import annotations
+
 DEFAULT_MODEL = "gpt-5.1"
 DEFAULT_PROVIDER = "openai"

--- a/arksim/evaluator/base_metric.py
+++ b/arksim/evaluator/base_metric.py
@@ -3,6 +3,8 @@
 Provides the abstract base for all evaluation metrics, both built-in and user-defined custom metrics.
 """
 
+from __future__ import annotations
+
 import abc
 from typing import Any
 

--- a/arksim/evaluator/builtin_metrics.py
+++ b/arksim/evaluator/builtin_metrics.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Built-in evaluation metrics implemented as QuantitativeMetric subclasses."""
 
+from __future__ import annotations
+
 from arksim.llms.chat import LLM
 
 from .base_metric import (

--- a/arksim/evaluator/error_detection.py
+++ b/arksim/evaluator/error_detection.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import contextlib
 import logging
 import uuid

--- a/arksim/evaluator/evaluate.py
+++ b/arksim/evaluator/evaluate.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/arksim/evaluator/evaluator.py
+++ b/arksim/evaluator/evaluator.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import importlib.util
 import inspect
 import logging

--- a/arksim/evaluator/utils/constants.py
+++ b/arksim/evaluator/utils/constants.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 # Quantitative Metric Threshold (1-5 scale)
 METRIC_THRESHOLD = 3
 

--- a/arksim/evaluator/utils/enums.py
+++ b/arksim/evaluator/utils/enums.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from enum import Enum
 
 

--- a/arksim/evaluator/utils/error_messages.py
+++ b/arksim/evaluator/utils/error_messages.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 SKIPPED_GOOD_PERFORMANCE_REASON = (
     "All metrics passed threshold, qualitative evaluation skipped"
 )

--- a/arksim/evaluator/utils/prompts.py
+++ b/arksim/evaluator/utils/prompts.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 #### Agent Performance Metrics Prompt ####
 helpfulness_system_prompt = """
 You are given a conversation between user and AI assistant. Please evaluate the last message from the AI assistant based on the following criteria, assigning a score from 1 to 5. Use the detailed descriptions below to guide your assessment:

--- a/arksim/evaluator/utils/schema.py
+++ b/arksim/evaluator/utils/schema.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from pydantic import BaseModel
 
 

--- a/arksim/llms/chat/base/base_llm.py
+++ b/arksim/llms/chat/base/base_llm.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import TypeVar, overload
 

--- a/arksim/llms/chat/base/types.py
+++ b/arksim/llms/chat/base/types.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import Literal
 
 from pydantic import BaseModel

--- a/arksim/llms/chat/llm.py
+++ b/arksim/llms/chat/llm.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import cast
 
 from typing_extensions import Self

--- a/arksim/llms/chat/providers/azure_openai.py
+++ b/arksim/llms/chat/providers/azure_openai.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import os
 from typing import Any, TypeVar, overload
 

--- a/arksim/llms/chat/providers/claude.py
+++ b/arksim/llms/chat/providers/claude.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import Any, TypeVar, overload
 
 import anthropic

--- a/arksim/llms/chat/providers/gemini.py
+++ b/arksim/llms/chat/providers/gemini.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import Any, TypeVar, overload
 
 from google import genai

--- a/arksim/llms/chat/providers/openai.py
+++ b/arksim/llms/chat/providers/openai.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import Any, TypeVar, overload
 
 from openai import AsyncOpenAI, OpenAI

--- a/arksim/llms/chat/utils.py
+++ b/arksim/llms/chat/utils.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import asyncio
 import functools
 import inspect

--- a/arksim/llms/utils/azure.py
+++ b/arksim/llms/utils/azure.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import os
 from collections.abc import Callable
 

--- a/arksim/scenario/entities.py
+++ b/arksim/scenario/entities.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from pydantic import BaseModel, model_validator
 
 from arksim.utils.output import load_json_file
@@ -46,6 +48,6 @@ class Scenarios(BaseModel):
     scenarios: list[Scenario]
 
     @classmethod
-    def load(cls, path: str) -> "Scenarios":
+    def load(cls, path: str) -> Scenarios:
         """Load scenarios from a JSON file."""
         return cls.model_validate(load_json_file(path))

--- a/arksim/simulation_engine/agent/base.py
+++ b/arksim/simulation_engine/agent/base.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from arksim.config import AgentConfig
 
 

--- a/arksim/simulation_engine/agent/clients/a2a.py
+++ b/arksim/simulation_engine/agent/clients/a2a.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 import uuid
 

--- a/arksim/simulation_engine/agent/clients/chat_completions.py
+++ b/arksim/simulation_engine/agent/clients/chat_completions.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import copy
 import logging
 import uuid

--- a/arksim/simulation_engine/agent/factory.py
+++ b/arksim/simulation_engine/agent/factory.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from arksim.config import AgentConfig, AgentType
 
 from .base import BaseAgent

--- a/arksim/simulation_engine/agent/utils.py
+++ b/arksim/simulation_engine/agent/utils.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import asyncio
 import logging
 import time

--- a/arksim/simulation_engine/core/multi_knowledge_handling.py
+++ b/arksim/simulation_engine/core/multi_knowledge_handling.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 import random
 from enum import Enum

--- a/arksim/simulation_engine/simulator.py
+++ b/arksim/simulation_engine/simulator.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import asyncio
 import logging
 import traceback

--- a/arksim/simulation_engine/utils/prompts.py
+++ b/arksim/simulation_engine/utils/prompts.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 DEFAULT_SIMULATED_USER_PROMPT_TEMPLATE = """\
 You are a user interacting with an agent through multiple turns.
 The agent is supplied by the following conversation context:

--- a/arksim/simulation_engine/utils/utils.py
+++ b/arksim/simulation_engine/utils/utils.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from typing import Any
 
 

--- a/arksim/ui/api/routes_evaluate.py
+++ b/arksim/ui/api/routes_evaluate.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Evaluation API endpoints."""
 
+from __future__ import annotations
+
 import threading
 
 from fastapi import APIRouter, Request

--- a/arksim/ui/api/routes_filesystem.py
+++ b/arksim/ui/api/routes_filesystem.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Filesystem browsing API endpoints."""
 
+from __future__ import annotations
+
 import glob
 import os
 from pathlib import Path

--- a/arksim/ui/api/routes_results.py
+++ b/arksim/ui/api/routes_results.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Results API endpoints."""
 
+from __future__ import annotations
+
 import os
 
 from fastapi import APIRouter, Request

--- a/arksim/ui/api/routes_simulate.py
+++ b/arksim/ui/api/routes_simulate.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Simulation API endpoints."""
 
+from __future__ import annotations
+
 import asyncio
 import threading
 

--- a/arksim/ui/api/state.py
+++ b/arksim/ui/api/state.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Server-side state manager for arksim UI jobs."""
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import logging

--- a/arksim/ui/api/ws_logs.py
+++ b/arksim/ui/api/ws_logs.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """WebSocket endpoint for real-time log streaming."""
 
+from __future__ import annotations
+
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from arksim.ui.api.state import AppState

--- a/arksim/ui/app.py
+++ b/arksim/ui/app.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Arksim Control Plane — FastAPI application."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import threading

--- a/arksim/utils/concurrency/workers.py
+++ b/arksim/utils/concurrency/workers.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+
 def validate_num_workers(num_workers: int | str) -> None:
     """Validate that num_workers is an integer or the string 'auto'."""
     if isinstance(num_workers, str):

--- a/arksim/utils/html_report/generate_html_report.py
+++ b/arksim/utils/html_report/generate_html_report.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-#!/usr/bin/env python3
 """
 Generate a standalone HTML report by embedding data into the template.
 This allows the HTML to be opened directly without needing an HTTP server.
 
 This module is called directly from arksim.py with data objects.
 """
+
+from __future__ import annotations
 
 import json
 from collections import Counter, defaultdict

--- a/arksim/utils/logger/logging.py
+++ b/arksim/utils/logger/logging.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import logging
 import os
 import sys

--- a/arksim/utils/output/types.py
+++ b/arksim/utils/output/types.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from enum import Enum
 
 

--- a/arksim/utils/output/utils.py
+++ b/arksim/utils/output/utils.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import asyncio
 import json
 import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,13 @@ ignore = [
   "E501",  # Line too long (if you're using Black)
   "UP045", # Use X | None instead of Optional[X] - keep for compatibility
 ]
+
+[tool.coverage.run]
+source = ["arksim"]
+
+[tool.coverage.report]
+fail_under = 30
+
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101", "B110"]


### PR DESCRIPTION
## Summary
- Add **Bandit security scanning** as a new CI job (scans `arksim/`, skips tests)
- Add **test coverage threshold** (30% minimum) — CI fails if coverage drops below baseline
- Add `from __future__ import annotations` to all 45 source files that were missing it
- Switch **coverage badge** from Codecov-hosted SVG to shields.io (more reliable)
- Expand **SECURITY.md** with response process, scope definition, and disclosure guidelines
- Add `[tool.coverage]` and `[tool.bandit]` config to `pyproject.toml`
- Clean up stale shebang in `generate_html_report.py`

## Test plan
- [x] CI passes (lint, tests x4 Python versions)
- [x] Bandit security scan passes clean
- [x] Coverage threshold enforced (38% > 30% minimum)
- [x] `ruff check` and `ruff format --check` pass
- [x] PR checks pass (title format, description, changelog)
- [x] CodeQL analysis