### PR TITLE
ci: trigger CI on release-please branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, release-please--branches--*]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

- Adds `release-please--branches--*` to the CI workflow push triggers so release PRs created by release-please automatically get CI checks without needing manual intervention.

## Context

Release-please creates PRs via the GitHub API rather than git push, which means the `pull_request` event never fires for its branch pushes. This left PR #58 with all required status checks stuck in a waiting state.

## Test plan

- [ ] Verify CI runs on the release-please branch after merge
- [ ] Future release-please PRs should trigger CI automatically