### PR TITLE
fix: remove stale token from Codecov coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </p>
   <p align="center">
     <a href="https://github.com/arklexai/arksim/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/arklexai/arksim/actions/workflows/ci.yml/badge.svg"></a>
-    <a href="https://app.codecov.io/gh/arklexai/arksim"><img alt="Coverage" src="https://img.shields.io/codecov/c/github/arklexai/arksim?token=90b886a9-5e88-4abf-a64e-8618c3c04677"></a>
+    <a href="https://app.codecov.io/gh/arklexai/arksim"><img alt="Coverage" src="https://img.shields.io/codecov/c/github/arklexai/arksim"></a>
     <a href="https://pypi.org/project/arksim/"><img alt="PyPI" src="https://img.shields.io/pypi/v/arksim.svg?cacheSeconds=300"></a>
     <a href="https://www.python.org/downloads/"><img alt="Python" src="https://img.shields.io/pypi/pyversions/arksim.svg?cacheSeconds=300"></a>
     <a href="https://github.com/arklexai/arksim/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>


### PR DESCRIPTION
## Summary

The README coverage badge shows "repository not found" because the hardcoded Codecov token in the shields.io URL is stale. Removing the `?token=...` parameter fixes it — the public endpoint works without authentication for public repos.

## Changes

- Remove `?token=90b886a9-5e88-4abf-a64e-8618c3c04677` from the Codecov badge URL in `README.md`

## Documentation

- [x] No docs needed (badge-only fix)

## How to Test

- Before: badge shows "repository not found"
- After: badge shows actual coverage (38%)