### PR TITLE
docs: normalize arksim capitalization across Mintlify pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to ArkSim will be documented in this file.
+All notable changes to arksim will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/docs/main/build-scenario.mdx
+++ b/docs/main/build-scenario.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Scenarios"
-description: "Define test scenarios in ArkSim by specifying the simulated user's profile, goal, and prior knowledge for realistic agent conversations."
+description: "Define test scenarios in arksim by specifying the simulated user's profile, goal, and prior knowledge for realistic agent conversations."
 ---
 
 ## What is a Scenario?
@@ -8,7 +8,7 @@ description: "Define test scenarios in ArkSim by specifying the simulated user's
 A scenario is a test case that describes who the simulated user is, what they want to accomplish, and what they already know going into the conversation with the agent.
 
 <Frame>
-  ![ArkSim Workflow](/images/scenarios.svg)
+  ![arksim Workflow](/images/scenarios.svg)
 </Frame>
 
 ## The Three Core Pillars
@@ -38,9 +38,9 @@ Provides context that shapes the simulated user's questions and expectations. Al
   Think of a scenario as answering three questions: **Who** is this user? **What** do they want? **What** do they know?
 </Tip>
 
-## Why ArkSim Scenarios?
+## Why arksim Scenarios?
 
-ArkSim Scenarios let you test and evaluate your agent using realistic, profile-driven simulations of user interactions. Each scenario is built around clearly defined goals and behaviors, enabling structured performance evaluation without requiring a real-world dataset.
+arksim Scenarios let you test and evaluate your agent using realistic, profile-driven simulations of user interactions. Each scenario is built around clearly defined goals and behaviors, enabling structured performance evaluation without requiring a real-world dataset.
 
 By using synthetic users, you can run consistent and reproducible tests across a wide range of interaction types, making it easy to scale evaluations and understand how your agent performs before deploying it to real users.
 
@@ -174,8 +174,8 @@ Understanding how each field is used helps you decide what to include.
 | `goal`                         | Simulator & Evaluator | Directly used in the simulator prompt; the most important field.     |
 | `knowledge[].content`          | Simulator & Evaluator | Provides simulated user's background knowledge for the conversation. |
 | `user_profile`                 | Simulator             | Used as-is in the simulated user prompt to define the persona.       |
-| `knowledge[].metadata`         | Not used by ArkSim    | For labeling and traceability only.                                  |
-| `origin`                       | Not used by ArkSim    | Tracks scenario provenance; reference only.                          |
+| `knowledge[].metadata`         | Not used by arksim    | For labeling and traceability only.                                  |
+| `origin`                       | Not used by arksim    | Tracks scenario provenance; reference only.                          |
 
 ## Next Steps
 

--- a/docs/main/ci-integration.mdx
+++ b/docs/main/ci-integration.mdx
@@ -1,15 +1,15 @@
 ---
 title: "CI Integration"
-description: "Run ArkSim as an automated quality gate in your CI pipeline so every code change is tested against your agent's quality bar before it ships."
+description: "Run arksim as an automated quality gate in your CI pipeline so every code change is tested against your agent's quality bar before it ships."
 ---
 
-## Why run ArkSim in CI?
+## Why run arksim in CI?
 
 Agents break in non-obvious ways. A prompt tweak, a model upgrade, or a dependency change can silently degrade helpfulness, introduce false information, or cause goal failures — without triggering any unit test.
 
-Running ArkSim on every pull request turns quality regression into a CI signal:
+Running arksim on every pull request turns quality regression into a CI signal:
 
-| Without ArkSim in CI | With ArkSim in CI |
+| Without arksim in CI | With arksim in CI |
 |----------------------|-------------------|
 | Regressions found in production | Regressions caught before merge |
 | Manual spot-checking before releases | Automated evaluation on every PR |
@@ -22,7 +22,7 @@ Running ArkSim on every pull request turns quality regression into a CI signal:
 
 | | pytest (custom agent) | HTTP server |
 |---|---|---|
-| **How it works** | ArkSim loads your agent class in-process | ArkSim calls your agent over HTTP |
+| **How it works** | arksim loads your agent class in-process | arksim calls your agent over HTTP |
 | **Agent type** | Python class subclassing `BaseAgent` | Any HTTP server (any language or framework) |
 | **CI complexity** | Simple — just run `pytest` | Requires starting, health-checking, and stopping a server |
 | **Template** | `arksim-pytest.yml` + `test_agent_quality.py` | `arksim.yml` |
@@ -31,7 +31,7 @@ Running ArkSim on every pull request turns quality regression into a CI signal:
 
 ## Approach 1: pytest with a custom agent
 
-Your agent is a Python class that subclasses `BaseAgent`. ArkSim loads it in-process — no HTTP server needed. The pytest test runs simulation and evaluation directly and asserts scores.
+Your agent is a Python class that subclasses `BaseAgent`. arksim loads it in-process — no HTTP server needed. The pytest test runs simulation and evaluation directly and asserts scores.
 
 ### How it works
 
@@ -142,7 +142,7 @@ GitHub Actions runner
 
     | Secret | Purpose |
     |--------|---------|
-    | `OPENAI_API_KEY` | LLM ArkSim uses to evaluate your agent |
+    | `OPENAI_API_KEY` | LLM arksim uses to evaluate your agent |
   </Step>
 
   <Step title="Push">
@@ -154,7 +154,7 @@ GitHub Actions runner
 
 ## Approach 2: HTTP server
 
-Your agent runs as an HTTP server exposing an OpenAI-compatible chat completions endpoint. ArkSim calls it over HTTP during CI — works with any language or framework.
+Your agent runs as an HTTP server exposing an OpenAI-compatible chat completions endpoint. arksim calls it over HTTP during CI — works with any language or framework.
 
 ### How it works
 
@@ -203,7 +203,7 @@ The CLI exits non-zero if any threshold is not met, which fails the job.
     ```
   </Step>
 
-  <Step title="Create your ArkSim config">
+  <Step title="Create your arksim config">
     Create `arksim/config.yaml` in your repo. Point the `endpoint` at the port where your agent server will listen:
 
     ```yaml
@@ -245,7 +245,7 @@ The CLI exits non-zero if any threshold is not met, which fails the job.
     See [Evaluation](./evaluate-conversation) for all configuration options and the full list of available metrics.
 
     <Tip>
-      If your agent's `requirements.txt` conflicts with ArkSim's dependencies, install them in separate virtual environments so they don't interfere:
+      If your agent's `requirements.txt` conflicts with arksim's dependencies, install them in separate virtual environments so they don't interfere:
 
       ```yaml
       - name: Install agent dependencies
@@ -253,7 +253,7 @@ The CLI exits non-zero if any threshold is not met, which fails the job.
           python -m venv .venv-agent
           .venv-agent/bin/pip install -r requirements.txt
 
-      - name: Install ArkSim
+      - name: Install arksim
         run: pip install arksim
 
       - name: Start agent server
@@ -330,7 +330,7 @@ The CLI exits non-zero if any threshold is not met, which fails the job.
 
     | Secret | Purpose |
     |--------|---------|
-    | `OPENAI_API_KEY` | LLM ArkSim uses to evaluate your agent |
+    | `OPENAI_API_KEY` | LLM arksim uses to evaluate your agent |
     | `AGENT_API_KEY` | *(optional)* API key your agent server needs |
   </Step>
 

--- a/docs/main/contact-email.mdx
+++ b/docs/main/contact-email.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Contact"
-description: "Get in touch with the ArkSim team for support and inquiries."
+description: "Get in touch with the arksim team for support and inquiries."
 ---
 
 ## Get Help
 
-Need assistance with ArkSim? For technical support, bug reports, or questions about using ArkSim, contact us:
+Need assistance with arksim? For technical support, bug reports, or questions about using arksim, contact us:
 
 **Email:** [support@arklex.ai](mailto:support@arklex.ai)
 

--- a/docs/main/customer-service-tool-calling-agent-evaluation.mdx
+++ b/docs/main/customer-service-tool-calling-agent-evaluation.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Customer Service Tool-Calling Agent"
-description: "End-to-end example of using ArkSim to evaluate a tool-calling customer service agent with trajectory matching against expected tool call sequences."
+description: "End-to-end example of using arksim to evaluate a tool-calling customer service agent with trajectory matching against expected tool call sequences."
 ---
 
 ## Overview
 
-This example walks through running ArkSim against a customer service agent that uses tool calling (OpenAI Agents SDK) backed by a SQLite database. Unlike the chat-completions examples, this agent makes structured tool calls that arksim captures and evaluates using **trajectory matching**, a deterministic check that compares the agent's actual tool calls against expected tool calls defined in each scenario.
+This example walks through running arksim against a customer service agent that uses tool calling (OpenAI Agents SDK) backed by a SQLite database. Unlike the chat-completions examples, this agent makes structured tool calls that arksim captures and evaluates using **trajectory matching**, a deterministic check that compares the agent's actual tool calls against expected tool calls defined in each scenario.
 
 The agent handles customer lookup, order management, product search, and identity verification for a fictional online store.
 
@@ -87,7 +87,7 @@ Trajectory matching runs between turn-level evaluation and goal completion, so f
 ---
 
 <Note>
-  Before following these steps, ensure [ArkSim is installed](./installation) (`pip install arksim`).
+  Before following these steps, ensure [arksim is installed](./installation) (`pip install arksim`).
 </Note>
 
 ## Running the Example

--- a/docs/main/e-commerce-customer-service-agent-evaluation.mdx
+++ b/docs/main/e-commerce-customer-service-agent-evaluation.mdx
@@ -1,11 +1,11 @@
 ---
 title: "E-Commerce Customer Service Agent"
-description: "End-to-end example of using ArkSim to simulate and evaluate an e-commerce shopping assistant agent with product recommendation and order handling scenarios."
+description: "End-to-end example of using arksim to simulate and evaluate an e-commerce shopping assistant agent with product recommendation and order handling scenarios."
 ---
 
 ## Overview
 
-This example walks through running ArkSim against a shopping assistant agent built for an e-commerce use case. The agent is designed to help customers navigate product discovery, orders, returns, and general shopping queries.
+This example walks through running arksim against a shopping assistant agent built for an e-commerce use case. The agent is designed to help customers navigate product discovery, orders, returns, and general shopping queries.
 
 The example includes two ready-to-run agent setups you can test against out of the box, and a guide for plugging in your own agent once you're familiar with the setup.
 
@@ -42,7 +42,7 @@ Scenarios are defined in `scenarios.json` in the example directory and can be ed
 ---
 
 <Note>
-  Before following either path, ensure [ArkSim is installed](./installation) (`pip install arksim`).
+  Before following either path, ensure [arksim is installed](./installation) (`pip install arksim`).
 </Note>
 
 ## Option 1: OpenAI Agent

--- a/docs/main/evaluate-conversation.mdx
+++ b/docs/main/evaluate-conversation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Evaluation"
-description: "Use ArkSim to score your agent's responses on helpfulness, coherence, relevance, faithfulness, and goal completion, and surface failure patterns with actionable fixes."
+description: "Use arksim to score your agent's responses on helpfulness, coherence, relevance, faithfulness, and goal completion, and surface failure patterns with actionable fixes."
 ---
 
 ## What is Evaluation?
@@ -230,7 +230,7 @@ If any gate fails, the CLI exits with code `1` and logs which conversations and 
 
 ### Programmatic threshold gates
 
-When running ArkSim programmatically (e.g. with a custom agent class), you can apply the same gates by importing `check_numeric_thresholds` and `check_qualitative_failure_labels` directly from `arksim.evaluator`:
+When running arksim programmatically (e.g. with a custom agent class), you can apply the same gates by importing `check_numeric_thresholds` and `check_qualitative_failure_labels` directly from `arksim.evaluator`:
 
 ```python
 import sys
@@ -276,7 +276,7 @@ for convo in evaluator_output.conversations:
 ## Running Evaluation
 
 <Steps>
-  <Step title="Install ArkSim">
+  <Step title="Install arksim">
     ```bash
     pip install arksim
     ```

--- a/docs/main/installation.mdx
+++ b/docs/main/installation.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Install ArkSim and get ready to simulate and evaluate your AI agents."
+description: "Install arksim and get ready to simulate and evaluate your AI agents."
 title: "Installation"
 ---
 
@@ -16,7 +16,7 @@ pip install arksim
 
 ### Optional provider extras
 
-ArkSim uses OpenAI by default. To use other providers, install the corresponding extra:
+arksim uses OpenAI by default. To use other providers, install the corresponding extra:
 
 ```bash
 # Anthropic

--- a/docs/main/insurance-customer-service-agent-evaluation.mdx
+++ b/docs/main/insurance-customer-service-agent-evaluation.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Insurance Customer Service Agent"
-description: "End-to-end example of using ArkSim to simulate and evaluate an insurance customer service agent with custom compliance metrics and adversarial scenarios."
+description: "End-to-end example of using arksim to simulate and evaluate an insurance customer service agent with custom compliance metrics and adversarial scenarios."
 ---
 
 ## Overview
 
-This example walks through running ArkSim against a customer service agent built for an insurance company (XYZ Insurance, part of XYZ Bank Group). The agent is designed to answer customer questions about insurance products and coverage, including topics like policy details, claims processes, deductibles, and coverage limits.
+This example walks through running arksim against a customer service agent built for an insurance company (XYZ Insurance, part of XYZ Bank Group). The agent is designed to answer customer questions about insurance products and coverage, including topics like policy details, claims processes, deductibles, and coverage limits.
 
 The example includes two ready-to-run agent implementations you can test against out of the box, and a guide for plugging in your own agent once you're familiar with the setup.
 
@@ -41,7 +41,7 @@ Scenarios are defined in `scenarios.json` in the example directory and can be ed
 ---
 
 <Note>
-  Before following either path, ensure [ArkSim is installed](./installation) (`pip install arksim`).
+  Before following either path, ensure [arksim is installed](./installation) (`pip install arksim`).
 </Note>
 
 ## Option 1: OpenAI Agent

--- a/docs/main/integrations.mdx
+++ b/docs/main/integrations.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Integrations"
-description: "Use ArkSim with any agent framework. Browse working examples for 14 popular frameworks."
+description: "Use arksim with any agent framework. Browse working examples for 14 popular frameworks."
 ---
 
-ArkSim connects to your agent through one of three [connection types](./simulate-conversation#connection-types). The examples below show how to wire up each framework.
+arksim connects to your agent through one of three [connection types](./simulate-conversation#connection-types). The examples below show how to wire up each framework.
 
 ## Custom connector
 
@@ -47,7 +47,7 @@ These Python examples load your agent directly as a `BaseAgent` subclass. No HTT
 
 ## Chat Completions connector
 
-These TypeScript examples expose your agent behind an OpenAI-compatible HTTP endpoint. ArkSim connects using the `chat_completions` connector.
+These TypeScript examples expose your agent behind an OpenAI-compatible HTTP endpoint. arksim connects using the `chat_completions` connector.
 
 <CardGroup cols={2}>
   <Card icon="server" href="https://github.com/arklexai/arksim/tree/main/examples/integrations/mastra/" title="Mastra">

--- a/docs/main/overview.mdx
+++ b/docs/main/overview.mdx
@@ -1,22 +1,22 @@
 ---
 title: "Overview"
-description: "ArkSim is an open-source agent testing framework that simulates realistic multi-turn conversations with your AI agent and evaluates performance across built-in and custom metrics."
+description: "arksim is an open-source agent testing framework that simulates realistic multi-turn conversations with your AI agent and evaluates performance across built-in and custom metrics."
 ---
 
-## What is ArkSim?
+## What is arksim?
 
-ArkSim is an open-source agent testing tool designed to help developers validate, simulate, and harden their agent systems. It focuses on reproducible interaction simulations to identify reliability and idempotency gaps before production deployment.
+arksim is an open-source agent testing tool designed to help developers validate, simulate, and harden their agent systems. It focuses on reproducible interaction simulations to identify reliability and idempotency gaps before production deployment.
 
 <Frame>
   <img
     className="hidden dark:block"
     src="/images/arksim-workflow.svg"
-    alt="ArkSim Workflow"
+    alt="arksim Workflow"
   />
   <img
     className="dark:hidden"
     src="/images/arksim-overview.svg"
-    alt="ArkSim Workflow"
+    alt="arksim Workflow"
   />
 </Frame>
 
@@ -58,17 +58,17 @@ Evaluation scores your agent on those conversations. You get quantitative and qu
 ## Frequently Asked Questions
 
 <AccordionGroup>
-  <Accordion title="What does ArkSim do?">
-    ArkSim generates realistic multi-turn conversations between LLM-powered synthetic users and your agent, then evaluates every turn. Each synthetic user has a distinct profile, goal, and knowledge level. This reveals failures that only emerge across multiple conversation turns, like losing context, calling the wrong tool, or contradicting earlier responses.
+  <Accordion title="What does arksim do?">
+    arksim generates realistic multi-turn conversations between LLM-powered synthetic users and your agent, then evaluates every turn. Each synthetic user has a distinct profile, goal, and knowledge level. This reveals failures that only emerge across multiple conversation turns, like losing context, calling the wrong tool, or contradicting earlier responses.
   </Accordion>
   <Accordion title="How do I get started?">
     Install with `pip install arksim`, run `arksim init` to scaffold a starter config and agent file, then run `arksim simulate-evaluate config.yaml`. See the [quickstart guide](./quickstart) for a full walkthrough.
   </Accordion>
   <Accordion title="What agents and frameworks are supported?">
-    ArkSim works with any AI agent, whether it is built with LangChain, CrewAI, OpenAI Agents SDK, or your own custom code. Connect through a Chat Completions HTTP endpoint, the A2A protocol, or load a Python agent class directly with no server needed. See the full list of [supported integrations](./integrations).
+    arksim works with any AI agent, whether it is built with LangChain, CrewAI, OpenAI Agents SDK, or your own custom code. Connect through a Chat Completions HTTP endpoint, the A2A protocol, or load a Python agent class directly with no server needed. See the full list of [supported integrations](./integrations).
   </Accordion>
   <Accordion title="Can I run this in CI/CD?">
-    Yes. ArkSim runs as a CLI command that exits non-zero when quality thresholds are not met. Add it to any CI pipeline as a quality gate on every pull request. See the [CI integration guide](./ci-integration).
+    Yes. arksim runs as a CLI command that exits non-zero when quality thresholds are not met. Add it to any CI pipeline as a quality gate on every pull request. See the [CI integration guide](./ci-integration).
   </Accordion>
   <Accordion title="What metrics are available?">
     Built-in metrics include helpfulness, coherence, relevance, faithfulness, verbosity, goal completion, and agent behavior failure detection. You can also define custom quantitative and qualitative metrics with full access to the conversation context. See the [evaluation guide](./evaluate-conversation).
@@ -77,7 +77,7 @@ Evaluation scores your agent on those conversations. You get quantitative and qu
 
 ## Ready to start?
 
-Test your AI agent with ArkSim. Follow the quick start or explore the source on GitHub.
+Test your AI agent with arksim. Follow the quick start or explore the source on GitHub.
 
 <CardGroup cols={2}>
   <Card icon="rocket" href="./quickstart" title="Quick Start">

--- a/docs/main/personal-ai-assistant-openclaw-evaluation.mdx
+++ b/docs/main/personal-ai-assistant-openclaw-evaluation.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Personal AI Assistant (OpenClaw)"
-description: "End-to-end example of using ArkSim to simulate and evaluate an OpenClaw personal AI assistant handling smart home, calendar, and messaging tasks."
+description: "End-to-end example of using arksim to simulate and evaluate an OpenClaw personal AI assistant handling smart home, calendar, and messaging tasks."
 ---
 
 ## Overview
 
-This example walks through running ArkSim against an **OpenClaw** personal AI assistant. OpenClaw is an open-source assistant that runs on your own hardware and can manage tasks, smart home devices, messaging, calendar, and files.
+This example walks through running arksim against an **OpenClaw** personal AI assistant. OpenClaw is an open-source assistant that runs on your own hardware and can manage tasks, smart home devices, messaging, calendar, and files.
 
 You use this setup to simulate and evaluate conversations against your own OpenClaw deployment. The agent is exposed via a Chat Completions-compatible endpoint; the example `config.yaml` is already configured for the OpenClaw gateway.
 
@@ -17,7 +17,7 @@ Before getting started:
 
 - **OpenClaw** installed and configured: [openclaw.ai](https://openclaw.ai/)
 - **OpenClaw gateway** running with the HTTP Chat Completions endpoint enabled
-- **OpenAI API key**: used by ArkSim to power the simulated user
+- **OpenAI API key**: used by arksim to power the simulated user
 - **OpenClaw gateway token**: for authenticating to your OpenClaw instance (see `~/.openclaw/openclaw.json` under `gateway.auth.token`)
 
 ---

--- a/docs/main/quickstart.mdx
+++ b/docs/main/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart"
-description: "Get started with ArkSim in minutes. Test your own agent or explore a pre-built example with a single command."
+description: "Get started with arksim in minutes. Test your own agent or explore a pre-built example with a single command."
 ---
 
 ## Prerequisites
@@ -49,7 +49,7 @@ If you already have an agent running, use `arksim init` to scaffold a starter co
 
 ## Option B: Explore a pre-built example
 
-If you want to see ArkSim in action before connecting your own agent, try one of the included examples.
+If you want to see arksim in action before connecting your own agent, try one of the included examples.
 
 <Steps>
   <Step title="Install and set your API key">
@@ -144,7 +144,7 @@ If you want to see ArkSim in action before connecting your own agent, try one of
 
 ### Using other LLM providers
 
-ArkSim uses OpenAI by default for both the simulated user and the evaluator. To use Anthropic or Google instead, set the provider in your `config.yaml`:
+arksim uses OpenAI by default for both the simulated user and the evaluator. To use Anthropic or Google instead, set the provider in your `config.yaml`:
 
 <Tabs>
   <Tab title="Anthropic">
@@ -178,4 +178,4 @@ ArkSim uses OpenAI by default for both the simulated user and the evaluator. To 
 Now that you've run your first simulation and evaluation, here's where to go next.
 
 - **Explore the core concepts:** Dive deeper into [Scenarios](./build-scenario), [Simulation](./simulate-conversation), and [Evaluation](./evaluate-conversation) to understand how each piece works and how to configure them for your agent.
-- **Explore the examples:** Run ArkSim against [E-commerce](./e-commerce-customer-service-agent-evaluation), [Insurance](./insurance-customer-service-agent-evaluation), [Customer Service (tool calling)](./customer-service-tool-calling-agent-evaluation), and [Personal AI assistant (OpenClaw)](./personal-ai-assistant-openclaw-evaluation) to see different use cases and configs.
+- **Explore the examples:** Run arksim against [E-commerce](./e-commerce-customer-service-agent-evaluation), [Insurance](./insurance-customer-service-agent-evaluation), [Customer Service (tool calling)](./customer-service-tool-calling-agent-evaluation), and [Personal AI assistant (OpenClaw)](./personal-ai-assistant-openclaw-evaluation) to see different use cases and configs.

--- a/docs/main/schema-reference.mdx
+++ b/docs/main/schema-reference.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Schema Reference"
-description: "JSON and YAML schemas used by ArkSim for scenarios, simulation output, evaluation output, and run configuration."
+description: "JSON and YAML schemas used by arksim for scenarios, simulation output, evaluation output, and run configuration."
 ---
 
-This page documents the structure of the main artifacts used and produced by ArkSim: scenario files, simulation output, evaluation output, and the run configuration file. Use it when building integrations, writing custom tooling, or debugging pipeline outputs.
+This page documents the structure of the main artifacts used and produced by arksim: scenario files, simulation output, evaluation output, and the run configuration file. Use it when building integrations, writing custom tooling, or debugging pipeline outputs.
 
 <Tip>
   For agent connection details (Chat Completions, A2A, and config), see [Agent configuration](./simulate-conversation#agent-configuration).
@@ -63,7 +63,7 @@ Written by `arksim simulate` or the simulation step of `arksim simulate-evaluate
 </ResponseField>
 
 <ResponseField name="simulator_version" type="string" required>
-  ArkSim package version that produced this file.
+  arksim package version that produced this file.
 </ResponseField>
 
 <ResponseField name="simulation_id" type="string" required>
@@ -115,7 +115,7 @@ Written by `arksim evaluate` or the evaluation step of `arksim simulate-evaluate
 </ResponseField>
 
 <ResponseField name="evaluator_version" type="string" required>
-  ArkSim package version that produced this file.
+  arksim package version that produced this file.
 </ResponseField>
 
 <ResponseField name="evaluation_id" type="string" required>

--- a/docs/main/simulate-conversation.mdx
+++ b/docs/main/simulate-conversation.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Simulation"
-description: "Run ArkSim scenarios as live multi-turn conversations against your agent and collect transcripts for evaluation."
+description: "Run arksim scenarios as live multi-turn conversations against your agent and collect transcripts for evaluation."
 ---
 
 ## What is Simulation?
 
-Simulation is the process where ArkSim runs your pre-built scenarios as live conversations against your agent. Each scenario acts as a simulated user with a defined persona, goal, and prior knowledge who drives a multi-turn interaction with the agent until the user's goal is achieved or the turn limit is reached.
+Simulation is the process where arksim runs your pre-built scenarios as live conversations against your agent. Each scenario acts as a simulated user with a defined persona, goal, and prior knowledge who drives a multi-turn interaction with the agent until the user's goal is achieved or the turn limit is reached.
 
 The **output** is a set of conversation transcripts you can inspect directly or pass into Evaluation.
 
 <Frame>
-  ![ArkSim Simulation Workflow](/images/simulation.svg)
+  ![arksim Simulation Workflow](/images/simulation.svg)
 </Frame>
 
 ---
@@ -22,7 +22,7 @@ Before running a simulation, you need three things in place:
 | Input            | Description                                                                                                                                  |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Scenarios**    | A `scenarios.json` file defining user attributes, goals, knowledge, and scenario metadata. [Learn how to write scenarios →](./build-scenario) |
-| **Agent config** | Inline `agent_config` in your config YAML. Defines how ArkSim connects to your agent. See [Agent configuration](#agent-configuration) below. |
+| **Agent config** | Inline `agent_config` in your config YAML. Defines how arksim connects to your agent. See [Agent configuration](#agent-configuration) below. |
 | **Config file**  | `config.yaml` controlling simulation parameters such as number of conversations, max turns, workers, and model settings.                     |
 
 ---
@@ -70,7 +70,7 @@ provider: openai
 
 ### Advanced: Custom simulated user prompt
 
-By default, ArkSim uses a built-in system prompt to drive the simulated user. You can override it by setting `simulated_user_prompt_template` in your config to a **Jinja2** template string. The template is rendered per conversation with these variables:
+By default, arksim uses a built-in system prompt to drive the simulated user. You can override it by setting `simulated_user_prompt_template` in your config to a **Jinja2** template string. The template is rendered per conversation with these variables:
 
 **From the scenario file**
 
@@ -135,7 +135,7 @@ Provide agent connection by defining `agent_config` inline in your config YAML.
 
 ### Connection types
 
-ArkSim supports three ways to connect your agent:
+arksim supports three ways to connect your agent:
 
 | Type                                                                                | When to use                                                                            |
 | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |

--- a/docs/main/tool-call-capture.mdx
+++ b/docs/main/tool-call-capture.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Tool Call Capture"
-description: "Capture and evaluate tool calls from agents that handle tools internally using ArkSim's trace receiver and trajectory matching."
+description: "Capture and evaluate tool calls from agents that handle tools internally using arksim's trace receiver and trajectory matching."
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary

Running prose in `docs/main/**/*.mdx` inconsistently capitalized the project name as `ArkSim` or `Arksim`, while the package, README, and source tree consistently use lowercase `arksim`. The mixed-case form showed up most visibly in Mintlify frontmatter `description` fields (meta tags on the docs site) and page headings.

This PR sweeps `docs/main/` and the `CHANGELOG.md` header to use lowercase `arksim` everywhere the project name appears as prose. 15 pages updated, 66 line changes, zero behavior impact.

## Scope

- **Included:** prose, headings, image alt text, frontmatter `description` fields, CHANGELOG.md header line 3.
- **Preserved by design:**
  - `ArksimTracingProcessor` (actual Python class name; not prose).
  - Historical release-note entries referencing past rebrand PRs, UI text, or renames (rewriting those would falsify the changelog record).
  - Versioned docs snapshots in `docs/v0.x.x/` (project convention forbids edits).

The word-boundary regex used means `ArksimTracingProcessor` (no word boundary between `m` and `T`) is untouched while `ArkSim` or `Arksim` as standalone words get normalized.

## Out of scope

Duplicate `## [Unreleased]` sections in `CHANGELOG.md` — this turned out to be content preservation work (the duplicate blocks hold feature descriptions that never made it into their correct release blocks), not a mechanical dedup. Tracking separately so it gets proper per-entry judgment rather than being bundled here.

## Test plan

- [x] `grep -rnE "\b(ArkSim|Arksim)\b" docs/main/` returns zero hits after the sweep.
- [x] `grep -c "ArksimTracingProcessor" docs/main/tool-call-capture.mdx` still returns 4 (class name preserved).
- [x] Remaining `ArkSim`/`Arksim` hits in `CHANGELOG.md` are historical release-note entries only (the rebrand PR title, past UI text, past rename description) and are intentionally preserved.
- [x] Pre-commit hooks green on the commit.

## Review

Mechanical sweep, nothing to review logically beyond the scope boundaries above.