### PR TITLE
feat: add root cause summary

### DIFF
--- a/arksim/evaluator/__init__.py
+++ b/arksim/evaluator/__init__.py
@@ -21,6 +21,8 @@ from .entities import (
     Evaluation,
     EvaluationInput,
     EvaluationParams,
+    RootCauseAnalysis,
+    RootCauseHypothesis,
 )
 from .error_scenarios import build_error_scenario_data
 from .evaluator import Evaluator, run_evaluation
@@ -40,6 +42,8 @@ __all__ = [
     "Evaluator",
     "EvaluationParams",
     "ErrorScenarioMapping",
+    "RootCauseAnalysis",
+    "RootCauseHypothesis",
     "ScoreInput",
     "QuantResult",
     "build_error_scenario_data",

--- a/arksim/evaluator/entities.py
+++ b/arksim/evaluator/entities.py
@@ -238,6 +238,21 @@ class ErrorScenarioMapping(BaseModel):
     scenario_ids: list[str]
 
 
+class RootCauseHypothesis(BaseModel):
+    """A single inferred root cause for agent failures."""
+
+    label: str  # 2–5 words, e.g. "Hallucination", "Over-brevity causing omissions"
+    problem: str  # one sentence, must cite specific numbers or patterns from the data
+    fix: str  # one concrete sentence on what to change
+
+
+class RootCauseAnalysis(BaseModel):
+    """Post-evaluation root cause analysis output."""
+
+    hypotheses: list[RootCauseHypothesis]
+    generated_at: str  # ISO 8601 UTC
+
+
 class Evaluation(BaseModel):
     """Top-level evaluation output file."""
 
@@ -249,3 +264,4 @@ class Evaluation(BaseModel):
     conversations: list[ConversationEvaluation]
     unique_errors: list[UniqueError]
     error_scenario_mappings: list[ErrorScenarioMapping] = Field(default_factory=list)
+    root_cause_analysis: RootCauseAnalysis | None = None

--- a/arksim/evaluator/evaluator.py
+++ b/arksim/evaluator/evaluator.py
@@ -932,6 +932,14 @@ def run_evaluation(
         scenarios=scenarios,
     )
     evaluator_output = evaluator.evaluate(simulation, on_progress=on_progress)
+
+    from .root_cause_analysis import generate_root_cause_analysis
+
+    logger.info("Running root cause analysis...")
+    evaluator_output.root_cause_analysis = generate_root_cause_analysis(
+        evaluator_output, simulation, llm
+    )
+
     evaluator.save_results()
     evaluator.display_evaluation_summary()
 

--- a/arksim/evaluator/root_cause_analysis.py
+++ b/arksim/evaluator/root_cause_analysis.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Root cause analysis for evaluation results.
+
+Analyses evaluation statistics and uses an LLM to generate human-readable
+hypotheses about why the agent failed, along with concrete recommendations.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from datetime import datetime, timezone
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# LLM output schema (internal — not exported)
+# ---------------------------------------------------------------------------
+
+
+class _HypothesisItem(BaseModel):
+    label: str  # 2–5 words
+    problem: str  # one sentence, cite specific numbers or patterns
+    fix: str  # one concrete sentence
+
+
+class _RcaOutput(BaseModel):
+    hypotheses: list[_HypothesisItem]
+
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT = """\
+You are a quality analyst reviewing AI agent evaluation results.
+Given a failure summary, return 2–3 root cause items.
+
+Each item has:
+- label: 2–5 words naming the root cause (e.g. "80-word brevity limit", \
+"Hallucination under pressure", "Knowledge base not used")
+- problem: ONE sentence describing the specific problem. \
+You MUST cite exact numbers or patterns from the data \
+(e.g. "average response is 67 words" not "responses are short", \
+"2 out of 4 errors are lack of specific information" not "many errors").
+- fix: ONE sentence stating the concrete action to fix it \
+(e.g. "Remove the word-count cap in the agent system prompt" not "improve the agent").
+
+Be blunt. No vague language. Cite the data.
+
+Common patterns:
+- avg response < 80 words + "lack of specific information" failures \
+→ label: "Word limit causing omissions", cite the avg word count
+- "false information" where knowledge has no numeric data \
+→ label: "Hallucination under pressure"
+- "disobey user request" for numbers when knowledge has them \
+→ label: "Over-cautious refusal", cite the specific error
+- repeated failures on same scenario → knowledge gap for that topic
+
+Return 2–3 items. No duplicates."""
+
+_USER_PROMPT = """\
+Conversations: {conversation_count} ({impaired_count} impaired)
+Avg response length: {avg_words:.0f} words
+
+Failures:
+{failure_distribution}
+
+Unique errors ({unique_error_count}):
+{unique_errors}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def generate_root_cause_analysis(
+    evaluation: object,
+    simulation: object,
+    llm: object,
+) -> object:
+    """Analyse evaluation results and generate root cause hypotheses.
+
+    Args:
+        evaluation: ``Evaluation`` output from the evaluator.
+        simulation: ``Simulation`` output (used to compute response lengths).
+        llm: ``LLM`` instance to call for hypothesis generation.
+
+    Returns:
+        ``RootCauseAnalysis`` with a list of hypotheses and a generated_at
+        timestamp.  Returns an empty ``RootCauseAnalysis`` on any error so
+        the rest of the pipeline is never blocked.
+    """
+    # Import here to avoid circular imports at module load time.
+    from arksim.evaluator.entities import RootCauseAnalysis, RootCauseHypothesis
+
+    try:
+        stats = _compute_stats(evaluation, simulation)
+        output: _RcaOutput = llm.call(
+            [
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": _format_prompt(stats)},
+            ],
+            schema=_RcaOutput,
+        )
+        hypotheses = [
+            RootCauseHypothesis(label=h.label, problem=h.problem, fix=h.fix)
+            for h in output.hypotheses
+        ]
+    except Exception:
+        logger.warning("Root cause analysis failed; skipping.", exc_info=True)
+        hypotheses = []
+
+    return RootCauseAnalysis(
+        hypotheses=hypotheses,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_stats(evaluation: object, simulation: object) -> dict:  # type: ignore[type-arg]
+    """Compute statistics needed for the LLM prompt."""
+    # Failure category distribution across all turns
+    failure_counts: Counter = Counter()
+    for conv in evaluation.conversations:
+        for turn in conv.turn_scores:
+            failure_counts[turn.turn_behavior_failure] += 1
+
+    # Average agent response word count
+    word_counts: list[int] = []
+    for conv in simulation.conversations:
+        for msg in conv.conversation_history:
+            if msg.role not in ("simulated_user", "user"):
+                word_counts.append(len(msg.content.split()))
+    avg_words = sum(word_counts) / len(word_counts) if word_counts else 0.0
+
+    # Impaired conversation count
+    impaired_statuses = {"Partial Failure", "Failed", "PARTIAL_FAILURE", "FAILED"}
+    impaired_count = sum(
+        1
+        for conv in evaluation.conversations
+        if conv.evaluation_status in impaired_statuses
+    )
+
+    return {
+        "conversation_count": len(evaluation.conversations),
+        "impaired_count": impaired_count,
+        "avg_words": avg_words,
+        "failure_counts": failure_counts,
+        "unique_errors": evaluation.unique_errors,
+    }
+
+
+def _format_prompt(stats: dict) -> str:  # type: ignore[type-arg]
+    """Format the user prompt from computed statistics."""
+    _skip = {"no failure", "none", "skipped_good_performance", "evaluation_run_failed"}
+    failure_lines = "\n".join(
+        f"  {category}: {count} turn(s)"
+        for category, count in sorted(
+            stats["failure_counts"].items(), key=lambda x: -x[1]
+        )
+        if category.lower() not in _skip and count > 0
+    ) or "  (no failures recorded)"
+
+    error_lines = "\n".join(
+        f"  [{err.severity.upper()}] {err.behavior_failure_category}: "
+        f"{err.unique_error_description}"
+        for err in stats["unique_errors"]
+    ) or "  (none)"
+
+    return _USER_PROMPT.format(
+        conversation_count=stats["conversation_count"],
+        impaired_count=stats["impaired_count"],
+        avg_words=stats["avg_words"],
+        failure_distribution=failure_lines,
+        unique_error_count=len(stats["unique_errors"]),
+        unique_errors=error_lines,
+    )

--- a/arksim/utils/html_report/generate_html_report.py
+++ b/arksim/utils/html_report/generate_html_report.py
@@ -90,6 +90,7 @@ class ReportSummary(BaseModel):
     evaluation_model: str | None = None
     evaluation_provider: str | None = None
     evaluation_prompts: list[EvaluationPromptSummary] | None = None
+    root_cause_insights: list[dict[str, Any]] | None = None
 
 
 class ConvoRow(BaseModel):
@@ -297,6 +298,12 @@ def _build_final_report_data(
     except Exception:
         pass
 
+    root_cause_insights: list[dict[str, Any]] | None = None
+    if evaluation.root_cause_analysis:
+        root_cause_insights = [
+            h.model_dump() for h in evaluation.root_cause_analysis.hypotheses
+        ]
+
     return ReportSummary(
         total_conversations=total_conversations,
         total_turns=total_turns,
@@ -307,6 +314,7 @@ def _build_final_report_data(
         evaluation_model=evaluation_model,
         evaluation_provider=evaluation_provider,
         evaluation_prompts=eval_prompts,
+        root_cause_insights=root_cause_insights,
     )
 
 

--- a/arksim/utils/html_report/report_template.html
+++ b/arksim/utils/html_report/report_template.html
@@ -1432,6 +1432,58 @@
         #globalTooltip.visible {
             opacity: 1;
         }
+        .root-cause-section {
+            margin-top: 20px;
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+        .root-cause-card {
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 12px;
+            background: #f8fafc;
+        }
+        .root-cause-card:last-child { margin-bottom: 0; }
+        .root-cause-title {
+            font-size: 15px;
+            font-weight: 600;
+            color: #1e293b;
+            margin-bottom: 8px;
+        }
+        .root-cause-confidence {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+            margin-left: 8px;
+            vertical-align: middle;
+        }
+        .conf-high { background: #fee2e2; color: #991b1b; }
+        .conf-medium { background: #fef3c7; color: #92400e; }
+        .conf-low { background: #e0f2fe; color: #0369a1; }
+        .root-cause-description { color: #475569; font-size: 14px; margin-bottom: 10px; }
+        .root-cause-evidence {
+            list-style: none;
+            padding: 0;
+            margin: 0 0 10px;
+            font-size: 13px;
+            color: #64748b;
+        }
+        .root-cause-evidence li { padding: 2px 0; }
+        .root-cause-evidence li::before { content: "•"; color: #94a3b8; margin-right: 8px; }
+        .root-cause-recommendation {
+            background: #f0fdf4;
+            border-left: 3px solid #22c55e;
+            padding: 8px 12px;
+            border-radius: 0 4px 4px 0;
+            font-size: 13px;
+            color: #166534;
+        }
     </style>
 </head>
 <body>
@@ -1579,6 +1631,22 @@
                 </div>
                 <div id="uniqueErrorsList">
                     <!-- Unique errors will be inserted here -->
+                </div>
+            </div>
+        </div>
+
+        <!-- Root Cause Analysis Section -->
+        <div class="root-cause-section" id="rootCauseSection" style="display: none;">
+            <div class="section-title collapsible-header" onclick="toggleRootCause()">
+                <span>Root Causes Summary</span>
+                <span class="arrow-icon material-icons" id="rootCauseArrow">expand_more</span>
+            </div>
+            <div id="rootCauseContent" class="collapsible-content" style="padding: 24px;">
+                <div style="margin-bottom: 20px; color: #64748b; font-size: 14px;">
+                    Inferred hypotheses about why failures occurred, with recommended fixes.
+                </div>
+                <div id="rootCauseList">
+                    <!-- Root cause cards will be inserted here -->
                 </div>
             </div>
         </div>
@@ -1845,6 +1913,33 @@
 
             content.classList.toggle('collapsed');
             arrow.classList.toggle('collapsed');
+        }
+
+        function toggleRootCause() {
+            const content = document.getElementById('rootCauseContent');
+            const arrow = document.getElementById('rootCauseArrow');
+            content.classList.toggle('collapsed');
+            arrow.classList.toggle('collapsed');
+        }
+
+        function renderRootCauseAnalysis() {
+            const insights = EMBEDDED_FINAL_REPORT.root_cause_insights;
+            if (!insights || insights.length === 0) return;
+
+            document.getElementById('rootCauseSection').style.display = 'block';
+
+            const list = document.getElementById('rootCauseList');
+            list.innerHTML = '<ol style="margin:0; padding-left:24px; font-size:14px; line-height:1.7;">' +
+                insights.map(function(h) {
+                    return '<li style="margin-bottom:16px; padding-right:8px;">' +
+                        '<strong style="color:#1e293b;">' + escapeHtml(h.label) + '</strong><br>' +
+                        '<span style="color:#475569;">Problem: ' + escapeHtml(h.problem) + '</span><br>' +
+                        '<span style="display:inline-block; margin-top:6px; padding:6px 10px; background:#f0fdf4; border-radius:4px; color:#166534;">' +
+                            '<strong>Fix:</strong> ' + escapeHtml(h.fix) +
+                        '</span>' +
+                    '</li>';
+                }).join('') +
+            '</ol>';
         }
 
         // Populate the conversations table
@@ -2581,6 +2676,7 @@
             renderEvaluationPipeline();
             populateTable();
             renderUniqueErrors();
+            renderRootCauseAnalysis();
             renderPromptsAppendix();
         };
     </script>


### PR DESCRIPTION
## Summary

After scoring completes, the evaluator calls the configured LLM to generate 2-3 hypotheses explaining why the agent failed, each with a problem statement and a concrete fix. Results are stored on `Evaluation` and rendered as a collapsible "Root Causes Summary" section in the HTML report.

## Changes

- Added `RootCauseHypothesis` and `RootCauseAnalysis` pydantic models
- Added `root_cause_analysis.py` with stat computation and the LLM call (errors are swallowed so the pipeline is never blocked)
- Wired into `run_evaluation()` after scoring
- Extended `ReportSummary` and `report_template.html` to render hypothesis cards

## Documentation

- [x] No docs needed (internal pipeline step, no public API changes)

## How to Test

- [x] `pytest tests/` passes
- [x] Manual: run `arksim evaluate` and confirm the HTML report shows a "Root Causes Summary" section

<img width="2139" height="1107" alt="截圖 2026-04-15 中午12 07 42" src="https://github.com/user-attachments/assets/1f92802a-26df-4aa3-a898-7022ae9661de" />



## Reviewers

/cc @arklexai/arksim-maintainers

