### PR TITLE
feat(chat-completions): capture tool calls from response bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* **chat-completions:** capture tool calls from response bodies (OpenAI `tool_calls`, Anthropic `tool_use` blocks, Google Gemini `functionCall` parts). Captured calls carry `source="chat_completions"`; tool results are not captured on this path. See [Tool Call Capture docs](https://docs.arklex.ai/main/tool-call-capture).
+
 ### Changed
 
 * **a2a:** migrate from a2a-sdk 0.3.x (Pydantic) to 1.0.0 (protobuf) ([#152](https://github.com/arklexai/arksim/pull/152))

--- a/arksim/simulation_engine/agent/response_parsers.py
+++ b/arksim/simulation_engine/agent/response_parsers.py
@@ -161,6 +161,7 @@ def _extract_anthropic_tool_calls(blocks: list[Any]) -> list[ToolCall]:
 def parse_anthropic(result: dict[str, Any]) -> AgentResponse:
     """Parse Anthropic Messages API format."""
     blocks = result.get("content", [])
+    # Defensive for direct callers; parse_response already checks this.
     if not isinstance(blocks, list):
         blocks = []
     text_parts: list[str] = []

--- a/arksim/simulation_engine/agent/response_parsers.py
+++ b/arksim/simulation_engine/agent/response_parsers.py
@@ -17,12 +17,75 @@ wrap it in OpenAI format, use the custom connector, or use OTel.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
-from arksim.simulation_engine.tool_types import AgentResponse
+from arksim.simulation_engine.tool_types import AgentResponse, ToolCall, ToolCallSource
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_openai_arguments(raw: object) -> dict[str, Any]:
+    """Normalize OpenAI tool call ``arguments`` into a dict.
+
+    Spec-compliant OpenAI returns a JSON string, but LiteLLM, vLLM, and
+    some Azure routers return a dict. None and other types fall back
+    to an empty dict with a debug log.
+    """
+    if isinstance(raw, dict):
+        return raw
+    if raw is None:
+        logger.debug("Tool call arguments is None; using empty dict")
+        return {}
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.debug("Tool call arguments is not valid JSON: %r", raw)
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+        logger.debug("Tool call arguments JSON did not decode to dict: %r", parsed)
+        return {}
+    logger.debug("Tool call arguments has unexpected type %s", type(raw).__name__)
+    return {}
+
+
+def _extract_openai_tool_calls(msg: dict[str, Any]) -> list[ToolCall]:
+    """Extract tool calls from an OpenAI chat message dict.
+
+    Skips entries missing a string ``function.name``. Each captured call
+    carries ``source=ToolCallSource.CHAT_COMPLETIONS``. ``result`` is left
+    as ``None`` (not available on this path -- see spec).
+    """
+    raw_calls = msg.get("tool_calls") or []
+    if not isinstance(raw_calls, list):
+        return []
+    tool_calls: list[ToolCall] = []
+    for entry in raw_calls:
+        if not isinstance(entry, dict):
+            continue
+        fn = entry.get("function")
+        if not isinstance(fn, dict):
+            continue
+        name = fn.get("name")
+        if not isinstance(name, str) or not name:
+            logger.debug(
+                "Skipping tool call with missing or non-string name: %r", entry
+            )
+            continue
+        call_id = entry.get("id")
+        tool_calls.append(
+            ToolCall(
+                id=call_id if isinstance(call_id, str) else "",
+                name=name,
+                arguments=_coerce_openai_arguments(fn.get("arguments")),
+                result=None,
+                source=ToolCallSource.CHAT_COMPLETIONS,
+            )
+        )
+    return tool_calls
 
 
 def parse_response(result: dict[str, Any]) -> AgentResponse:
@@ -58,12 +121,48 @@ def parse_openai(result: dict[str, Any]) -> AgentResponse:
     raw_content = msg.get("content")
     content = raw_content if isinstance(raw_content, str) else ""
 
-    return AgentResponse(content=content, tool_calls=[])
+    return AgentResponse(
+        content=content,
+        tool_calls=_extract_openai_tool_calls(msg),
+    )
+
+
+def _extract_anthropic_tool_calls(blocks: list[Any]) -> list[ToolCall]:
+    """Extract tool calls from an Anthropic ``content[]`` block list.
+
+    Skips entries missing a string ``name``. ``input`` is already a dict
+    in spec-compliant responses; non-dict values fall back to empty dict.
+    """
+    tool_calls: list[ToolCall] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_use":
+            continue
+        name = block.get("name")
+        if not isinstance(name, str) or not name:
+            logger.debug("Skipping Anthropic tool_use block missing name: %r", block)
+            continue
+        raw_input = block.get("input")
+        arguments = raw_input if isinstance(raw_input, dict) else {}
+        block_id = block.get("id")
+        tool_calls.append(
+            ToolCall(
+                id=block_id if isinstance(block_id, str) else "",
+                name=name,
+                arguments=arguments,
+                result=None,
+                source=ToolCallSource.CHAT_COMPLETIONS,
+            )
+        )
+    return tool_calls
 
 
 def parse_anthropic(result: dict[str, Any]) -> AgentResponse:
     """Parse Anthropic Messages API format."""
     blocks = result.get("content", [])
+    if not isinstance(blocks, list):
+        blocks = []
     text_parts: list[str] = []
 
     for block in blocks:
@@ -72,7 +171,41 @@ def parse_anthropic(result: dict[str, Any]) -> AgentResponse:
         if block.get("type") == "text":
             text_parts.append(block.get("text", ""))
 
-    return AgentResponse(content="".join(text_parts), tool_calls=[])
+    return AgentResponse(
+        content="".join(text_parts),
+        tool_calls=_extract_anthropic_tool_calls(blocks),
+    )
+
+
+def _extract_gemini_tool_calls(parts: list[Any]) -> list[ToolCall]:
+    """Extract tool calls from a Gemini ``content.parts[]`` list.
+
+    Skips entries missing a string ``name``. Gemini has no per-call id
+    field; id defaults to ``""`` (matches the A2A convention).
+    """
+    tool_calls: list[ToolCall] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        fn = part.get("functionCall")
+        if not isinstance(fn, dict):
+            continue
+        name = fn.get("name")
+        if not isinstance(name, str) or not name:
+            logger.debug("Skipping Gemini functionCall part missing name: %r", part)
+            continue
+        raw_args = fn.get("args")
+        arguments = raw_args if isinstance(raw_args, dict) else {}
+        tool_calls.append(
+            ToolCall(
+                id="",
+                name=name,
+                arguments=arguments,
+                result=None,
+                source=ToolCallSource.CHAT_COMPLETIONS,
+            )
+        )
+    return tool_calls
 
 
 def parse_gemini(result: dict[str, Any]) -> AgentResponse:
@@ -83,6 +216,8 @@ def parse_gemini(result: dict[str, Any]) -> AgentResponse:
 
     content_obj = candidates[0].get("content", {})
     parts = content_obj.get("parts", []) if isinstance(content_obj, dict) else []
+    if not isinstance(parts, list):
+        parts = []
 
     text_parts: list[str] = []
 
@@ -92,7 +227,10 @@ def parse_gemini(result: dict[str, Any]) -> AgentResponse:
         if "text" in part:
             text_parts.append(part["text"])
 
-    return AgentResponse(content="".join(text_parts), tool_calls=[])
+    return AgentResponse(
+        content="".join(text_parts),
+        tool_calls=_extract_gemini_tool_calls(parts),
+    )
 
 
 __all__ = ["parse_response", "parse_openai", "parse_anthropic", "parse_gemini"]

--- a/arksim/simulation_engine/agent/response_parsers.py
+++ b/arksim/simulation_engine/agent/response_parsers.py
@@ -124,7 +124,15 @@ def parse_response(result: dict[str, Any]) -> AgentResponse:
 
 
 def parse_openai(result: dict[str, Any]) -> AgentResponse:
-    """Parse OpenAI Chat Completions format."""
+    """Parse OpenAI Chat Completions format.
+
+    Reads text content from ``choices[0].message.content`` (or falls back
+    to ``choices[0].delta.content`` for streaming-shaped inputs). Tool
+    calls are extracted only when ``message.tool_calls`` is a complete,
+    non-streaming list; partial ``tool_calls`` arrays from SSE ``delta``
+    chunks are not supported and their incomplete ``arguments`` strings
+    will decode to empty dicts via the defensive fallback.
+    """
     choices = result.get("choices", [])
     if not choices:
         raise ValueError("API response has empty 'choices'")

--- a/arksim/simulation_engine/agent/response_parsers.py
+++ b/arksim/simulation_engine/agent/response_parsers.py
@@ -42,11 +42,16 @@ def _coerce_openai_arguments(raw: object) -> dict[str, Any]:
         try:
             parsed = json.loads(raw)
         except json.JSONDecodeError:
-            logger.debug("Tool call arguments is not valid JSON: %r", raw)
+            logger.debug(
+                "OpenAI tool call arguments failed JSON decode; using empty dict"
+            )
             return {}
         if isinstance(parsed, dict):
             return parsed
-        logger.debug("Tool call arguments JSON did not decode to dict: %r", parsed)
+        logger.debug(
+            "OpenAI tool call arguments JSON decoded to %s, not dict; using empty dict",
+            type(parsed).__name__,
+        )
         return {}
     logger.debug("Tool call arguments has unexpected type %s", type(raw).__name__)
     return {}
@@ -57,7 +62,12 @@ def _extract_openai_tool_calls(msg: dict[str, Any]) -> list[ToolCall]:
 
     Skips entries missing a string ``function.name``. Each captured call
     carries ``source=ToolCallSource.CHAT_COMPLETIONS``. ``result`` is left
-    as ``None`` (not available on this path -- see spec).
+    as ``None`` (not available on this path — see spec).
+
+    The entry-level ``type`` field (e.g. ``"function"``) is intentionally
+    ignored. OpenAI may add new ``type`` values (code interpreter, computer
+    use) in the future; those will be silently skipped until explicitly
+    modeled.
     """
     raw_calls = msg.get("tool_calls") or []
     if not isinstance(raw_calls, list):
@@ -72,12 +82,14 @@ def _extract_openai_tool_calls(msg: dict[str, Any]) -> list[ToolCall]:
         name = fn.get("name")
         if not isinstance(name, str) or not name:
             logger.debug(
-                "Skipping tool call with missing or non-string name: %r", entry
+                "Skipping OpenAI tool call: missing or non-string function.name"
             )
             continue
         call_id = entry.get("id")
         tool_calls.append(
             ToolCall(
+                # Empty string matches A2A convention for missing id. OpenAI spec
+                # requires a string id; we fall back defensively.
                 id=call_id if isinstance(call_id, str) else "",
                 name=name,
                 arguments=_coerce_openai_arguments(fn.get("arguments")),
@@ -117,7 +129,14 @@ def parse_openai(result: dict[str, Any]) -> AgentResponse:
     if not choices:
         raise ValueError("API response has empty 'choices'")
 
-    msg = choices[0].get("message") or choices[0].get("delta") or {}
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        raise ValueError(
+            "API response 'choices[0]' must be a dict, got "
+            f"{type(first_choice).__name__}"
+        )
+
+    msg = first_choice.get("message") or first_choice.get("delta") or {}
     raw_content = msg.get("content")
     content = raw_content if isinstance(raw_content, str) else ""
 
@@ -132,6 +151,9 @@ def _extract_anthropic_tool_calls(blocks: list[Any]) -> list[ToolCall]:
 
     Skips entries missing a string ``name``. ``input`` is already a dict
     in spec-compliant responses; non-dict values fall back to empty dict.
+
+    Evaluation-irrelevant fields on ``tool_use`` blocks (``cache_control``,
+    extended-thinking metadata) are intentionally not mapped.
     """
     tool_calls: list[ToolCall] = []
     for block in blocks:
@@ -141,13 +163,16 @@ def _extract_anthropic_tool_calls(blocks: list[Any]) -> list[ToolCall]:
             continue
         name = block.get("name")
         if not isinstance(name, str) or not name:
-            logger.debug("Skipping Anthropic tool_use block missing name: %r", block)
+            logger.debug(
+                "Skipping Anthropic tool_use block: missing or non-string name"
+            )
             continue
         raw_input = block.get("input")
         arguments = raw_input if isinstance(raw_input, dict) else {}
         block_id = block.get("id")
         tool_calls.append(
             ToolCall(
+                # Empty string matches A2A convention for missing id.
                 id=block_id if isinstance(block_id, str) else "",
                 name=name,
                 arguments=arguments,
@@ -190,15 +215,24 @@ def _extract_gemini_tool_calls(parts: list[Any]) -> list[ToolCall]:
             continue
         fn = part.get("functionCall")
         if not isinstance(fn, dict):
+            # Debug hint for Gemini features we do not yet model
+            # (executableCode, codeExecutionResult, etc).
+            if any(k in part for k in ("executableCode", "codeExecutionResult")):
+                logger.debug(
+                    "Skipping unmodeled Gemini part type: %s", ",".join(part.keys())
+                )
             continue
         name = fn.get("name")
         if not isinstance(name, str) or not name:
-            logger.debug("Skipping Gemini functionCall part missing name: %r", part)
+            logger.debug(
+                "Skipping Gemini functionCall part: missing or non-string name"
+            )
             continue
         raw_args = fn.get("args")
         arguments = raw_args if isinstance(raw_args, dict) else {}
         tool_calls.append(
             ToolCall(
+                # Gemini has no per-call id; empty string matches A2A convention.
                 id="",
                 name=name,
                 arguments=arguments,

--- a/arksim/simulation_engine/agent/response_parsers.py
+++ b/arksim/simulation_engine/agent/response_parsers.py
@@ -62,7 +62,7 @@ def _extract_openai_tool_calls(msg: dict[str, Any]) -> list[ToolCall]:
 
     Skips entries missing a string ``function.name``. Each captured call
     carries ``source=ToolCallSource.CHAT_COMPLETIONS``. ``result`` is left
-    as ``None`` (not available on this path — see spec).
+    as ``None`` (not available on this path; see spec).
 
     The entry-level ``type`` field (e.g. ``"function"``) is intentionally
     ignored. OpenAI may add new ``type`` values (code interpreter, computer

--- a/arksim/simulation_engine/simulator.py
+++ b/arksim/simulation_engine/simulator.py
@@ -232,12 +232,14 @@ class Simulator:
                 # Dedup by ID first, then by (name, arguments) to handle
                 # cases where the trace receiver falls back to spanId while
                 # AgentResponse carries an SDK-assigned tool call ID.
+                # Empty-string ids (Gemini always; A2A when absent) are excluded
+                # from the ID set so they fall through to signature-based dedup.
                 if self.trace_receiver is not None:
                     traced = await self.trace_receiver.wait_for_traces(
                         conversation_id, turn
                     )
                     if traced:
-                        existing_ids = {tc.id for tc in turn_tool_calls}
+                        existing_ids = {tc.id for tc in turn_tool_calls if tc.id}
                         sig_to_idx: dict[tuple[str, str], int] = {}
                         for i, tc in enumerate(turn_tool_calls):
                             sig = (tc.name, json.dumps(tc.arguments, sort_keys=True))

--- a/arksim/simulation_engine/tool_types.py
+++ b/arksim/simulation_engine/tool_types.py
@@ -29,6 +29,13 @@ class ToolCallSource(str, Enum):
     #: Captured from an OTLP / OpenInference span (via the trace receiver).
     OTEL_TRACE = "otel_trace"
 
+    #: Captured from a Chat Completions connector response body (OpenAI,
+    #: Anthropic, or Gemini formats). Result is not captured on this path:
+    #: raw Chat Completions endpoints return tool results through follow-up
+    #: ``role=tool`` messages sent by the client, and arksim does not supply
+    #: the tool implementations needed to produce those messages.
+    CHAT_COMPLETIONS = "chat_completions"
+
 
 class A2AToolCaptureExtension:
     """A2A AgentExtension URI for arksim's tool call capture convention.

--- a/docs/main/tool-call-capture.mdx
+++ b/docs/main/tool-call-capture.mdx
@@ -124,7 +124,7 @@ arksim's Chat Completions connector extracts tool calls directly from the respon
 Captured tool calls carry `source="chat_completions"`. Tool *results* are not captured on this path. Raw Chat Completions endpoints return results through follow-up `role=tool` messages sent by the client, and arksim does not supply those tool implementations.
 
 <Warning>
-**Wrapper servers that handle tool execution internally are not captured.** If your wrapper runs the tool loop and returns only final text (like `examples/bank-insurance/agent_server/chat_completions`), response parsing finds nothing — the wrapper has already flattened the loop into a single text reply.
+**Wrapper servers that handle tool execution internally are not captured.** If your wrapper runs the tool loop and returns only final text (like `examples/bank-insurance/agent_server/chat_completions`), response parsing finds nothing because the wrapper has already flattened the loop into a single text reply.
 
 For these deployments:
 
@@ -252,7 +252,7 @@ See the [customer-service A2A example](https://github.com/arklexai/arksim/tree/m
 
 Tool call metadata is more sensitive than the agent's text response. Arguments can contain PII (email addresses, customer IDs), verification codes, internal tool names that expose your agent's architecture, and verbatim tool results. A server that emits this data unconditionally exposes strictly more than it would without the extension.
 
-Unlike A2A (where tool call emission is gated by the client's `A2A-Extensions` request header), Chat Completions capture is unconditional: any tool call the endpoint returns in the response body is captured by arksim. If the endpoint is public or shared with non-arksim clients, tool call metadata is already visible in the response — arksim just reads what's already there. Apply endpoint-level auth or a separate evaluation-only deployment if this is a concern.
+Unlike A2A (where tool call emission is gated by the client's `A2A-Extensions` request header), Chat Completions capture is unconditional: any tool call the endpoint returns in the response body is captured by arksim. If the endpoint is public or shared with non-arksim clients, tool call metadata is already visible in the response, and arksim just reads what's already there. Apply endpoint-level auth or a separate evaluation-only deployment if this is a concern.
 
 The arksim example server gates tool call emission on the client's `A2A-Extensions` request header: if the client does not request the extension, the server omits tool call metadata from the artifact. This is the right default, but the request header is not access control; any HTTP client can send it.
 

--- a/docs/main/tool-call-capture.mdx
+++ b/docs/main/tool-call-capture.mdx
@@ -21,11 +21,11 @@ If both are active, arksim deduplicates automatically (see [Deduplication](#dedu
 | Connector | Explicit (`AgentResponse`) | Automatic Capture |
 |-----------|--------------------------|-------------------|
 | Python connector | Supported | Supported via `ArksimTracingProcessor` |
-| Chat Completions | Planned | Planned |
+| Chat Completions | Supported (response-parsed, request side only; no tool results) | Not supported for wrapper-internal tool loops; open an issue describing your shape |
 | A2A | Supported via A2A AgentExtension | Not applicable |
 
 <Info>
-Tool call capture works with the Python connector and A2A. A2A agents declare the `https://arksim.arklex.ai/a2a/tool-call-capture/v1` extension and surface tool calls in `Task.artifacts[*].metadata`. Chat Completions support is planned.
+Tool call capture works with the Python connector, Chat Completions (response-parsed), and A2A. A2A agents declare the `https://arksim.arklex.ai/a2a/tool-call-capture/v1` extension and surface tool calls in `Task.artifacts[*].metadata`. Chat Completions captures tool calls directly from the response body.
 </Info>
 
 ---
@@ -108,6 +108,22 @@ The module loader caches modules by file path, so `add_trace_processor` runs exa
 See `examples/customer-service/traced_agent.py` for a complete working example.
 
 Requires `pip install openai-agents`.
+
+---
+
+## Chat Completions Capture
+
+Arksim's Chat Completions connector extracts tool calls directly from the response body when the endpoint returns them in the standard location for each format:
+
+- **OpenAI format:** `choices[0].message.tool_calls`
+- **Anthropic format:** `content[]` blocks with `type: "tool_use"`
+- **Google Gemini format:** `candidates[0].content.parts[]` entries with `functionCall`
+
+Captured tool calls carry `source="chat_completions"`. Tool *results* are not captured on this path. Raw Chat Completions endpoints return results through follow-up `role=tool` messages sent by the client, and arksim does not supply those tool implementations.
+
+<Warning>
+Wrapper servers that handle tool execution internally and return only final text (for example, `examples/bank-insurance/agent_server/chat_completions`) are not covered by response parsing. The wrapper flattens the tool loop into a single text reply, leaving nothing for the parser to read. For these deployments, use the **A2A protocol** (tool calls carried in `Task.artifacts[*].metadata` via the arksim `AgentExtension`) or the **Python connector** (`AgentResponse` with explicit tool calls). If your wrapper shape isn't served by either path, open a GitHub issue describing it: cross-process Chat Completions wrapper capture requires a separate design.
+</Warning>
 
 ---
 

--- a/docs/main/tool-call-capture.mdx
+++ b/docs/main/tool-call-capture.mdx
@@ -21,7 +21,7 @@ If both are active, arksim deduplicates automatically (see [Deduplication](#dedu
 | Connector | Explicit (`AgentResponse`) | Automatic Capture |
 |-----------|--------------------------|-------------------|
 | Python connector | Supported | Supported via `ArksimTracingProcessor` |
-| Chat Completions | Supported (response-parsed, request side only; no tool results) | Not supported for wrapper-internal tool loops; open an issue describing your shape |
+| Chat Completions | Supported (response-parsed, no tool results) | Not supported for wrapper-internal tool loops; see below |
 | A2A | Supported via A2A AgentExtension | Not applicable |
 
 <Info>
@@ -113,6 +113,8 @@ Requires `pip install openai-agents`.
 
 ## Chat Completions Capture
 
+**No config needed.** arksim captures tool calls automatically whenever the Chat Completions endpoint returns them in the response body. Point arksim's `agent_type: chat_completions` at any OpenAI-compatible endpoint that returns tool calls in the standard format.
+
 arksim's Chat Completions connector extracts tool calls directly from the response body when the endpoint returns them in the standard location for each format:
 
 - **OpenAI format:** `choices[0].message.tool_calls`
@@ -122,7 +124,14 @@ arksim's Chat Completions connector extracts tool calls directly from the respon
 Captured tool calls carry `source="chat_completions"`. Tool *results* are not captured on this path. Raw Chat Completions endpoints return results through follow-up `role=tool` messages sent by the client, and arksim does not supply those tool implementations.
 
 <Warning>
-Wrapper servers that handle tool execution internally and return only final text (for example, `examples/bank-insurance/agent_server/chat_completions`) are not covered by response parsing. The wrapper flattens the tool loop into a single text reply, leaving nothing for the parser to read. For these deployments, use the **A2A protocol** (tool calls carried in `Task.artifacts[*].metadata` via the arksim `AgentExtension`) or the **Python connector** (`AgentResponse` with explicit tool calls). If your wrapper shape isn't served by either path, open a GitHub issue describing it: cross-process Chat Completions wrapper capture requires a separate design.
+**Wrapper servers that handle tool execution internally are not captured.** If your wrapper runs the tool loop and returns only final text (like `examples/bank-insurance/agent_server/chat_completions`), response parsing finds nothing — the wrapper has already flattened the loop into a single text reply.
+
+For these deployments:
+
+- **A2A protocol.** Tool calls carried in `Task.artifacts[*].metadata` via the arksim `AgentExtension`.
+- **Python connector.** `AgentResponse` with explicit tool calls.
+
+If neither path fits your wrapper shape, open a GitHub issue describing it. Cross-process Chat Completions wrapper capture requires a separate design.
 </Warning>
 
 ---

--- a/docs/main/tool-call-capture.mdx
+++ b/docs/main/tool-call-capture.mdx
@@ -113,7 +113,7 @@ Requires `pip install openai-agents`.
 
 ## Chat Completions Capture
 
-Arksim's Chat Completions connector extracts tool calls directly from the response body when the endpoint returns them in the standard location for each format:
+arksim's Chat Completions connector extracts tool calls directly from the response body when the endpoint returns them in the standard location for each format:
 
 - **OpenAI format:** `choices[0].message.tool_calls`
 - **Anthropic format:** `content[]` blocks with `type: "tool_use"`
@@ -242,6 +242,8 @@ See the [customer-service A2A example](https://github.com/arklexai/arksim/tree/m
 ## Security considerations
 
 Tool call metadata is more sensitive than the agent's text response. Arguments can contain PII (email addresses, customer IDs), verification codes, internal tool names that expose your agent's architecture, and verbatim tool results. A server that emits this data unconditionally exposes strictly more than it would without the extension.
+
+Unlike A2A (where tool call emission is gated by the client's `A2A-Extensions` request header), Chat Completions capture is unconditional: any tool call the endpoint returns in the response body is captured by arksim. If the endpoint is public or shared with non-arksim clients, tool call metadata is already visible in the response — arksim just reads what's already there. Apply endpoint-level auth or a separate evaluation-only deployment if this is a concern.
 
 The arksim example server gates tool call emission on the client's `A2A-Extensions` request header: if the client does not request the extension, the server omits tool call metadata from the artifact. This is the right default, but the request header is not access control; any HTTP client can send it.
 

--- a/tests/unit/test_chat_completions.py
+++ b/tests/unit/test_chat_completions.py
@@ -37,31 +37,6 @@ class TestParseResponseOpenAI:
         assert response.content == ""
         assert response.tool_calls == []
 
-    def test_tool_calls_not_extracted(self) -> None:
-        """Response parsers no longer extract tool calls from responses."""
-        result = {
-            "choices": [
-                {
-                    "message": {
-                        "role": "assistant",
-                        "content": "",
-                        "tool_calls": [
-                            {
-                                "id": "call_abc",
-                                "function": {
-                                    "name": "search",
-                                    "arguments": '{"query": "arksim"}',
-                                },
-                            }
-                        ],
-                    }
-                }
-            ]
-        }
-        response = parse_response(result)
-        assert response.content == ""
-        assert response.tool_calls == []
-
 
 class TestParseResponseAnthropic:
     """Tests for Anthropic-style response format."""
@@ -91,23 +66,6 @@ class TestParseResponseAnthropic:
         }
         response = parse_response(result)
         assert response.content == "Only this."
-
-    def test_tool_use_block_not_extracted(self) -> None:
-        """Response parsers no longer extract tool calls from responses."""
-        result = {
-            "content": [
-                {"type": "text", "text": "Using tool."},
-                {
-                    "type": "tool_use",
-                    "id": "toolu_01",
-                    "name": "calculator",
-                    "input": {"expression": "2+2"},
-                },
-            ]
-        }
-        response = parse_response(result)
-        assert response.content == "Using tool."
-        assert response.tool_calls == []
 
 
 class TestParseResponseGoogle:
@@ -142,29 +100,6 @@ class TestParseResponseGoogle:
         result = {"candidates": []}
         with pytest.raises(ValueError, match="empty 'candidates'"):
             parse_response(result)
-
-    def test_function_call_part_not_extracted(self) -> None:
-        """Response parsers no longer extract tool calls from responses."""
-        result = {
-            "candidates": [
-                {
-                    "content": {
-                        "parts": [
-                            {"text": "Calling tool."},
-                            {
-                                "functionCall": {
-                                    "name": "weather",
-                                    "args": {"city": "NYC"},
-                                }
-                            },
-                        ]
-                    }
-                }
-            ]
-        }
-        response = parse_response(result)
-        assert response.content == "Calling tool."
-        assert response.tool_calls == []
 
 
 class TestParseResponseUnsupported:

--- a/tests/unit/test_chat_completions.py
+++ b/tests/unit/test_chat_completions.py
@@ -114,3 +114,69 @@ class TestParseResponseUnsupported:
         result = {"id": "xyz", "usage": {}}
         with pytest.raises(ValueError, match="Keys present"):
             parse_response(result)
+
+
+class TestChatCompletionsAgentExecute:
+    """End-to-end: execute() flows captured tool calls into AgentResponse."""
+
+    @pytest.mark.asyncio
+    async def test_execute_populates_tool_calls(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Full path: execute() -> parse_openai -> AgentResponse.tool_calls."""
+        from arksim.config import AgentConfig, AgentType
+        from arksim.simulation_engine.agent.clients.chat_completions import (
+            ChatCompletionsAgent,
+        )
+        from arksim.simulation_engine.tool_types import ToolCallSource
+
+        # AgentConfig's mode='before' validator calls ChatCompletionsConfig(**api_config),
+        # so api_config must be a plain dict, not a pre-constructed model instance.
+        config = AgentConfig(
+            agent_name="test",
+            agent_type=AgentType.CHAT_COMPLETIONS.value,
+            api_config={
+                "endpoint": "http://localhost:9999/v1/chat/completions",
+                "headers": {"Authorization": "Bearer test"},
+                "body": {
+                    "model": "test-model",
+                    "messages": [{"role": "system", "content": "you are a test"}],
+                },
+            },
+        )
+        agent = ChatCompletionsAgent(config)
+
+        async def fake_post(payload: dict) -> dict:
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_x",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "get_weather",
+                                        "arguments": '{"city": "SF"}',
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(agent, "_post_request", fake_post)
+
+        response = await agent.execute("what's the weather?")
+        assert response.content == ""
+        assert len(response.tool_calls) == 1
+        tc = response.tool_calls[0]
+        assert tc.id == "call_x"
+        assert tc.name == "get_weather"
+        assert tc.arguments == {"city": "SF"}
+        assert tc.source == ToolCallSource.CHAT_COMPLETIONS
+
+        await agent.close()

--- a/tests/unit/test_response_parsers.py
+++ b/tests/unit/test_response_parsers.py
@@ -11,6 +11,7 @@ from arksim.simulation_engine.agent.response_parsers import (
     parse_openai,
     parse_response,
 )
+from arksim.simulation_engine.tool_types import ToolCallSource
 
 
 class TestParseOpenAI:
@@ -21,7 +22,7 @@ class TestParseOpenAI:
         assert response.tool_calls == []
 
     def test_tool_calls_only(self) -> None:
-        """content=None with tool_calls: the crash fix (content=None -> "")."""
+        """content=None with tool_calls captured as-is; content falls back to ""."""
         result = {
             "choices": [
                 {
@@ -44,10 +45,16 @@ class TestParseOpenAI:
         }
         response = parse_openai(result)
         assert response.content == ""
-        assert response.tool_calls == []
+        assert len(response.tool_calls) == 1
+        tc = response.tool_calls[0]
+        assert tc.id == "call_1"
+        assert tc.name == "get_weather"
+        assert tc.arguments == {"city": "NYC"}
+        assert tc.result is None
+        assert tc.source == ToolCallSource.CHAT_COMPLETIONS
 
     def test_text_and_tool_calls(self) -> None:
-        """Tool calls in response are ignored; only content is extracted."""
+        """Both content and tool_calls captured."""
         result = {
             "choices": [
                 {
@@ -70,19 +77,60 @@ class TestParseOpenAI:
         }
         response = parse_openai(result)
         assert response.content == "Let me check."
-        assert response.tool_calls == []
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].name == "search"
+        assert response.tool_calls[0].arguments == {"q": "test"}
 
-    def test_empty_choices_raises(self) -> None:
-        with pytest.raises(ValueError, match="empty 'choices'"):
-            parse_openai({"choices": []})
-
-    def test_malformed_arguments_ignored(self) -> None:
-        """Tool calls in response are not extracted, so malformed args are irrelevant."""
+    def test_arguments_as_dict(self) -> None:
+        """Some OpenAI-compatible routers (LiteLLM, vLLM) return arguments as a dict."""
         result = {
             "choices": [
                 {
                     "message": {
-                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_dict",
+                                "type": "function",
+                                "function": {
+                                    "name": "f",
+                                    "arguments": {"k": "v"},
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+        response = parse_openai(result)
+        assert response.tool_calls[0].arguments == {"k": "v"}
+
+    def test_arguments_none(self) -> None:
+        result = {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_none",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": None},
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+        response = parse_openai(result)
+        assert response.tool_calls[0].arguments == {}
+
+    def test_arguments_malformed_json(self) -> None:
+        """Malformed JSON string falls back to empty dict; call still captured."""
+        result = {
+            "choices": [
+                {
+                    "message": {
                         "content": None,
                         "tool_calls": [
                             {
@@ -99,16 +147,87 @@ class TestParseOpenAI:
             ]
         }
         response = parse_openai(result)
-        assert response.content == ""
-        assert response.tool_calls == []
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].name == "bad_tool"
+        assert response.tool_calls[0].arguments == {}
 
-    def test_tool_call_id_missing_ignored(self) -> None:
-        """Tool calls in response are not extracted regardless of missing fields."""
+    def test_multiple_tool_calls(self) -> None:
         result = {
             "choices": [
                 {
                     "message": {
-                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "c1",
+                                "type": "function",
+                                "function": {"name": "a", "arguments": "{}"},
+                            },
+                            {
+                                "id": "c2",
+                                "type": "function",
+                                "function": {"name": "b", "arguments": "{}"},
+                            },
+                        ],
+                    }
+                }
+            ]
+        }
+        response = parse_openai(result)
+        assert [tc.name for tc in response.tool_calls] == ["a", "b"]
+
+    def test_missing_name_skipped(self) -> None:
+        """Tool call entries without a name are skipped."""
+        result = {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "c1",
+                                "type": "function",
+                                "function": {"arguments": "{}"},
+                            },
+                            {
+                                "id": "c2",
+                                "type": "function",
+                                "function": {"name": "ok", "arguments": "{}"},
+                            },
+                        ],
+                    }
+                }
+            ]
+        }
+        response = parse_openai(result)
+        assert [tc.name for tc in response.tool_calls] == ["ok"]
+
+    def test_non_string_name_skipped(self) -> None:
+        result = {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "c1",
+                                "type": "function",
+                                "function": {"name": 42, "arguments": "{}"},
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+        response = parse_openai(result)
+        assert response.tool_calls == []
+
+    def test_missing_id_defaults_to_empty_string(self) -> None:
+        """Matches the A2A convention; OpenAI spec requires id but be defensive."""
+        result = {
+            "choices": [
+                {
+                    "message": {
                         "content": None,
                         "tool_calls": [
                             {
@@ -121,8 +240,18 @@ class TestParseOpenAI:
             ]
         }
         response = parse_openai(result)
-        assert response.content == ""
+        assert response.tool_calls[0].id == ""
+        assert response.tool_calls[0].name == "f"
+
+    def test_empty_tool_calls_list(self) -> None:
+        result = {"choices": [{"message": {"content": "hi", "tool_calls": []}}]}
+        response = parse_openai(result)
+        assert response.content == "hi"
         assert response.tool_calls == []
+
+    def test_empty_choices_raises(self) -> None:
+        with pytest.raises(ValueError, match="empty 'choices'"):
+            parse_openai({"choices": []})
 
 
 class TestParseAnthropic:
@@ -248,8 +377,8 @@ class TestParseResponseDispatch:
         with pytest.raises(ValueError, match="Unsupported response format"):
             parse_response({"data": "something"})
 
-    def test_tool_calls_not_extracted(self) -> None:
-        """Response parsers no longer extract tool calls from responses."""
+    def test_tool_calls_extracted_via_dispatch(self) -> None:
+        """parse_response delegates tool call extraction to the provider parser."""
         result = {
             "choices": [
                 {
@@ -267,7 +396,8 @@ class TestParseResponseDispatch:
             ]
         }
         response = parse_response(result)
-        assert response.tool_calls == []
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].name == "f"
 
     def test_openai_takes_precedence_over_anthropic(self) -> None:
         """A response with both 'choices' and 'content' is parsed as OpenAI."""

--- a/tests/unit/test_response_parsers.py
+++ b/tests/unit/test_response_parsers.py
@@ -262,7 +262,6 @@ class TestParseAnthropic:
         assert response.tool_calls == []
 
     def test_tool_use_blocks(self) -> None:
-        """Tool use blocks in response are not extracted; only text is."""
         result = {
             "content": [
                 {
@@ -275,10 +274,14 @@ class TestParseAnthropic:
         }
         response = parse_anthropic(result)
         assert response.content == ""
-        assert response.tool_calls == []
+        assert len(response.tool_calls) == 1
+        tc = response.tool_calls[0]
+        assert tc.id == "toolu_01"
+        assert tc.name == "get_weather"
+        assert tc.arguments == {"city": "NYC"}
+        assert tc.source == ToolCallSource.CHAT_COMPLETIONS
 
     def test_mixed_text_and_tool_use(self) -> None:
-        """Only text blocks are extracted; tool_use blocks are ignored."""
         result = {
             "content": [
                 {"type": "text", "text": "Let me check. "},
@@ -292,7 +295,43 @@ class TestParseAnthropic:
         }
         response = parse_anthropic(result)
         assert response.content == "Let me check. "
-        assert response.tool_calls == []
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].name == "search"
+
+    def test_multiple_tool_use_blocks(self) -> None:
+        result = {
+            "content": [
+                {"type": "tool_use", "id": "t1", "name": "a", "input": {}},
+                {"type": "tool_use", "id": "t2", "name": "b", "input": {}},
+            ]
+        }
+        response = parse_anthropic(result)
+        assert [tc.name for tc in response.tool_calls] == ["a", "b"]
+
+    def test_tool_use_missing_name_skipped(self) -> None:
+        result = {
+            "content": [
+                {"type": "tool_use", "id": "t1", "input": {}},
+                {"type": "tool_use", "id": "t2", "name": "ok", "input": {}},
+            ]
+        }
+        response = parse_anthropic(result)
+        assert [tc.name for tc in response.tool_calls] == ["ok"]
+
+    def test_tool_use_input_not_dict(self) -> None:
+        """Defensive: if input isn't a dict, fall back to empty dict."""
+        result = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "f",
+                    "input": "not-a-dict",
+                }
+            ]
+        }
+        response = parse_anthropic(result)
+        assert response.tool_calls[0].arguments == {}
 
     def test_non_dict_blocks_ignored(self) -> None:
         """Malformed non-dict entries in content list are silently skipped."""

--- a/tests/unit/test_response_parsers.py
+++ b/tests/unit/test_response_parsers.py
@@ -81,7 +81,7 @@ class TestParseOpenAI:
         assert response.tool_calls[0].name == "search"
         assert response.tool_calls[0].arguments == {"q": "test"}
 
-    def test_arguments_as_dict(self) -> None:
+    def test_dict_arguments_normalized_without_modification(self) -> None:
         """Some OpenAI-compatible routers (LiteLLM, vLLM) return arguments as a dict."""
         result = {
             "choices": [
@@ -105,7 +105,7 @@ class TestParseOpenAI:
         response = parse_openai(result)
         assert response.tool_calls[0].arguments == {"k": "v"}
 
-    def test_arguments_none(self) -> None:
+    def test_none_arguments_yields_empty_dict(self) -> None:
         result = {
             "choices": [
                 {
@@ -125,7 +125,7 @@ class TestParseOpenAI:
         response = parse_openai(result)
         assert response.tool_calls[0].arguments == {}
 
-    def test_arguments_malformed_json(self) -> None:
+    def test_unparseable_arguments_yields_empty_dict(self) -> None:
         """Malformed JSON string falls back to empty dict; call still captured."""
         result = {
             "choices": [
@@ -252,6 +252,13 @@ class TestParseOpenAI:
     def test_empty_choices_raises(self) -> None:
         with pytest.raises(ValueError, match="empty 'choices'"):
             parse_openai({"choices": []})
+
+    def test_non_dict_first_choice_raises(self) -> None:
+        """choices=[None] or choices=[str] must raise ValueError, not AttributeError."""
+        with pytest.raises(ValueError, match="must be a dict"):
+            parse_openai({"choices": [None]})
+        with pytest.raises(ValueError, match="must be a dict"):
+            parse_openai({"choices": ["not-a-dict"]})
 
 
 class TestParseAnthropic:
@@ -518,3 +525,65 @@ class TestParseResponseDispatch:
         }
         response = parse_response(result)
         assert response.content == "from choices"
+
+
+class TestDebugLogsAreSafe:
+    """Debug logs in parsers must never include raw tool arguments.
+
+    arksim.ui.api.state.py attaches a WebSocket log handler to the
+    ``arksim`` logger at DEBUG during UI-driven runs. Raw tool args
+    can contain PII; logging them broadcasts to all connected clients.
+    """
+
+    def test_malformed_json_does_not_log_raw_content(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        result = {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "c",
+                                "type": "function",
+                                "function": {
+                                    "name": "f",
+                                    "arguments": "SECRET_PII_TOKEN_abc123",
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+        with caplog.at_level("DEBUG", logger="arksim"):
+            parse_openai(result)
+        for record in caplog.records:
+            assert "SECRET_PII_TOKEN_abc123" not in record.getMessage()
+
+    def test_missing_name_does_not_log_raw_arguments(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        result = {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "c",
+                                "type": "function",
+                                "function": {
+                                    "arguments": '{"ssn": "SECRET_PII_TOKEN_xyz"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+        with caplog.at_level("DEBUG", logger="arksim"):
+            parse_openai(result)
+        for record in caplog.records:
+            assert "SECRET_PII_TOKEN_xyz" not in record.getMessage()

--- a/tests/unit/test_response_parsers.py
+++ b/tests/unit/test_response_parsers.py
@@ -361,7 +361,6 @@ class TestParseGemini:
         assert response.tool_calls == []
 
     def test_function_call_parts(self) -> None:
-        """Function call parts in response are not extracted; only text is."""
         result = {
             "candidates": [
                 {
@@ -380,7 +379,80 @@ class TestParseGemini:
         }
         response = parse_gemini(result)
         assert response.content == ""
-        assert response.tool_calls == []
+        assert len(response.tool_calls) == 1
+        tc = response.tool_calls[0]
+        assert tc.id == ""  # Gemini has no id field; A2A convention applies
+        assert tc.name == "get_weather"
+        assert tc.arguments == {"city": "NYC"}
+        assert tc.source == ToolCallSource.CHAT_COMPLETIONS
+
+    def test_mixed_text_and_function_call(self) -> None:
+        result = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"text": "Let me check. "},
+                            {
+                                "functionCall": {
+                                    "name": "search",
+                                    "args": {"q": "test"},
+                                }
+                            },
+                        ]
+                    }
+                }
+            ]
+        }
+        response = parse_gemini(result)
+        assert response.content == "Let me check. "
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].name == "search"
+
+    def test_multiple_function_calls(self) -> None:
+        result = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"functionCall": {"name": "a", "args": {}}},
+                            {"functionCall": {"name": "b", "args": {}}},
+                        ]
+                    }
+                }
+            ]
+        }
+        response = parse_gemini(result)
+        assert [tc.name for tc in response.tool_calls] == ["a", "b"]
+
+    def test_function_call_missing_name_skipped(self) -> None:
+        result = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"functionCall": {"args": {}}},
+                            {"functionCall": {"name": "ok", "args": {}}},
+                        ]
+                    }
+                }
+            ]
+        }
+        response = parse_gemini(result)
+        assert [tc.name for tc in response.tool_calls] == ["ok"]
+
+    def test_function_call_args_not_dict(self) -> None:
+        result = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [{"functionCall": {"name": "f", "args": "not-dict"}}]
+                    }
+                }
+            ]
+        }
+        response = parse_gemini(result)
+        assert response.tool_calls[0].arguments == {}
 
     def test_empty_candidates_raises(self) -> None:
         with pytest.raises(ValueError, match="empty 'candidates'"):

--- a/tests/unit/test_tool_types.py
+++ b/tests/unit/test_tool_types.py
@@ -8,9 +8,18 @@ class TestToolCallSource:
     def test_chat_completions_variant_exists(self) -> None:
         assert ToolCallSource.CHAT_COMPLETIONS.value == "chat_completions"
 
-    def test_chat_completions_serializes_to_string(self) -> None:
-        """Enum inherits from str so pydantic/json serialize it as plain string."""
-        assert str(ToolCallSource.CHAT_COMPLETIONS.value) == "chat_completions"
+    def test_chat_completions_serializes_via_pydantic(self) -> None:
+        """Pydantic serializes the enum to a plain string in model_dump()."""
+        from arksim.simulation_engine.tool_types import ToolCall
+
+        tc = ToolCall(
+            id="c1",
+            name="f",
+            source=ToolCallSource.CHAT_COMPLETIONS,
+        )
+        dumped = tc.model_dump()
+        assert dumped["source"] == "chat_completions"
+        assert isinstance(dumped["source"], str)
 
     def test_existing_variants_unchanged(self) -> None:
         assert ToolCallSource.A2A_PROTOCOL.value == "a2a_protocol"

--- a/tests/unit/test_tool_types.py
+++ b/tests/unit/test_tool_types.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from arksim.simulation_engine.tool_types import ToolCallSource
+
+
+class TestToolCallSource:
+    def test_chat_completions_variant_exists(self) -> None:
+        assert ToolCallSource.CHAT_COMPLETIONS.value == "chat_completions"
+
+    def test_chat_completions_serializes_to_string(self) -> None:
+        """Enum inherits from str so pydantic/json serialize it as plain string."""
+        assert str(ToolCallSource.CHAT_COMPLETIONS.value) == "chat_completions"
+
+    def test_existing_variants_unchanged(self) -> None:
+        assert ToolCallSource.A2A_PROTOCOL.value == "a2a_protocol"
+        assert ToolCallSource.OPENAI_AGENTS.value == "openai_agents"
+        assert ToolCallSource.OTEL_TRACE.value == "otel_trace"

--- a/tests/unit/test_trace_merge.py
+++ b/tests/unit/test_trace_merge.py
@@ -420,3 +420,112 @@ async def test_trace_merge_three_way_overlap() -> None:
     ids = [tc["id"] for tc in tc_list]
     assert "b" in ids
     assert "span-b" not in ids
+
+
+@pytest.mark.asyncio
+async def test_empty_ids_do_not_collapse_distinct_traced_calls() -> None:
+    """Empty tool-call ids must not be treated as a match in ID dedup.
+
+    Gemini (always id="") and A2A (id="" when absent) emit empty ids.
+    If turn_tool_calls contains any empty-id call, every traced call
+    with a distinct (name, arguments) signature must still be merged.
+    """
+    receiver = AsyncMock()
+    receiver.signal_turn_complete = MagicMock()
+    receiver.wait_for_traces = AsyncMock(
+        return_value=[
+            ToolCall(id="", name="c", arguments={"z": 3}),
+        ]
+    )
+
+    sim = _make_simulator(trace_receiver=receiver)
+
+    mock_agent = AsyncMock()
+    mock_agent.get_chat_id = AsyncMock(return_value="conv-1")
+    mock_agent.execute = AsyncMock(
+        return_value=AgentResponse(
+            content="result",
+            tool_calls=[
+                ToolCall(id="", name="a", arguments={"x": 1}),
+                ToolCall(id="", name="b", arguments={"y": 2}),
+            ],
+        )
+    )
+    mock_agent.close = AsyncMock()
+
+    sim.llm.call_async = AsyncMock(side_effect=["hello", "###STOP###"])
+
+    with patch(
+        "arksim.simulation_engine.simulator.create_agent",
+        return_value=mock_agent,
+    ):
+        state = await sim._run_single_conversation(
+            profile="test user",
+            goal="test goal",
+            knowledge=[{"content": "k1"}],
+            agent_context="context",
+            max_turns=3,
+            scenario_id="s1",
+        )
+
+    assert state is not None
+    agent_msgs = [m for m in state.conversation_history if m.get("role") == "user"]
+    assert len(agent_msgs) == 1
+    tc_list = agent_msgs[0].get("tool_calls", [])
+    # 2 explicit (a, b) + 1 traced (c) = 3; empty ids must not collapse them
+    assert len(tc_list) == 3
+    names = {tc["name"] for tc in tc_list}
+    assert names == {"a", "b", "c"}
+
+
+@pytest.mark.asyncio
+async def test_empty_id_signature_match_still_dedupes() -> None:
+    """Signature-based dedup fires even when both sides have empty ids.
+
+    When turn_tool_calls and traced both carry id="" for the same
+    (name, arguments), the call must appear exactly once in the result.
+    """
+    receiver = AsyncMock()
+    receiver.signal_turn_complete = MagicMock()
+    receiver.wait_for_traces = AsyncMock(
+        return_value=[
+            ToolCall(id="", name="a", arguments={"x": 1}),
+        ]
+    )
+
+    sim = _make_simulator(trace_receiver=receiver)
+
+    mock_agent = AsyncMock()
+    mock_agent.get_chat_id = AsyncMock(return_value="conv-1")
+    mock_agent.execute = AsyncMock(
+        return_value=AgentResponse(
+            content="result",
+            tool_calls=[
+                ToolCall(id="", name="a", arguments={"x": 1}),
+            ],
+        )
+    )
+    mock_agent.close = AsyncMock()
+
+    sim.llm.call_async = AsyncMock(side_effect=["hello", "###STOP###"])
+
+    with patch(
+        "arksim.simulation_engine.simulator.create_agent",
+        return_value=mock_agent,
+    ):
+        state = await sim._run_single_conversation(
+            profile="test user",
+            goal="test goal",
+            knowledge=[{"content": "k1"}],
+            agent_context="context",
+            max_turns=3,
+            scenario_id="s1",
+        )
+
+    assert state is not None
+    agent_msgs = [m for m in state.conversation_history if m.get("role") == "user"]
+    assert len(agent_msgs) == 1
+    tc_list = agent_msgs[0].get("tool_calls", [])
+    # Signature match: only 1 call, not 2
+    assert len(tc_list) == 1
+    assert tc_list[0]["name"] == "a"


### PR DESCRIPTION
## Summary

- Populates `AgentResponse.tool_calls` for Chat Completions connector agents by extracting tool calls from OpenAI, Anthropic, and Gemini response bodies.
- Adds `ToolCallSource.CHAT_COMPLETIONS` so custom metrics can reason about capture provenance.
- Closes the "Planned" cells on the Chat Completions row of the Connector Support table for users pointing arksim at raw OpenAI-compatible endpoints.
- Fixes a latent dedup bug where multiple tool calls sharing empty ids (Gemini always, A2A / Chat Completions when `id` is absent) collapsed incorrectly in the simulator.

## Why now

arksim drives agents from outside the process, not from inside as a library. Observability platforms (Braintrust, Langfuse, Arize Phoenix, Patronus) capture tool calls by wrapping the OpenAI client, which requires the user to own and modify the agent code. That posture is unavailable to arksim by construction. OpenAI's own Evals framework response-parses `choices[0].message.tool_calls` directly; this PR matches that pattern, which is the natural fit for a simulator-driver posture.

## What ships

- Extraction for three response shapes:
  - **OpenAI:** `choices[0].message.tool_calls`
  - **Anthropic:** `content[]` blocks with `type: "tool_use"`
  - **Gemini:** `candidates[0].content.parts[]` entries with `functionCall`
- Defensive argument normalization for OpenAI (string / dict / None / malformed JSON) because LiteLLM, vLLM, and some Azure routers return `arguments` as a dict rather than the spec-compliant JSON string.
- Helpers are pure functions: `_coerce_openai_arguments`, `_extract_openai_tool_calls`, `_extract_anthropic_tool_calls`, `_extract_gemini_tool_calls`.
- Every captured `ToolCall` carries `source=ToolCallSource.CHAT_COMPLETIONS` and `result=None`.
- Graceful degradation on malformed input (skip + debug log, no raise).
- **Dedup correctness fix in `simulator.py`:** empty tool-call ids no longer collapse into a single set entry; trace-sourced calls with `id=""` now fall through to the signature-based dedup stage correctly. Pre-existing bug triggered by this PR's new source, which is why it ships here.
- **`parse_openai` docstring clarifies the `delta` fallback scope:** content-from-delta stays supported; tool-call extraction from streaming `delta` fragments is not supported (partial `arguments` JSON silently becomes `{}` via the defensive decoder).

## Non-goals (explicit)

- **Wrapper servers that handle tool execution internally and return only final text** are not covered by response parsing. Docs point these deployments at A2A (`Task.artifacts[*].metadata` via the arksim `AgentExtension`) or the Python connector.
- **Tool results** are not captured on this path. Raw Chat Completions endpoints return results through follow-up `role=tool` messages sent by the client, and arksim does not supply the tool implementations needed to produce those.
- **W3C Trace Context propagation** is not introduced.
- **Cross-process trace receiver integration** for wrappers is not introduced; that needs its own design.
- **No new example.** PR #140 consolidated tool-capture demos into `examples/customer-service/`; that remains the canonical demo.

## Security note

Tool call arguments can contain PII. The new docs section documents that Chat Completions capture is unconditional (unlike A2A's extension-gated emission) and recommends endpoint-level auth or a dedicated evaluation deployment when the endpoint is shared with non-arksim clients.

Parser debug logs emit only type names and structural keys, never raw tool argument values. This is intentional: arksim's UI attaches a WebSocket log handler at DEBUG level during simulate/evaluate runs, so raw-content log records would reach connected browser clients. Regression tests lock the behavior in.

## Test plan

- [x] Unit suite: 801 passed / 4 skipped.
- [x] Parser coverage: 91% on `response_parsers.py`, 100% on `tool_types.py`.
- [x] Edge cases per provider: happy path, mixed content + tool calls, malformed JSON, non-dict arguments, missing name, non-string name, empty lists, missing id, multiple tool calls in one response.
- [x] Contract regression: `parse_openai({"choices": [null]})` now raises `ValueError` (not `AttributeError`).
- [x] PII regression: two tests assert secret tokens never appear in any `arksim` logger record during the failure paths.
- [x] Dedup regression: two new tests lock in the empty-id behavior. Distinct-signature trace calls with `id=""` are merged; matching-signature calls with `id=""` on both sides still dedupe.
- [x] End-to-end wire test: `TestChatCompletionsAgentExecute::test_execute_populates_tool_calls` drives `execute()` through the real `parse_response` path with a monkeypatched `_post_request`.
- [x] Smoke test: local FastAPI mock endpoint returning OpenAI-shaped `tool_calls`, driven through `ChatCompletionsAgent.execute()`; confirmed populated `AgentResponse.tool_calls` with `source=ToolCallSource.CHAT_COMPLETIONS`.
- [x] `ruff check` + `ruff format --check` clean.

## Docs + changelog

- `docs/main/tool-call-capture.mdx` updated: Connector Support table, a new **Chat Completions Capture** section, and a new security subsection acknowledging the unconditional capture behavior.
- `CHANGELOG.md` `[Unreleased] → Added` entry.