### PR TITLE
refactor(dify): replace dify-client SDK with httpx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **simulation:** bump output schema version to v1.1 (additive `tool_calls` field on Message)
 * **evaluator:** bump evaluation output schema version to v1.1 (additive `error_scenario_mappings` field)
 * **chat-completions:** refactor to persistent httpx client with `AgentResponse` return type
+* **examples:** replace `dify-client` SDK with direct HTTP (httpx) in the Dify integration
 
 ### Fixed
 

--- a/examples/integrations/dify/README.md
+++ b/examples/integrations/dify/README.md
@@ -1,15 +1,15 @@
 # Dify Integration
 
-This example demonstrates how to connect a [Dify](https://dify.ai) chatbot to ArkSim using the custom agent connector. It tests a customer service bot backed by a Dify knowledge base.
+This example connects a [Dify](https://dify.ai) Chatbot app to ArkSim using the custom agent connector. It uses Dify's Chat API directly via httpx with no SDK dependency.
 
-> **Note:** This integration requires a **Chatbot** app in Dify (not a Workflow or Text Generator app).
+> **Note:** This integration uses blocking mode, which requires a **Chatbot** app in Dify (not an Agent, Workflow, or Text Generator app).
 
 ## Prerequisites
 
-1. Install ArkSim and the Dify Python SDK:
+1. Install ArkSim:
 
    ```bash
-   pip install arksim dify-client
+   pip install arksim
    ```
 
 2. Create a **Chatbot** app in Dify (Cloud or self-hosted) and add a knowledge base with your documents. The included scenarios assume a home improvement store knowledge base, but you can adapt them to match your own content.
@@ -46,6 +46,6 @@ Results are written to `./results/simulation/simulation.json`. The evaluation re
 
 | File              | Description                                              |
 | ----------------- | -------------------------------------------------------- |
-| `custom_agent.py` | ArkSim agent that connects to Dify via the Chat API      |
+| `custom_agent.py` | ArkSim agent that connects to Dify via HTTP (httpx)      |
 | `config.yaml`     | ArkSim simulation and evaluation settings                |
 | `scenarios.json`  | Test scenarios for a home improvement customer service bot |

--- a/examples/integrations/dify/custom_agent.py
+++ b/examples/integrations/dify/custom_agent.py
@@ -1,20 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 """Dify integration for ArkSim.
 
-Install: pip install dify-client
-Auth:    export DIFY_API_KEY="<your-app-api-key>"
+Connects to a Dify Chatbot app via the Chat API using httpx.
+Uses Dify's non-streaming (blocking) response mode.
+
+Auth: export DIFY_API_KEY="<your-app-api-key>"
 """
 
 from __future__ import annotations
 
-import asyncio
 import os
 import uuid
 
-from dify_client import ChatClient
+import httpx
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+
+_DEFAULT_BASE_URL = "https://api.dify.ai/v1"
+_REQUEST_TIMEOUT = httpx.Timeout(120.0)
 
 
 class DifyAgent(BaseAgent):
@@ -27,35 +31,62 @@ class DifyAgent(BaseAgent):
                 "DIFY_API_KEY environment variable is required. "
                 "Get it from API Access in your Dify app dashboard."
             )
-        self._client = ChatClient(api_key)
-        self._client.base_url = os.environ.get(
-            "DIFY_BASE_URL", "https://api.dify.ai/v1"
-        )
+        base_url = os.environ.get("DIFY_BASE_URL", _DEFAULT_BASE_URL)
+        self._endpoint = f"{base_url.rstrip('/')}/chat-messages"
+        self._headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        self._client = httpx.AsyncClient(timeout=_REQUEST_TIMEOUT)
         self._conversation_id: str | None = None
 
     async def get_chat_id(self) -> str:
         return self._chat_id
 
     async def execute(self, user_query: str, **kwargs: object) -> str:
-        call_kwargs: dict[str, object] = {
+        body: dict[str, object] = {
             "inputs": {},
             "query": user_query,
             "user": self._chat_id,
             "response_mode": "blocking",
         }
         if self._conversation_id is not None:
-            call_kwargs["conversation_id"] = self._conversation_id
+            body["conversation_id"] = self._conversation_id
 
-        response = await asyncio.to_thread(
-            self._client.create_chat_message, **call_kwargs
-        )
-        response.raise_for_status()
-        result = response.json()
+        try:
+            response = await self._client.post(
+                self._endpoint, headers=self._headers, json=body
+            )
+            response.raise_for_status()
+        except httpx.ConnectError as exc:
+            raise RuntimeError(
+                f"Could not connect to Dify API at {self._endpoint}. "
+                "Is the server running?"
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise RuntimeError(
+                f"Request to Dify API at {self._endpoint} timed out."
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            detail = exc.response.text
+            if status == 401:
+                raise RuntimeError(
+                    "Dify API authentication failed. "
+                    "Check your DIFY_API_KEY environment variable."
+                ) from exc
+            raise RuntimeError(f"Dify API returned HTTP {status}: {detail}") from exc
+        data = response.json()
 
-        self._conversation_id = result.get("conversation_id")
-        answer = result.get("answer")
+        new_id = data.get("conversation_id")
+        if new_id is not None:
+            self._conversation_id = new_id
+        answer = data.get("answer")
         if answer is None:
             raise RuntimeError(
-                f"Dify response missing 'answer' field. Response: {result}"
+                f"Dify response missing 'answer' field. Response: {data}"
             )
         return answer
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/tests/unit/test_dify_agent.py
+++ b/tests/unit/test_dify_agent.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Dify integration agent (httpx).
+
+Covers constructor validation, HTTP call mechanics, conversation_id
+persistence, and error handling.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from arksim.config import AgentConfig
+from arksim.simulation_engine.agent.base import BaseAgent
+
+
+def _load_dify_agent_class() -> type[BaseAgent]:
+    """Lazy-import DifyAgent to avoid module-level DIFY_API_KEY requirement."""
+    from examples.integrations.dify.custom_agent import DifyAgent
+
+    return DifyAgent
+
+
+def _make_agent_config() -> AgentConfig:
+    """Minimal AgentConfig for testing."""
+    return AgentConfig(
+        agent_type="custom",
+        agent_name="dify-test",
+        custom_config={"module_path": "./custom_agent.py"},
+    )
+
+
+def _dify_response(
+    answer: str = "Hello!",
+    conversation_id: str = "conv-123",
+) -> dict[str, Any]:
+    """Build a Dify blocking-mode response dict."""
+    return {
+        "answer": answer,
+        "conversation_id": conversation_id,
+        "message_id": str(uuid.uuid4()),
+    }
+
+
+class TestDifyAgentInit:
+    """Constructor validation."""
+
+    def test_missing_api_key_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DIFY_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="DIFY_API_KEY"):
+            _load_dify_agent_class()(_make_agent_config())
+
+
+class TestDifyAgentExecute:
+    """HTTP call and response parsing."""
+
+    @pytest.fixture()
+    def agent(self, monkeypatch: pytest.MonkeyPatch) -> BaseAgent:
+        monkeypatch.setenv("DIFY_API_KEY", "test-key-123")
+        return _load_dify_agent_class()(_make_agent_config())
+
+    async def test_returns_answer(self, agent: BaseAgent) -> None:
+        """Successful response returns the answer string."""
+        mock_response = httpx.Response(
+            200,
+            json=_dify_response(answer="I can help with that."),
+            request=httpx.Request("POST", "https://api.dify.ai/v1/chat-messages"),
+        )
+        agent._client = AsyncMock()
+        agent._client.post = AsyncMock(return_value=mock_response)
+        result = await agent.execute("How do I return an item?")
+        assert result == "I can help with that."
+
+    async def test_conversation_id_persists(self, agent: BaseAgent) -> None:
+        """Second call sends conversation_id from first response."""
+        mock_response = httpx.Response(
+            200,
+            json=_dify_response(conversation_id="conv-abc"),
+            request=httpx.Request("POST", "https://api.dify.ai/v1/chat-messages"),
+        )
+        agent._client = AsyncMock()
+        agent._client.post = AsyncMock(return_value=mock_response)
+        await agent.execute("first message")
+        assert agent._conversation_id == "conv-abc"
+        await agent.execute("second message")
+        second_call_kwargs = agent._client.post.call_args_list[1]
+        body = second_call_kwargs.kwargs.get("json") or second_call_kwargs[1].get(
+            "json"
+        )
+        assert body["conversation_id"] == "conv-abc"
+
+    async def test_missing_answer_raises(self, agent: BaseAgent) -> None:
+        """Response without 'answer' field raises RuntimeError."""
+        mock_response = httpx.Response(
+            200,
+            json={"conversation_id": "conv-123"},
+            request=httpx.Request("POST", "https://api.dify.ai/v1/chat-messages"),
+        )
+        agent._client = AsyncMock()
+        agent._client.post = AsyncMock(return_value=mock_response)
+        with pytest.raises(RuntimeError, match="answer"):
+            await agent.execute("hello")
+
+    async def test_auth_error_mentions_api_key(self, agent: BaseAgent) -> None:
+        """401 response raises RuntimeError mentioning DIFY_API_KEY."""
+        mock_response = httpx.Response(
+            401,
+            json={"code": "invalid_api_key", "message": "Invalid API key"},
+            request=httpx.Request("POST", "https://api.dify.ai/v1/chat-messages"),
+        )
+        agent._client = AsyncMock()
+        agent._client.post = AsyncMock(return_value=mock_response)
+        with pytest.raises(RuntimeError, match="DIFY_API_KEY"):
+            await agent.execute("hello")
+
+    async def test_server_error_includes_status_and_body(
+        self, agent: BaseAgent
+    ) -> None:
+        """5xx response raises RuntimeError with status code and response body."""
+        mock_response = httpx.Response(
+            500,
+            text="Internal Server Error",
+            request=httpx.Request("POST", "https://api.dify.ai/v1/chat-messages"),
+        )
+        agent._client = AsyncMock()
+        agent._client.post = AsyncMock(return_value=mock_response)
+        with pytest.raises(RuntimeError, match="HTTP 500"):
+            await agent.execute("hello")
+
+    async def test_connect_error_raises_readable_message(
+        self, agent: BaseAgent
+    ) -> None:
+        """Unreachable Dify server raises RuntimeError with diagnostic message."""
+        agent._client = AsyncMock()
+        agent._client.post = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+        with pytest.raises(RuntimeError, match="Could not connect to Dify API"):
+            await agent.execute("hello")
+
+    async def test_timeout_raises_readable_message(self, agent: BaseAgent) -> None:
+        """Timeout raises RuntimeError with diagnostic message."""
+        agent._client = AsyncMock()
+        agent._client.post = AsyncMock(side_effect=httpx.ReadTimeout("timed out"))
+        with pytest.raises(RuntimeError, match="timed out"):
+            await agent.execute("hello")


### PR DESCRIPTION
## Summary

- Replace `dify-client` Python SDK with direct HTTP via `httpx.AsyncClient`
- Native async (no more `asyncio.to_thread` wrapping a sync client)
- Comprehensive error handling: ConnectError, TimeoutException, HTTPStatusError with actionable messages (401 mentions `DIFY_API_KEY`)
- Guard `conversation_id` against None overwrite on edge-case responses
- Scope explicitly to Chatbot apps in blocking mode (README updated)

Motivated by feedback from Dify's team who suggested using HTTP POST instead of the SDK. The SDK's async client exists on GitHub but is not published to PyPI.

## Changes

- `examples/integrations/dify/custom_agent.py`: Rewrite with httpx, proper error handling, idempotent close
- `examples/integrations/dify/README.md`: Remove `dify-client` dep, scope to Chatbot apps, clarify blocking mode
- `tests/unit/test_dify_agent.py`: 8 new tests (init, response, conversation_id, missing answer, 401, 500, connect error, timeout)
- `CHANGELOG.md`: Entry under `[Unreleased] > Changed`

## Test plan

- [x] `pytest tests/unit/test_dify_agent.py` (8 tests pass)
- [x] `pytest tests/unit/` (full suite, 750+ tests pass)
- [x] `ruff check` + `ruff format` clean
- [x] Live-tested against Dify Cloud: 2-turn conversation, conversation_id persists correctly