### PR TITLE
docs: add star history section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,7 @@ Apache-2.0. See [LICENSE](https://github.com/arklexai/arksim/blob/main/LICENSE).
       url={https://arxiv.org/abs/2510.11997},
 }
 ```
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=arklexai/arksim&type=date)](https://star-history.com/#arklexai/arksim&date)


### PR DESCRIPTION
docs: add star history chart to README

## Summary

Adds a Star History chart to the README so visitors can see the repo's growth over time.

## Changes

- Added `## Star History` section to `README.md` with an SVG chart badge linked to star-history.com

## Documentation

- [x] Updated `README.md` (if installation, quickstart, or usage changed)

## How to Test

- [ ] `ruff check .` passes
- [ ] `ruff format --check .` passes
- [ ] `pytest tests/` passes
- [x] Manual verification: opened README preview on GitHub and confirmed the Star History SVG chart renders correctly

## Notes

Used the `/svg` endpoint from `api.star-history.com` instead of `/chart` with a `<picture>` tag, as GitHub's HTML sanitizer strips `srcset` attributes and blocks the chart from rendering.

## Reviewers
/cc @arklexai/arksim-maintainers