### PR TITLE
feat(evaluator): add scope (turn vs. conversation) to custom metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+* **evaluator:** `EvaluationParams.custom_qualitative_metrics` is deprecated; pass qualitative metrics in `custom_metrics` alongside quantitative ones. The field still works but emits a `DeprecationWarning` and will be removed in a future major release.
+
 ### Changed
 
 * **a2a:** migrate from a2a-sdk 0.3.x (Pydantic) to 1.0.0 (protobuf) ([#152](https://github.com/arklexai/arksim/pull/152))

--- a/arksim/evaluator/__init__.py
+++ b/arksim/evaluator/__init__.py
@@ -9,6 +9,7 @@ from arksim.scenario.entities import AssertionType, ToolCallsAssertion
 
 from .base_metric import (
     ChatMessage,
+    MetricScope,
     QualitativeMetric,
     QualResult,
     QuantitativeMetric,
@@ -34,6 +35,7 @@ __all__ = [
     "ChatMessage",
     "Evaluation",
     "EvaluationInput",
+    "MetricScope",
     "QuantitativeMetric",
     "QualitativeMetric",
     "QualResult",

--- a/arksim/evaluator/base_metric.py
+++ b/arksim/evaluator/base_metric.py
@@ -31,6 +31,7 @@ class QuantResult(BaseModel):
     value: float
     reason: str | None = None
     metadata: dict[str, Any] | None = None
+    scope: str = "turn"
 
 
 class QualResult(BaseModel):
@@ -39,6 +40,7 @@ class QualResult(BaseModel):
     name: str
     value: str
     reason: str | None = None
+    scope: str = "turn"
 
 
 class ScoreInput(BaseModel):
@@ -100,6 +102,9 @@ class QuantitativeMetric(_LLMMixin, abc.ABC):
             metrics). The range is used to normalise the value for the aggregated
             turn score and to derive a per-metric failure threshold
             (60 % of *max*).
+        scope: When the metric runs: ``"turn"`` (default) evaluates every
+            individual turn; ``"conversation"`` evaluates once per conversation
+            alongside goal completion.
         llm: Optional LLM instance injected by the evaluator. Custom metrics that
             need an LLM for scoring should accept ``llm=None`` in their
             ``__init__`` and pass it to ``super().__init__(llm=llm)``, then use
@@ -135,12 +140,14 @@ class QuantitativeMetric(_LLMMixin, abc.ABC):
         additional_input: dict[str, Any] | None = None,
         description: str = "",
         llm: BaseLLM | None = None,
+        scope: str = "turn",
     ) -> None:
         self.name = name if name is not None else self.__class__.__name__
         self.score_range = score_range
         self.additional_input = additional_input or {}
         self.description = description
         self._llm = llm
+        self.scope = scope
 
     @abc.abstractmethod
     def score(self, score_input: ScoreInput) -> QuantResult:
@@ -157,6 +164,9 @@ class QualitativeMetric(_LLMMixin, abc.ABC):
         name: The name of the metric. If not provided, uses the class name as default.
         description: Human-readable description of what the metric measures.
         label_colors: Mapping of label values to hex colour strings for the report UI.
+        scope: When the metric runs: ``"turn"`` (default) evaluates every
+            individual turn; ``"conversation"`` evaluates once per conversation
+            alongside goal completion.
         llm: Optional LLM instance injected by the evaluator. Custom metrics that
             need an LLM for evaluation should accept ``llm=None`` in their
             ``__init__`` and pass it to ``super().__init__(llm=llm)``, then use
@@ -191,11 +201,13 @@ class QualitativeMetric(_LLMMixin, abc.ABC):
         description: str = "",
         label_colors: dict[str, str] | None = None,
         llm: BaseLLM | None = None,
+        scope: str = "turn",
     ) -> None:
         self.name = name if name is not None else self.__class__.__name__
         self.description = description
         self.label_colors: dict[str, str] = label_colors or {}
         self._llm = llm
+        self.scope = scope
 
     @abc.abstractmethod
     def evaluate(self, score_input: ScoreInput) -> QualResult:

--- a/arksim/evaluator/base_metric.py
+++ b/arksim/evaluator/base_metric.py
@@ -151,6 +151,12 @@ class QuantitativeMetric(_LLMMixin, abc.ABC):
         self._llm = llm
         self.scope = scope
 
+    def run(self, score_input: ScoreInput) -> QuantResult:
+        """Score *score_input* and stamp ``scope`` on the result."""
+        r = self.score(score_input.model_copy(update=self.additional_input))
+        r.scope = self.scope
+        return r
+
     @abc.abstractmethod
     def score(self, score_input: ScoreInput) -> QuantResult:
         raise NotImplementedError()
@@ -210,6 +216,12 @@ class QualitativeMetric(_LLMMixin, abc.ABC):
         self.label_colors: dict[str, str] = label_colors or {}
         self._llm = llm
         self.scope = scope
+
+    def run(self, score_input: ScoreInput) -> QualResult:
+        """Evaluate *score_input* and stamp ``scope`` on the result."""
+        r = self.evaluate(score_input)
+        r.scope = self.scope
+        return r
 
     @abc.abstractmethod
     def evaluate(self, score_input: ScoreInput) -> QualResult:

--- a/arksim/evaluator/base_metric.py
+++ b/arksim/evaluator/base_metric.py
@@ -210,16 +210,18 @@ class QualitativeMetric(_LLMMixin, abc.ABC):
         label_colors: dict[str, str] | None = None,
         llm: BaseLLM | None = None,
         scope: MetricScope = "turn",
+        additional_input: dict[str, Any] | None = None,
     ) -> None:
         self.name = name if name is not None else self.__class__.__name__
         self.description = description
         self.label_colors: dict[str, str] = label_colors or {}
         self._llm = llm
         self.scope = scope
+        self.additional_input = additional_input or {}
 
     def run(self, score_input: ScoreInput) -> QualResult:
         """Evaluate *score_input* and stamp ``scope`` on the result."""
-        r = self.evaluate(score_input)
+        r = self.evaluate(score_input.model_copy(update=self.additional_input))
         r.scope = self.scope
         return r
 

--- a/arksim/evaluator/base_metric.py
+++ b/arksim/evaluator/base_metric.py
@@ -6,12 +6,14 @@ Provides the abstract base for all evaluation metrics, both built-in and user-de
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from arksim.llms.chat.base.base_llm import BaseLLM
+
+MetricScope = Literal["turn", "conversation"]
 
 
 class ChatMessage(BaseModel):
@@ -31,7 +33,7 @@ class QuantResult(BaseModel):
     value: float
     reason: str | None = None
     metadata: dict[str, Any] | None = None
-    scope: str = "turn"
+    scope: MetricScope = "turn"
 
 
 class QualResult(BaseModel):
@@ -40,7 +42,7 @@ class QualResult(BaseModel):
     name: str
     value: str
     reason: str | None = None
-    scope: str = "turn"
+    scope: MetricScope = "turn"
 
 
 class ScoreInput(BaseModel):
@@ -140,7 +142,7 @@ class QuantitativeMetric(_LLMMixin, abc.ABC):
         additional_input: dict[str, Any] | None = None,
         description: str = "",
         llm: BaseLLM | None = None,
-        scope: str = "turn",
+        scope: MetricScope = "turn",
     ) -> None:
         self.name = name if name is not None else self.__class__.__name__
         self.score_range = score_range
@@ -201,7 +203,7 @@ class QualitativeMetric(_LLMMixin, abc.ABC):
         description: str = "",
         label_colors: dict[str, str] | None = None,
         llm: BaseLLM | None = None,
-        scope: str = "turn",
+        scope: MetricScope = "turn",
     ) -> None:
         self.name = name if name is not None else self.__class__.__name__
         self.description = description

--- a/arksim/evaluator/entities.py
+++ b/arksim/evaluator/entities.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import warnings
 
 from arksim.simulation_engine.tool_types import ToolCall
 
@@ -164,6 +165,23 @@ class EvaluationParams(BaseModel):
         default_factory=list
     )
     metrics_to_run: list[str] | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _merge_legacy_qualitative_metrics(cls, data: object) -> object:
+        """Merge deprecated custom_qualitative_metrics into custom_metrics."""
+        if isinstance(data, dict) and "custom_qualitative_metrics" in data:
+            warnings.warn(
+                "`custom_qualitative_metrics` is deprecated; pass qualitative "
+                "metrics in `custom_metrics` alongside quantitative ones.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            legacy = data.pop("custom_qualitative_metrics") or []
+            data["custom_metrics"] = list(data.get("custom_metrics") or []) + list(
+                legacy
+            )
+        return data
 
 
 class TurnItem(BaseModel):

--- a/arksim/evaluator/entities.py
+++ b/arksim/evaluator/entities.py
@@ -162,6 +162,10 @@ class EvaluationParams(BaseModel):
     num_workers: int | str = Field(default=50)
     custom_metrics: list[QuantitativeMetric] = Field(default_factory=list)
     custom_qualitative_metrics: list[QualitativeMetric] = Field(default_factory=list)
+    convo_custom_metrics: list[QuantitativeMetric] = Field(default_factory=list)
+    convo_custom_qualitative_metrics: list[QualitativeMetric] = Field(
+        default_factory=list
+    )
     metrics_to_run: list[str] | None = None
 
 
@@ -226,6 +230,10 @@ class ConversationEvaluation(BaseModel):
     overall_agent_score: float  # 0–1
     evaluation_status: str
     turn_scores: list[TurnEvaluation]
+    scores: list[QuantResult] = Field(default_factory=list)  # convo-level custom quant
+    qual_scores: list[QualResult] = Field(
+        default_factory=list
+    )  # convo-level custom qual
 
 
 class ErrorScenarioMapping(BaseModel):

--- a/arksim/evaluator/entities.py
+++ b/arksim/evaluator/entities.py
@@ -160,10 +160,7 @@ class EvaluationParams(BaseModel):
     code_file_path: str | None = None
     entry_function: str | None = None
     num_workers: int | str = Field(default=50)
-    custom_metrics: list[QuantitativeMetric] = Field(default_factory=list)
-    custom_qualitative_metrics: list[QualitativeMetric] = Field(default_factory=list)
-    convo_custom_metrics: list[QuantitativeMetric] = Field(default_factory=list)
-    convo_custom_qualitative_metrics: list[QualitativeMetric] = Field(
+    custom_metrics: list[QuantitativeMetric | QualitativeMetric] = Field(
         default_factory=list
     )
     metrics_to_run: list[str] | None = None
@@ -230,10 +227,8 @@ class ConversationEvaluation(BaseModel):
     overall_agent_score: float  # 0–1
     evaluation_status: str
     turn_scores: list[TurnEvaluation]
-    scores: list[QuantResult] = Field(default_factory=list)  # convo-level custom quant
-    qual_scores: list[QualResult] = Field(
-        default_factory=list
-    )  # convo-level custom qual
+    convo_scores: list[QuantResult] = Field(default_factory=list)
+    convo_qual_scores: list[QualResult] = Field(default_factory=list)
 
 
 class ErrorScenarioMapping(BaseModel):

--- a/arksim/evaluator/evaluate.py
+++ b/arksim/evaluator/evaluate.py
@@ -55,6 +55,70 @@ def _should_run(name: str, metrics_to_run: list[str] | None) -> bool:
     return not metrics_to_run or name in metrics_to_run
 
 
+def _run_metrics_parallel(
+    quant_metrics: list[QuantitativeMetric],
+    qual_metrics: list[QualitativeMetric],
+    score_input: ScoreInput,
+    num_workers: int,
+    log_context: str,
+) -> tuple[list[QuantResult], list[QualResult]]:
+    """Run quant and qual metrics concurrently, returning (scores, qual_scores).
+
+    Each metric's ScoreInput is built by copying *score_input* and merging
+    the metric's ``additional_input`` so callers never reconstruct fields.
+    Scope is taken from ``metric.scope`` rather than being hardcoded.
+    """
+
+    def _run_quant(metric: QuantitativeMetric) -> QuantResult:
+        r = metric.score(
+            score_input.model_copy(update=getattr(metric, "additional_input", {}))
+        )
+        return QuantResult(
+            name=metric.name, value=r.value, reason=r.reason, scope=metric.scope
+        )
+
+    def _run_qual(metric: QualitativeMetric) -> QualResult:
+        r = metric.evaluate(
+            score_input.model_copy(update=getattr(metric, "additional_input", {}))
+        )
+        return QualResult(
+            name=r.name, value=r.value, reason=r.reason, scope=metric.scope
+        )
+
+    quant_tasks: list[tuple[str, Callable[[], QuantResult]]] = [
+        (m.name, lambda metric=m: _run_quant(metric)) for m in quant_metrics
+    ]
+    qual_tasks: list[tuple[str, Callable[[], QualResult]]] = [
+        (m.name, lambda metric=m: _run_qual(metric)) for m in qual_metrics
+    ]
+    all_tasks = quant_tasks + qual_tasks
+
+    scores: list[QuantResult] = []
+    qual_scores: list[QualResult] = []
+
+    if all_tasks:
+        _max = min(num_workers, len(all_tasks)) if num_workers > 0 else len(all_tasks)
+        with ThreadPoolExecutor(max_workers=_max) as pool:
+            score_futures = {pool.submit(fn): name for name, fn in quant_tasks}
+            qual_futures = {pool.submit(fn): name for name, fn in qual_tasks}
+            all_futures = {**score_futures, **qual_futures}
+
+            for future in as_completed(all_futures):
+                name = all_futures[future]
+                try:
+                    result = future.result()
+                    if future in score_futures:
+                        scores.append(result)
+                    else:
+                        qual_scores.append(result)
+                except Exception as e:
+                    logger.warning(
+                        "Metric '%s' failed for %s: %s", name, log_context, e
+                    )
+
+    return scores, qual_scores
+
+
 def evaluate_turn(
     llm: LLM,
     turn_item: TurnItem,
@@ -94,77 +158,17 @@ def evaluate_turn(
         m for m in builtin if _should_run(m.name, metrics_to_run)
     ] + (custom_metrics or [])
 
-    def _run(metric: QuantitativeMetric) -> QuantResult:
-        result = metric.score(
-            ScoreInput(
-                chat_history=score_input.chat_history,
-                current_turn=score_input.current_turn,
-                knowledge=score_input.knowledge,
-                user_goal=score_input.user_goal,
-                profile=score_input.profile,
-                **metric.additional_input,
-            )
-        )
-        return QuantResult(
-            name=metric.name,
-            value=result.value,
-            reason=result.reason or "",
-            scope="turn",
-        )
-
-    def _run_qual(metric: QualitativeMetric) -> QualResult:
-        result = metric.evaluate(
-            ScoreInput(
-                chat_history=score_input.chat_history,
-                current_turn=score_input.current_turn,
-                knowledge=score_input.knowledge,
-                user_goal=score_input.user_goal,
-                profile=score_input.profile,
-                **getattr(metric, "additional_input", {}),
-            )
-        )
-        return QualResult(
-            name=result.name,
-            value=result.value,
-            reason=result.reason,
-            scope="turn",
-        )
-
-    metric_tasks: list[tuple[str, Callable[[], QuantResult]]] = [
-        (m.name, lambda metric=m: _run(metric)) for m in all_metrics
-    ]
-    qual_tasks: list[tuple[str, Callable[[], QualResult]]] = [
-        (m.name, lambda metric=m: _run_qual(metric))
-        for m in (custom_qualitative_metrics or [])
-    ]
-    all_tasks = metric_tasks + qual_tasks
-
-    scores: list[QuantResult] = []
-    qual_scores: list[QualResult] = []
-
-    if all_tasks:
-        _max = min(num_workers, len(all_tasks)) if num_workers > 0 else len(all_tasks)
-        # This inner pool is nested inside the outer per-turn pool in
-        # evaluator.py. Total LLM concurrency is roughly
-        # outer_workers * metrics_per_turn (unbounded in "auto" mode),
-        # so large runs may hit rate limits.
-        with ThreadPoolExecutor(max_workers=_max) as pool:
-            score_futures = {pool.submit(fn): name for name, fn in metric_tasks}
-            qual_futures = {pool.submit(fn): name for name, fn in qual_tasks}
-            all_futures = {**score_futures, **qual_futures}
-
-            for future in as_completed(all_futures):
-                name = all_futures[future]
-                try:
-                    result = future.result()
-                    if future in score_futures:
-                        scores.append(result)
-                    else:
-                        qual_scores.append(result)
-                except Exception as e:
-                    logger.warning(
-                        f"Metric '{name}' failed for turn {turn_item.turn_id}: {e}"
-                    )
+    # This inner pool is nested inside the outer per-turn pool in
+    # evaluator.py. Total LLM concurrency is roughly
+    # outer_workers * metrics_per_turn (unbounded in "auto" mode),
+    # so large runs may hit rate limits.
+    scores, qual_scores = _run_metrics_parallel(
+        all_metrics,
+        custom_qualitative_metrics or [],
+        score_input,
+        num_workers,
+        f"turn {turn_item.turn_id}",
+    )
 
     metric_max = {m.name: m.score_range[1] for m in all_metrics}
     has_threshold_failure = any(
@@ -244,8 +248,8 @@ def evaluate_conversation(
     llm: LLM,
     convo_item: ConvoItem,
     turns_details: list[TurnEvaluation],
-    custom_metrics: list[QuantitativeMetric] | None = None,
-    custom_qualitative_metrics: list[QualitativeMetric] | None = None,
+    custom_convo_metrics: list[QuantitativeMetric] | None = None,
+    custom_convo_qualitative_metrics: list[QualitativeMetric] | None = None,
     metrics_to_run: list[str] | None = None,
     num_workers: int = 0,
 ) -> ConversationEvaluation:
@@ -255,8 +259,8 @@ def evaluate_conversation(
         llm: The LLM instance to use for evaluation.
         convo_item: The conversation item with full history and metadata.
         turns_details: Completed TurnEvaluation objects for this conversation.
-        custom_metrics: Optional list of conversation-level quantitative metrics.
-        custom_qualitative_metrics: Optional list of conversation-level qualitative metrics.
+        custom_convo_metrics: Optional list of conversation-level quantitative metrics.
+        custom_convo_qualitative_metrics: Optional list of conversation-level qualitative metrics.
         metrics_to_run: Optional list of metric names to run.
         num_workers: Max concurrent metric LLM calls. 0 means unlimited.
     """
@@ -281,74 +285,13 @@ def evaluate_conversation(
         goal_completion_reason = ""
 
     # Run conversation-level custom metrics in parallel.
-    scores: list[QuantResult] = []
-    qual_scores: list[QualResult] = []
-
-    def _run(metric: QuantitativeMetric) -> QuantResult:
-        r = metric.score(
-            ScoreInput(
-                chat_history=score_input.chat_history,
-                knowledge=score_input.knowledge,
-                user_goal=score_input.user_goal,
-                profile=score_input.profile,
-                **metric.additional_input,
-            )
-        )
-        return QuantResult(
-            name=metric.name,
-            value=r.value,
-            reason=r.reason or "",
-            scope="conversation",
-        )
-
-    def _run_qual(metric: QualitativeMetric) -> QualResult:
-        r = metric.evaluate(
-            ScoreInput(
-                chat_history=score_input.chat_history,
-                knowledge=score_input.knowledge,
-                user_goal=score_input.user_goal,
-                profile=score_input.profile,
-                **getattr(metric, "additional_input", {}),
-            )
-        )
-        return QualResult(
-            name=r.name,
-            value=r.value,
-            reason=r.reason,
-            scope="conversation",
-        )
-
-    metric_tasks: list[tuple[str, Callable[[], QuantResult]]] = [
-        (m.name, lambda metric=m: _run(metric)) for m in (custom_metrics or [])
-    ]
-    qual_tasks: list[tuple[str, Callable[[], QualResult]]] = [
-        (m.name, lambda metric=m: _run_qual(metric))
-        for m in (custom_qualitative_metrics or [])
-    ]
-    all_tasks = metric_tasks + qual_tasks
-
-    if all_tasks:
-        _max = min(num_workers, len(all_tasks)) if num_workers > 0 else len(all_tasks)
-        with ThreadPoolExecutor(max_workers=_max) as pool:
-            score_futures = {pool.submit(fn): name for name, fn in metric_tasks}
-            qual_futures = {pool.submit(fn): name for name, fn in qual_tasks}
-            all_futures = {**score_futures, **qual_futures}
-
-            for future in as_completed(all_futures):
-                name = all_futures[future]
-                try:
-                    r = future.result()
-                    if future in score_futures:
-                        scores.append(r)
-                    else:
-                        qual_scores.append(r)
-                except Exception as e:
-                    logger.warning(
-                        "Conversation metric '%s' failed for %s: %s",
-                        name,
-                        convo_item.chat_id,
-                        e,
-                    )
+    scores, qual_scores = _run_metrics_parallel(
+        custom_convo_metrics or [],
+        custom_convo_qualitative_metrics or [],
+        score_input,
+        num_workers,
+        convo_item.chat_id,
+    )
 
     behavior_failures = sum(
         1 for t in turns_details if t.turn_behavior_failure not in SKIP_OUTCOMES
@@ -385,6 +328,6 @@ def evaluate_conversation(
         overall_agent_score=overall_agent_score,
         evaluation_status=status,
         turn_scores=turns_details,
-        scores=scores,
-        qual_scores=qual_scores,
+        convo_scores=scores,
+        convo_qual_scores=qual_scores,
     )

--- a/arksim/evaluator/evaluate.py
+++ b/arksim/evaluator/evaluate.py
@@ -106,11 +106,14 @@ def evaluate_turn(
             )
         )
         return QuantResult(
-            name=metric.name, value=result.value, reason=result.reason or ""
+            name=metric.name,
+            value=result.value,
+            reason=result.reason or "",
+            scope="turn",
         )
 
     def _run_qual(metric: QualitativeMetric) -> QualResult:
-        return metric.evaluate(
+        result = metric.evaluate(
             ScoreInput(
                 chat_history=score_input.chat_history,
                 current_turn=score_input.current_turn,
@@ -119,6 +122,12 @@ def evaluate_turn(
                 profile=score_input.profile,
                 **getattr(metric, "additional_input", {}),
             )
+        )
+        return QualResult(
+            name=result.name,
+            value=result.value,
+            reason=result.reason,
+            scope="turn",
         )
 
     metric_tasks: list[tuple[str, Callable[[], QuantResult]]] = [
@@ -231,20 +240,33 @@ def evaluate_turn(
     )
 
 
-def evaluate_goal_completion(
+def evaluate_conversation(
     llm: LLM,
     convo_item: ConvoItem,
     turns_details: list[TurnEvaluation],
+    custom_metrics: list[QuantitativeMetric] | None = None,
+    custom_qualitative_metrics: list[QualitativeMetric] | None = None,
     metrics_to_run: list[str] | None = None,
+    num_workers: int = 0,
 ) -> ConversationEvaluation:
-    """Compute goal completion and build ConversationEvaluation.
+    """Compute goal completion, run conversation-level custom metrics, and build ConversationEvaluation.
 
     Args:
         llm: The LLM instance to use for evaluation.
         convo_item: The conversation item with full history and metadata.
         turns_details: Completed TurnEvaluation objects for this conversation.
+        custom_metrics: Optional list of conversation-level quantitative metrics.
+        custom_qualitative_metrics: Optional list of conversation-level qualitative metrics.
         metrics_to_run: Optional list of metric names to run.
+        num_workers: Max concurrent metric LLM calls. 0 means unlimited.
     """
+    score_input = ScoreInput(
+        chat_history=convo_item.chat_history,
+        knowledge=combine_knowledge(convo_item.knowledge or []),
+        user_goal=convo_item.user_goal,
+        profile=convo_item.profile,
+    )
+
     if _should_run("goal_completion", metrics_to_run):
         result = GoalCompletionMetric(llm).score(
             ScoreInput(
@@ -257,6 +279,76 @@ def evaluate_goal_completion(
     else:
         goal_completion_score = SCORE_NOT_COMPUTED
         goal_completion_reason = ""
+
+    # Run conversation-level custom metrics in parallel.
+    scores: list[QuantResult] = []
+    qual_scores: list[QualResult] = []
+
+    def _run(metric: QuantitativeMetric) -> QuantResult:
+        r = metric.score(
+            ScoreInput(
+                chat_history=score_input.chat_history,
+                knowledge=score_input.knowledge,
+                user_goal=score_input.user_goal,
+                profile=score_input.profile,
+                **metric.additional_input,
+            )
+        )
+        return QuantResult(
+            name=metric.name,
+            value=r.value,
+            reason=r.reason or "",
+            scope="conversation",
+        )
+
+    def _run_qual(metric: QualitativeMetric) -> QualResult:
+        r = metric.evaluate(
+            ScoreInput(
+                chat_history=score_input.chat_history,
+                knowledge=score_input.knowledge,
+                user_goal=score_input.user_goal,
+                profile=score_input.profile,
+                **getattr(metric, "additional_input", {}),
+            )
+        )
+        return QualResult(
+            name=r.name,
+            value=r.value,
+            reason=r.reason,
+            scope="conversation",
+        )
+
+    metric_tasks: list[tuple[str, Callable[[], QuantResult]]] = [
+        (m.name, lambda metric=m: _run(metric)) for m in (custom_metrics or [])
+    ]
+    qual_tasks: list[tuple[str, Callable[[], QualResult]]] = [
+        (m.name, lambda metric=m: _run_qual(metric))
+        for m in (custom_qualitative_metrics or [])
+    ]
+    all_tasks = metric_tasks + qual_tasks
+
+    if all_tasks:
+        _max = min(num_workers, len(all_tasks)) if num_workers > 0 else len(all_tasks)
+        with ThreadPoolExecutor(max_workers=_max) as pool:
+            score_futures = {pool.submit(fn): name for name, fn in metric_tasks}
+            qual_futures = {pool.submit(fn): name for name, fn in qual_tasks}
+            all_futures = {**score_futures, **qual_futures}
+
+            for future in as_completed(all_futures):
+                name = all_futures[future]
+                try:
+                    r = future.result()
+                    if future in score_futures:
+                        scores.append(r)
+                    else:
+                        qual_scores.append(r)
+                except Exception as e:
+                    logger.warning(
+                        "Conversation metric '%s' failed for %s: %s",
+                        name,
+                        convo_item.chat_id,
+                        e,
+                    )
 
     behavior_failures = sum(
         1 for t in turns_details if t.turn_behavior_failure not in SKIP_OUTCOMES
@@ -293,4 +385,6 @@ def evaluate_goal_completion(
         overall_agent_score=overall_agent_score,
         evaluation_status=status,
         turn_scores=turns_details,
+        scores=scores,
+        qual_scores=qual_scores,
     )

--- a/arksim/evaluator/evaluate.py
+++ b/arksim/evaluator/evaluate.py
@@ -69,27 +69,11 @@ def _run_metrics_parallel(
     Scope is taken from ``metric.scope`` rather than being hardcoded.
     """
 
-    def _run_quant(metric: QuantitativeMetric) -> QuantResult:
-        r = metric.score(
-            score_input.model_copy(update=getattr(metric, "additional_input", {}))
-        )
-        return QuantResult(
-            name=metric.name, value=r.value, reason=r.reason, scope=metric.scope
-        )
-
-    def _run_qual(metric: QualitativeMetric) -> QualResult:
-        r = metric.evaluate(
-            score_input.model_copy(update=getattr(metric, "additional_input", {}))
-        )
-        return QualResult(
-            name=r.name, value=r.value, reason=r.reason, scope=metric.scope
-        )
-
     quant_tasks: list[tuple[str, Callable[[], QuantResult]]] = [
-        (m.name, lambda metric=m: _run_quant(metric)) for m in quant_metrics
+        (m.name, lambda metric=m: metric.run(score_input)) for m in quant_metrics
     ]
     qual_tasks: list[tuple[str, Callable[[], QualResult]]] = [
-        (m.name, lambda metric=m: _run_qual(metric)) for m in qual_metrics
+        (m.name, lambda metric=m: metric.run(score_input)) for m in qual_metrics
     ]
     all_tasks = quant_tasks + qual_tasks
 
@@ -271,27 +255,27 @@ def evaluate_conversation(
         profile=convo_item.profile,
     )
 
+    builtin_convo_metrics: list[QuantitativeMetric] = []
     if _should_run("goal_completion", metrics_to_run):
-        result = GoalCompletionMetric(llm).score(
-            ScoreInput(
-                chat_history=convo_item.chat_history,
-                user_goal=convo_item.user_goal,
-            )
-        )
-        goal_completion_score = result.value
-        goal_completion_reason = result.reason
-    else:
-        goal_completion_score = SCORE_NOT_COMPUTED
-        goal_completion_reason = ""
+        builtin_convo_metrics.append(GoalCompletionMetric(llm))
 
-    # Run conversation-level custom metrics in parallel.
+    # Run built-in and custom conversation-level metrics in parallel.
     scores, qual_scores = _run_metrics_parallel(
-        custom_convo_metrics or [],
+        builtin_convo_metrics + (custom_convo_metrics or []),
         custom_convo_qualitative_metrics or [],
         score_input,
         num_workers,
         convo_item.chat_id,
     )
+
+    gc_result = next((r for r in scores if r.name == "goal_completion"), None)
+    if gc_result is not None:
+        scores = [r for r in scores if r.name != "goal_completion"]
+        goal_completion_score = gc_result.value
+        goal_completion_reason = gc_result.reason
+    else:
+        goal_completion_score = SCORE_NOT_COMPUTED
+        goal_completion_reason = ""
 
     behavior_failures = sum(
         1 for t in turns_details if t.turn_behavior_failure not in SKIP_OUTCOMES

--- a/arksim/evaluator/evaluator.py
+++ b/arksim/evaluator/evaluator.py
@@ -38,7 +38,7 @@ from .entities import (
 )
 from .error_detection import detect_agent_error
 from .evaluate import (
-    evaluate_goal_completion,
+    evaluate_conversation,
     evaluate_turn,
 )
 from .trajectory_matching import match_trajectory
@@ -321,17 +321,21 @@ class Evaluator:
         convo_score_list: list[ConversationEvaluation] = []
 
         gc_max_workers = max(1, min(num_workers, len(processed_entries)))
+        gc_inner_workers = 0 if self.params.num_workers == "auto" else num_workers
         with ThreadPoolExecutor(max_workers=gc_max_workers) as executor:
             gc_futures = {
                 executor.submit(
-                    evaluate_goal_completion,
+                    evaluate_conversation,
                     self.llm,
                     convo_item,
                     sorted(
                         turn_results.get(convo_item.chat_id, []),
                         key=lambda t: t.turn_id,
                     ),
+                    self.params.convo_custom_metrics or None,
+                    self.params.convo_custom_qualitative_metrics or None,
                     self.params.metrics_to_run,
+                    gc_inner_workers,
                 ): convo_item
                 for _, convo_item in processed_entries
             }
@@ -705,6 +709,8 @@ class Evaluator:
                 for score in turn.scores:
                     metric_scores[score.name].append(score.value)
                 failure_counts[turn.turn_behavior_failure] += 1
+            for score in conv.scores:
+                metric_scores[score.name].append(score.value)
 
         averages: dict[str, float] = {
             metric: sum(vals) / len(vals)
@@ -914,15 +920,25 @@ def run_evaluation(
         model=settings.model,
         provider=settings.provider,
     )
-    custom_metrics, custom_qualitative_metrics = _load_custom_metrics(
+    all_quant, all_qual = _load_custom_metrics(
         settings.custom_metrics_file_paths, llm=llm
     )
+
+    # Split custom metrics by scope (turn vs. conversation).
+    turn_quant = [m for m in all_quant if getattr(m, "scope", "turn") == "turn"]
+    convo_quant = [
+        m for m in all_quant if getattr(m, "scope", "turn") == "conversation"
+    ]
+    turn_qual = [m for m in all_qual if getattr(m, "scope", "turn") == "turn"]
+    convo_qual = [m for m in all_qual if getattr(m, "scope", "turn") == "conversation"]
 
     params = EvaluationParams(
         output_dir=settings.output_dir,
         num_workers=settings.num_workers,
-        custom_metrics=custom_metrics,
-        custom_qualitative_metrics=custom_qualitative_metrics,
+        custom_metrics=turn_quant,
+        custom_qualitative_metrics=turn_qual,
+        convo_custom_metrics=convo_quant,
+        convo_custom_qualitative_metrics=convo_qual,
         metrics_to_run=settings.metrics_to_run or None,
     )
 
@@ -944,14 +960,12 @@ def run_evaluation(
         html_output_path = os.path.join(settings.output_dir, "final_report.html")
 
         logger.info("Generating HTML report...")
-        all_custom = list(custom_metrics) + list(custom_qualitative_metrics)
+        all_custom = list(all_quant) + list(all_qual)
         metric_descriptions = {
             m.name: m.description for m in all_custom if m.description
         }
-        metric_ranges = {m.name: tuple(m.score_range) for m in custom_metrics}
-        qual_label_colors = {
-            m.name: m.label_colors for m in custom_qualitative_metrics if m.label_colors
-        }
+        metric_ranges = {m.name: tuple(m.score_range) for m in all_quant}
+        qual_label_colors = {m.name: m.label_colors for m in all_qual if m.label_colors}
         report_params = HtmlReportParams(
             simulation=simulation,
             evaluation=evaluator_output,

--- a/arksim/evaluator/evaluator.py
+++ b/arksim/evaluator/evaluator.py
@@ -245,7 +245,10 @@ class Evaluator:
 
         logger.info(f"Preprocessing complete: {total_turns} total turns to evaluate")
 
-        # When auto: enough workers for all turns + goal_completion calls at once.
+        # When auto: enough workers for all turns + per-conversation evaluate_conversation
+        # calls at once. Each evaluate_conversation call may itself spawn an inner pool
+        # for convo-scope custom metrics, but that pool is unbounded in auto mode so
+        # additional workers beyond total_turns + len(conversations) are not needed here.
         # When explicit int: use that value as-is.
         if self.params.num_workers == "auto":
             num_workers = total_turns + len(conversations)
@@ -263,6 +266,28 @@ class Evaluator:
             pbar.update(1)
             if on_progress:
                 on_progress(int(pbar.n), total_turns + len(conversations))
+
+        # Route custom metrics to turn- or conversation-level execution by scope.
+        _turn_quant = [
+            m
+            for m in self.params.custom_metrics
+            if isinstance(m, QuantitativeMetric) and m.scope == "turn"
+        ]
+        _turn_qual = [
+            m
+            for m in self.params.custom_metrics
+            if isinstance(m, QualitativeMetric) and m.scope == "turn"
+        ]
+        _convo_quant = [
+            m
+            for m in self.params.custom_metrics
+            if isinstance(m, QuantitativeMetric) and m.scope == "conversation"
+        ]
+        _convo_qual = [
+            m
+            for m in self.params.custom_metrics
+            if isinstance(m, QualitativeMetric) and m.scope == "conversation"
+        ]
 
         # Phase 1: evaluate all turns in parallel across all conversations
         all_turn_tasks = [
@@ -285,8 +310,8 @@ class Evaluator:
                         evaluate_turn,
                         self.llm,
                         turn_item,
-                        self.params.custom_metrics or None,
-                        self.params.custom_qualitative_metrics or None,
+                        _turn_quant or None,
+                        _turn_qual or None,
                         self.params.metrics_to_run,
                         inner_workers,
                     ): turn_item
@@ -317,13 +342,13 @@ class Evaluator:
                 conversations, processed_entries, turn_results
             )
 
-        # Phase 2: goal_completion for each conversation (parallel)
+        # Phase 2: conversation-level evaluation (parallel)
         convo_score_list: list[ConversationEvaluation] = []
 
-        gc_max_workers = max(1, min(num_workers, len(processed_entries)))
-        gc_inner_workers = 0 if self.params.num_workers == "auto" else num_workers
-        with ThreadPoolExecutor(max_workers=gc_max_workers) as executor:
-            gc_futures = {
+        convo_max_workers = max(1, min(num_workers, len(processed_entries)))
+        convo_inner_workers = 0 if self.params.num_workers == "auto" else num_workers
+        with ThreadPoolExecutor(max_workers=convo_max_workers) as executor:
+            convo_futures = {
                 executor.submit(
                     evaluate_conversation,
                     self.llm,
@@ -332,21 +357,21 @@ class Evaluator:
                         turn_results.get(convo_item.chat_id, []),
                         key=lambda t: t.turn_id,
                     ),
-                    self.params.convo_custom_metrics or None,
-                    self.params.convo_custom_qualitative_metrics or None,
+                    _convo_quant or None,
+                    _convo_qual or None,
                     self.params.metrics_to_run,
-                    gc_inner_workers,
+                    convo_inner_workers,
                 ): convo_item
                 for _, convo_item in processed_entries
             }
-            for future in as_completed(gc_futures):
-                convo_item = gc_futures[future]
+            for future in as_completed(convo_futures):
+                convo_item = convo_futures[future]
                 try:
                     convo_eval = future.result()
                     convo_score_list.append(convo_eval)
                 except Exception as e:
                     logger.error(
-                        f"Error computing goal completion for {convo_item.chat_id}: {e}"
+                        f"Error evaluating conversation {convo_item.chat_id}: {e}"
                     )
                 pbar.update(1)
 
@@ -701,21 +726,21 @@ class Evaluator:
             logger.info(f"\n{'=' * 60}")
             return
 
-        # Compute aggregates on-the-fly from Evaluation
-        metric_scores: dict[str, list[float]] = defaultdict(list)
+        # Compute aggregates on-the-fly from Evaluation.
+        # Key by (name, scope) so a turn-scope and convo-scope metric that
+        # share a name are never pooled into the same bucket.
+        metric_scores: dict[tuple[str, str], list[float]] = defaultdict(list)
         failure_counts: Counter = Counter()
         for conv in results.conversations:
             for turn in conv.turn_scores:
                 for score in turn.scores:
-                    metric_scores[score.name].append(score.value)
+                    metric_scores[(score.name, "turn")].append(score.value)
                 failure_counts[turn.turn_behavior_failure] += 1
-            for score in conv.scores:
-                metric_scores[score.name].append(score.value)
+            for score in conv.convo_scores:
+                metric_scores[(score.name, "convo")].append(score.value)
 
-        averages: dict[str, float] = {
-            metric: sum(vals) / len(vals)
-            for metric, vals in metric_scores.items()
-            if vals
+        averages: dict[tuple[str, str], float] = {
+            key: sum(vals) / len(vals) for key, vals in metric_scores.items() if vals
         }
 
         if results.conversations:
@@ -731,9 +756,9 @@ class Evaluator:
             "faithfulness",
         ]
         valid_scores = [
-            averages[m]
+            averages[(m, "turn")]
             for m in builtin_metrics
-            if m in averages and averages[m] != SCORE_NOT_COMPUTED
+            if (m, "turn") in averages and averages[(m, "turn")] != SCORE_NOT_COMPUTED
         ]
 
         if valid_scores:
@@ -744,17 +769,26 @@ class Evaluator:
                 "performance and 5 indicates excellent performance.\n"
             )
             for metric in builtin_metrics:
-                if metric in averages and averages[metric] != SCORE_NOT_COMPUTED:
+                key = (metric, "turn")
+                if key in averages and averages[key] != SCORE_NOT_COMPUTED:
                     logger.info(
                         f"• {metric.title()}: "
-                        f"{self._format_metric_score(averages[metric])}"
+                        f"{self._format_metric_score(averages[key])}"
                     )
 
-            # Custom metrics
-            for name, score in averages.items():
-                if name not in builtin_metrics and score != SCORE_NOT_COMPUTED:
+            # Custom metrics -- label with scope when the same name appears in
+            # both turn and convo scope to avoid ambiguity.
+            builtin_set = set(builtin_metrics)
+            turn_names = {name for name, scope in averages if scope == "turn"}
+            convo_names = {name for name, scope in averages if scope == "convo"}
+            shared_names = turn_names & convo_names
+            for (name, scope), score in averages.items():
+                if name not in builtin_set and score != SCORE_NOT_COMPUTED:
+                    label = name.replace("_", " ").title()
+                    if name in shared_names:
+                        label = f"{label} ({scope})"
                     logger.info(
-                        f"• {name.replace('_', ' ').title()}: "
+                        f"• {label}: "
                         f"{self._format_metric_score(score, use_label=False)}"
                     )
 
@@ -924,21 +958,10 @@ def run_evaluation(
         settings.custom_metrics_file_paths, llm=llm
     )
 
-    # Split custom metrics by scope (turn vs. conversation).
-    turn_quant = [m for m in all_quant if getattr(m, "scope", "turn") == "turn"]
-    convo_quant = [
-        m for m in all_quant if getattr(m, "scope", "turn") == "conversation"
-    ]
-    turn_qual = [m for m in all_qual if getattr(m, "scope", "turn") == "turn"]
-    convo_qual = [m for m in all_qual if getattr(m, "scope", "turn") == "conversation"]
-
     params = EvaluationParams(
         output_dir=settings.output_dir,
         num_workers=settings.num_workers,
-        custom_metrics=turn_quant,
-        custom_qualitative_metrics=turn_qual,
-        convo_custom_metrics=convo_quant,
-        convo_custom_qualitative_metrics=convo_qual,
+        custom_metrics=list(all_quant) + list(all_qual),
         metrics_to_run=settings.metrics_to_run or None,
     )
 

--- a/arksim/evaluator/evaluator.py
+++ b/arksim/evaluator/evaluator.py
@@ -268,26 +268,14 @@ class Evaluator:
                 on_progress(int(pbar.n), total_turns + len(conversations))
 
         # Route custom metrics to turn- or conversation-level execution by scope.
-        _turn_quant = [
-            m
-            for m in self.params.custom_metrics
-            if isinstance(m, QuantitativeMetric) and m.scope == "turn"
-        ]
-        _turn_qual = [
-            m
-            for m in self.params.custom_metrics
-            if isinstance(m, QualitativeMetric) and m.scope == "turn"
-        ]
-        _convo_quant = [
-            m
-            for m in self.params.custom_metrics
-            if isinstance(m, QuantitativeMetric) and m.scope == "conversation"
-        ]
-        _convo_qual = [
-            m
-            for m in self.params.custom_metrics
-            if isinstance(m, QualitativeMetric) and m.scope == "conversation"
-        ]
+        _buckets: dict[tuple[str, str], list] = defaultdict(list)
+        for _m in self.params.custom_metrics:
+            _kind = "quant" if isinstance(_m, QuantitativeMetric) else "qual"
+            _buckets[(_m.scope, _kind)].append(_m)
+        _turn_quant = _buckets[("turn", "quant")]
+        _turn_qual = _buckets[("turn", "qual")]
+        _convo_quant = _buckets[("conversation", "quant")]
+        _convo_qual = _buckets[("conversation", "qual")]
 
         # Phase 1: evaluate all turns in parallel across all conversations
         all_turn_tasks = [

--- a/arksim/evaluator/thresholds.py
+++ b/arksim/evaluator/thresholds.py
@@ -54,9 +54,13 @@ def check_numeric_thresholds(
                 raw = convo.goal_completion_score
                 score: float | None = raw if raw >= 0 else None
             else:
-                # Conversation-level custom metrics live on conv.scores.
+                # Conversation-level custom metrics live on conv.convo_scores.
                 convo_match = next(
-                    (r for r in convo.scores if r.name == metric_name and r.value >= 0),
+                    (
+                        r
+                        for r in convo.convo_scores
+                        if r.name == metric_name and r.value >= 0
+                    ),
                     None,
                 )
                 if convo_match is not None:
@@ -132,7 +136,7 @@ def check_qualitative_failure_labels(
             failures: list[dict[str, object]] = []
 
             # Check conversation-level qual scores.
-            for qs in convo.qual_scores:
+            for qs in convo.convo_qual_scores:
                 if qs.name == metric_name and qs.value in failure_labels:
                     failures.append({"turn_id": "conversation", "label": qs.value})
 

--- a/arksim/evaluator/thresholds.py
+++ b/arksim/evaluator/thresholds.py
@@ -54,13 +54,22 @@ def check_numeric_thresholds(
                 raw = convo.goal_completion_score
                 score: float | None = raw if raw >= 0 else None
             else:
-                values = [
-                    r.value
-                    for turn in convo.turn_scores
-                    for r in turn.scores
-                    if r.name == metric_name and r.value >= 0
-                ]
-                score = sum(values) / len(values) if values else None
+                # Conversation-level custom metrics live on conv.scores.
+                convo_match = next(
+                    (r for r in convo.scores if r.name == metric_name and r.value >= 0),
+                    None,
+                )
+                if convo_match is not None:
+                    score = convo_match.value
+                else:
+                    # Turn-level metrics: average across turns.
+                    values = [
+                        r.value
+                        for turn in convo.turn_scores
+                        for r in turn.scores
+                        if r.name == metric_name and r.value >= 0
+                    ]
+                    score = sum(values) / len(values) if values else None
 
             if score is None:
                 logger.warning(
@@ -120,7 +129,14 @@ def check_qualitative_failure_labels(
     for metric_name, failure_labels in qualitative_failure_labels.items():
         failed_conversations = []
         for convo in evaluator_output.conversations:
-            failing_turns = []
+            failures: list[dict[str, object]] = []
+
+            # Check conversation-level qual scores.
+            for qs in convo.qual_scores:
+                if qs.name == metric_name and qs.value in failure_labels:
+                    failures.append({"turn_id": "conversation", "label": qs.value})
+
+            # Check turn-level qual scores.
             for turn in convo.turn_scores:
                 if metric_name == "agent_behavior_failure":
                     label = turn.turn_behavior_failure
@@ -135,13 +151,13 @@ def check_qualitative_failure_labels(
                     label = match.value
 
                 if label in failure_labels:
-                    failing_turns.append({"turn_id": turn.turn_id, "label": label})
+                    failures.append({"turn_id": turn.turn_id, "label": label})
 
-            if failing_turns:
+            if failures:
                 failed_conversations.append(
                     {
                         "conversation_id": convo.conversation_id,
-                        "failing_turns": failing_turns,
+                        "failing_turns": failures,
                     }
                 )
 
@@ -159,7 +175,7 @@ def check_qualitative_failure_labels(
                     )
         else:
             logger.info(
-                f"Qualitative gate passed: '{metric_name}' — no failure labels found"
+                f"Qualitative gate passed: '{metric_name}' - no failure labels found"
             )
 
     return all_passed

--- a/arksim/utils/html_report/generate_html_report.py
+++ b/arksim/utils/html_report/generate_html_report.py
@@ -104,6 +104,8 @@ class ConvoRow(BaseModel):
     status: str
     knowledge: list[str] = Field(default_factory=list)
     goal_completion_reason: str
+    scores: list[dict[str, Any]] = Field(default_factory=list)
+    qual_scores: list[dict[str, Any]] = Field(default_factory=list)
 
 
 class TurnRow(BaseModel):
@@ -188,12 +190,18 @@ def _build_final_report_data(
     failure_counts: Counter = Counter()
     qual_label_counts: dict[str, Counter] = defaultdict(Counter)
     for conv in evaluation.conversations:
+        # Turn-level metrics
         for turn in conv.turn_scores:
             for score in turn.scores:
                 metric_scores[score.name].append(score.value)
             for qs in turn.qual_scores:
                 qual_label_counts[qs.name][qs.value] += 1
             failure_counts[turn.turn_behavior_failure] += 1
+        # Conversation-level custom metrics
+        for score in conv.scores:
+            metric_scores[score.name].append(score.value)
+        for qs in conv.qual_scores:
+            qual_label_counts[qs.name][qs.value] += 1
 
     def safe_avg(values: list[float]) -> float:
         valid = [v for v in values if v != -1]
@@ -351,6 +359,8 @@ def _build_convo_rows(
                 if scenario and scenario.knowledge
                 else [],
                 goal_completion_reason=conv.goal_completion_reason,
+                scores=[s.model_dump() for s in conv.scores],
+                qual_scores=[q.model_dump() for q in conv.qual_scores],
             )
         )
     return rows

--- a/arksim/utils/html_report/generate_html_report.py
+++ b/arksim/utils/html_report/generate_html_report.py
@@ -198,9 +198,9 @@ def _build_final_report_data(
                 qual_label_counts[qs.name][qs.value] += 1
             failure_counts[turn.turn_behavior_failure] += 1
         # Conversation-level custom metrics
-        for score in conv.scores:
+        for score in conv.convo_scores:
             metric_scores[score.name].append(score.value)
-        for qs in conv.qual_scores:
+        for qs in conv.convo_qual_scores:
             qual_label_counts[qs.name][qs.value] += 1
 
     def safe_avg(values: list[float]) -> float:
@@ -359,8 +359,8 @@ def _build_convo_rows(
                 if scenario and scenario.knowledge
                 else [],
                 goal_completion_reason=conv.goal_completion_reason,
-                scores=[s.model_dump() for s in conv.scores],
-                qual_scores=[q.model_dump() for q in conv.qual_scores],
+                scores=[s.model_dump() for s in conv.convo_scores],
+                qual_scores=[q.model_dump() for q in conv.convo_qual_scores],
             )
         )
     return rows

--- a/arksim/utils/html_report/report_template.html
+++ b/arksim/utils/html_report/report_template.html
@@ -483,6 +483,16 @@
             color: #1e3a8a;
             box-shadow: 0 1px 3px rgba(37, 99, 235, 0.3);
         }
+        .qual-turn-chip--convo {
+            background-color: #eff6ff;
+            color: #1d4ed8;
+            border-color: #bfdbfe;
+        }
+        .qual-turn-chip--convo:hover {
+            background-color: #dbeafe;
+            color: #1e3a8a;
+            box-shadow: 0 1px 3px rgba(37, 99, 235, 0.3);
+        }
         .qual-turn-details .qual-turn-empty {
             color: #94a3b8;
             font-style: italic;
@@ -758,6 +768,73 @@
             background: #f8fafc;
             border-radius: 6px;
             border-left: 3px solid #667eea;
+        }
+
+        /* Conversation-level scores list in modal */
+        .conv-scores-list {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+        .conv-score-item {
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            border-radius: 6px;
+            overflow: hidden;
+        }
+        .conv-score-item[open] {
+            border-color: #667eea;
+        }
+        .conv-score-summary {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 10px 14px;
+            cursor: pointer;
+            list-style: none;
+            user-select: none;
+            gap: 12px;
+        }
+        .conv-score-summary::-webkit-details-marker { display: none; }
+        .conv-score-summary::after {
+            content: 'expand_more';
+            font-family: 'Material Icons';
+            font-size: 18px;
+            color: #94a3b8;
+            flex-shrink: 0;
+            transition: transform 0.15s ease;
+        }
+        .conv-score-item[open] .conv-score-summary::after {
+            transform: rotate(180deg);
+        }
+        .conv-score-name {
+            font-size: 14px;
+            font-weight: 500;
+            color: #1e293b;
+            flex: 1;
+            text-transform: capitalize;
+        }
+        .conv-score-value {
+            font-size: 14px;
+            font-weight: 600;
+            color: #667eea;
+            flex-shrink: 0;
+        }
+        .conv-qual-badge {
+            font-size: 12px;
+            font-weight: 600;
+            flex-shrink: 0;
+        }
+        .conv-qual-badge.positive { color: #16a34a; }
+        .conv-qual-badge.neutral  { color: #d97706; }
+        .conv-qual-badge.negative { color: #dc2626; }
+        .conv-score-reason {
+            padding: 10px 14px;
+            font-size: 13px;
+            color: #475569;
+            border-top: 1px solid #e2e8f0;
+            background: #fff;
+            line-height: 1.6;
         }
 
         .conversation-section {
@@ -1995,16 +2072,54 @@
 
                     <div class="info-section">
                         <div class="info-label">Scores</div>
-                        <div class="info-value">
-                            <strong>Goal Completion Score:</strong> ${parseFloat(convosRow.goal_completion_score).toFixed(2)} |
-                            <strong>Final Score:</strong> ${parseFloat(convosRow.final_score).toFixed(2)} |
-                            <strong>Status:</strong> <span class="status-badge ${modalStatusClass}">${cleanedModalStatus}</span>
+                        <div class="conv-scores-list">
+                            <details class="conv-score-item">
+                                <summary class="conv-score-summary">
+                                    <span class="conv-score-name">Goal Completion</span>
+                                    <span class="conv-score-value">${parseFloat(convosRow.goal_completion_score).toFixed(2)}</span>
+                                </summary>
+                                <div class="conv-score-reason">${escapeHtml(convosRow.goal_completion_reason || 'N/A')}</div>
+                            </details>
+                            <details class="conv-score-item">
+                                <summary class="conv-score-summary">
+                                    <span class="conv-score-name">Final Score</span>
+                                    <span class="conv-score-value">${parseFloat(convosRow.final_score).toFixed(2)}</span>
+                                </summary>
+                                <div class="conv-score-reason">Weighted average of Turn Success Ratio (40%) and Goal Completion Score (60%).</div>
+                            </details>
+                            <details class="conv-score-item">
+                                <summary class="conv-score-summary">
+                                    <span class="conv-score-name">Status</span>
+                                    <span class="status-badge ${modalStatusClass}">${cleanedModalStatus}</span>
+                                </summary>
+                                <div class="conv-score-reason">Done if final score = 1.0; Partial Failure if ≥ 0.6; Failed if &lt; 0.6.</div>
+                            </details>
+                            ${(convosRow.scores || []).map(s => `
+                            <details class="conv-score-item">
+                                <summary class="conv-score-summary">
+                                    <span class="conv-score-name">${escapeHtml(s.name.replace(/_/g, ' '))}</span>
+                                    <span class="conv-score-value">${parseFloat(s.value).toFixed(2)}</span>
+                                </summary>
+                                <div class="conv-score-reason">${escapeHtml(s.reason || 'No reason provided.')}</div>
+                            </details>`).join('')}
+                            ${(convosRow.qual_scores || []).map(q => {
+                                const POSITIVE_LABELS = ['compliant', 'professional', 'pass', 'good', 'complete', 'no failure', 'ok'];
+                                const NEGATIVE_LABELS = ['flagged', 'unprofessional', 'fail', 'error', 'poor', 'missing', 'violated', 'partial'];
+                                const sentiment = POSITIVE_LABELS.includes(q.value.toLowerCase()) ? 'positive'
+                                               : NEGATIVE_LABELS.includes(q.value.toLowerCase()) ? 'negative'
+                                               : 'neutral';
+                                const customColor = (QUAL_LABEL_COLORS[q.name] || {})[q.value];
+                                const styleAttr = customColor ? ` style="color:${customColor};"` : '';
+                                return `
+                            <details class="conv-score-item">
+                                <summary class="conv-score-summary">
+                                    <span class="conv-score-name">${escapeHtml(q.name.replace(/_/g, ' '))}</span>
+                                    <span class="conv-qual-badge ${sentiment}"${styleAttr}>${escapeHtml(q.value)}</span>
+                                </summary>
+                                <div class="conv-score-reason">${escapeHtml(q.reason || 'No reason provided.')}</div>
+                            </details>`;
+                            }).join('')}
                         </div>
-                    </div>
-
-                    <div class="info-section">
-                        <div class="info-label">Goal Completion Reason</div>
-                        <div class="info-value">${convosRow.goal_completion_reason || 'N/A'}</div>
                     </div>
 
                     <details class="info-section" style="margin-bottom:24px">
@@ -2438,24 +2553,48 @@
                         );
                     });
 
-                    if (matchingTurns.length === 0) {
-                        details.innerHTML = '<div class="qual-turn-empty">No matching turns found</div>';
+                    // Find matching conversations (conversation-level metrics)
+                    const matchingConvos = convosData.filter(c =>
+                        (c.qual_scores || []).some(
+                            q => q.name === metricName && q.value === label
+                        )
+                    );
+
+                    if (matchingTurns.length === 0 && matchingConvos.length === 0) {
+                        details.innerHTML = '<div class="qual-turn-empty">No matching results found</div>';
                     } else {
-                        // Group turns by conversation
-                        const grouped = {};
-                        matchingTurns.forEach(t => {
-                            if (!grouped[t.chat_id]) grouped[t.chat_id] = [];
-                            grouped[t.chat_id].push(t.turn_id);
-                        });
-                        details.innerHTML = Object.entries(grouped).map(([chatId, turnIds]) =>
-                            `<div class="qual-turn-group">` +
-                            `<div class="qual-turn-conv-label">${escapeHtml(chatLabel(chatId))}</div>` +
-                            `<div class="qual-turn-chips">` +
-                            turnIds.map(tid =>
-                                `<button class="qual-turn-chip" data-chat-id="${escapeHtml(chatId)}" data-turn-id="${tid}" onclick="openModal(this.getAttribute('data-chat-id'), parseInt(this.getAttribute('data-turn-id')))">Turn ${tid}</button>`
-                            ).join('') +
-                            `</div></div>`
-                        ).join('');
+                        let html = '';
+
+                        // Conversation-level matches — all chips on one row
+                        if (matchingConvos.length > 0) {
+                            html +=
+                                `<div class="qual-turn-group">` +
+                                `<div class="qual-turn-chips">` +
+                                matchingConvos.map(c =>
+                                    `<button class="qual-turn-chip qual-turn-chip--convo" onclick="openModal('${escapeHtml(c.chat_id)}')">${escapeHtml(chatLabel(c.chat_id))}</button>`
+                                ).join('') +
+                                `</div></div>`;
+                        }
+
+                        // Turn-level matches (grouped by conversation)
+                        if (matchingTurns.length > 0) {
+                            const grouped = {};
+                            matchingTurns.forEach(t => {
+                                if (!grouped[t.chat_id]) grouped[t.chat_id] = [];
+                                grouped[t.chat_id].push(t.turn_id);
+                            });
+                            html += Object.entries(grouped).map(([chatId, turnIds]) =>
+                                `<div class="qual-turn-group">` +
+                                `<div class="qual-turn-conv-label">${escapeHtml(chatLabel(chatId))}</div>` +
+                                `<div class="qual-turn-chips">` +
+                                turnIds.map(tid =>
+                                    `<button class="qual-turn-chip" data-chat-id="${escapeHtml(chatId)}" data-turn-id="${tid}" onclick="openModal(this.getAttribute('data-chat-id'), parseInt(this.getAttribute('data-turn-id')))">Turn ${tid}</button>`
+                                ).join('') +
+                                `</div></div>`
+                            ).join('');
+                        }
+
+                        details.innerHTML = html;
                     }
 
                     row.addEventListener('click', () => {

--- a/docs/main/evaluate-conversation.mdx
+++ b/docs/main/evaluate-conversation.mdx
@@ -122,6 +122,17 @@ In addition to the built-in metrics (helpfulness, coherence, relevance, verbosit
   Names of built-in metrics to run. If empty, all built-in metrics run. Use this to restrict evaluation to a subset of built-ins while still running all custom metrics from `custom_metrics_file_paths`.
 </ParamField>
 
+### Scope
+
+Every custom metric has a **scope** that controls when it runs:
+
+| Scope | Runs | Receives |
+| --- | --- | --- |
+| `"turn"` (default) | Once per agent response | The current turn + conversation history up to that point |
+| `"conversation"` | Once per full conversation | The complete conversation history |
+
+Use `"turn"` for response-quality checks (clarity, tone, compliance statements). Use `"conversation"` for end-to-end assessments that only make sense after the whole conversation (goal completion, needs assessment, product suitability).
+
 ### Metric Types
 
 <Tabs>
@@ -141,15 +152,26 @@ In addition to the built-in metrics (helpfulness, coherence, relevance, verbosit
         ScoreInput,
     )
 
+    # Turn-level: scored on every agent response
     class ClarityScore(QuantitativeMetric):
         def __init__(self, llm=None):
-            super().__init__(name="clarity", score_range=(0, 5), llm=llm)
+            super().__init__(name="clarity", score_range=(0, 5), llm=llm, scope="turn")
 
         def score(self, score_input: ScoreInput) -> QuantResult:
             # self.llm is the evaluator's configured LLM, injected automatically.
-            # score_input.chat_history, .user_goal, .knowledge, etc.
+            # score_input.chat_history, .current_turn, .user_goal, .knowledge, etc.
             value = ...  # your scoring logic using self.llm or any other logic
             return QuantResult(name="clarity", value=value, reason="...")
+
+    # Conversation-level: scored once after the full conversation
+    class ProductSuitabilityScore(QuantitativeMetric):
+        def __init__(self, llm=None):
+            super().__init__(name="product_suitability", score_range=(0, 5), llm=llm, scope="conversation")
+
+        def score(self, score_input: ScoreInput) -> QuantResult:
+            # score_input.chat_history contains the full conversation.
+            value = ...
+            return QuantResult(name="product_suitability", value=value, reason="...")
     ```
   </Tab>
   <Tab title="Qualitative">
@@ -168,13 +190,24 @@ In addition to the built-in metrics (helpfulness, coherence, relevance, verbosit
         ScoreInput,
     )
 
-    class NeedsAssessment(QualitativeMetric):
+    # Turn-level: checked on every agent response
+    class ProhibitedStatements(QualitativeMetric):
         def __init__(self, llm=None):
-            super().__init__(name="needs_assessment", llm=llm)
+            super().__init__(name="prohibited_statements", llm=llm, scope="turn")
 
         def evaluate(self, score_input: ScoreInput) -> QualResult:
             # self.llm is the evaluator's configured LLM, injected automatically.
-            # score_input.chat_history, .user_goal, .knowledge, etc.
+            # score_input.chat_history, .current_turn, .user_goal, .knowledge, etc.
+            label = ...  # "ok" | "violated"
+            return QualResult(name="prohibited_statements", value=label, reason="...")
+
+    # Conversation-level: checked once after the full conversation
+    class NeedsAssessment(QualitativeMetric):
+        def __init__(self, llm=None):
+            super().__init__(name="needs_assessment", llm=llm, scope="conversation")
+
+        def evaluate(self, score_input: ScoreInput) -> QualResult:
+            # score_input.chat_history contains the full conversation.
             label = ...  # "complete" | "partial" | "missing"
             return QualResult(name="needs_assessment", value=label, reason="...")
     ```
@@ -206,7 +239,8 @@ Per-metric minimum scores on each metric's native scale. The mean score across a
 | `overall_score` | 0–1 | Per-conversation `overall_agent_score` compared directly |
 | `faithfulness`, `helpfulness`, `coherence`, `verbosity`, `relevance` | 1–5 | Mean of per-turn scores |
 | `goal_completion` | 0–1 | Per-conversation score compared directly |
-| Custom quantitative metrics | Your scale | Mean of per-turn scores |
+| Custom quantitative metrics (`scope="turn"`) | Your scale | Mean of per-turn scores |
+| Custom quantitative metrics (`scope="conversation"`) | Your scale | Per-conversation score compared directly |
 
 ```yaml
 numeric_thresholds:

--- a/examples/bank-insurance/config.yaml
+++ b/examples/bank-insurance/config.yaml
@@ -72,6 +72,7 @@ numeric_thresholds:
   overall_score: 0.6
   goal_completion: 0.6
   clarity: 3.5 # custom metric
+  product_suitability: 4.0
 
 # Qualitative failure labels: fail the run if any evaluated turn returns one of these labels
 # Works with built-in and custom qualitative metrics

--- a/examples/bank-insurance/custom_metrics.py
+++ b/examples/bank-insurance/custom_metrics.py
@@ -11,16 +11,27 @@ via the ``llm`` keyword argument.
 To create a quantitative metric (numeric score):
   1. Subclass ``QuantitativeMetric``.
   2. Add ``llm=None`` to ``__init__`` and pass it to ``super().__init__(llm=llm)``.
-  3. Implement ``score()`` — receives a ``ScoreInput``, returns a
+  3. Implement ``score()`` -- receives a ``ScoreInput``, returns a
      ``QuantResult`` with ``name``, ``value`` (float), and ``reason``.
      Use ``self.llm`` to call the LLM.
 
 To create a qualitative metric (categorical label):
   1. Subclass ``QualitativeMetric``.
   2. Add ``llm=None`` to ``__init__`` and pass it to ``super().__init__(llm=llm)``.
-  3. Implement ``evaluate()`` — receives a ``ScoreInput``, returns a
+  3. Implement ``evaluate()`` -- receives a ``ScoreInput``, returns a
      ``QualResult`` with ``name``, ``value`` (str label), and ``reason``.
      Use ``self.llm`` to call the LLM.
+
+Scope:
+  Each metric can declare ``scope="turn"`` (default) or
+  ``scope="conversation"`` in ``super().__init__()``.
+
+  - ``"turn"`` metrics run once per turn inside ``evaluate_turn``.
+    They receive ``current_turn`` (the user+assistant pair) and the
+    full ``chat_history`` up to that turn.
+  - ``"conversation"`` metrics run once per conversation inside
+    ``evaluate_conversation``, alongside goal completion. They receive
+    the complete ``chat_history`` for the entire conversation.
 
   4. Add the file path to ``custom_metrics_file_paths`` in config.yaml
      and (optionally) add the metric name to ``metrics_to_run``.
@@ -99,6 +110,7 @@ class ProductSuitabilityMetric(QuantitativeMetric):
                 " customer's stated needs and risk profile (0=poor match, 5=excellent match)."
             ),
             llm=llm,
+            scope="conversation",
         )
 
     def score(self, score_input: ScoreInput) -> QuantResult:
@@ -186,6 +198,7 @@ class NeedsAssessmentMetric(QuantitativeMetric):
                 " 5=comprehensive needs discovery)."
             ),
             llm=llm,
+            scope="conversation",
         )
 
     def score(self, score_input: ScoreInput) -> QuantResult:
@@ -266,6 +279,7 @@ class ClarityMetric(QuantitativeMetric):
                 " 5=plain language with comprehension check)."
             ),
             llm=llm,
+            scope="turn",
         )
 
     def score(self, score_input: ScoreInput) -> QuantResult:
@@ -353,11 +367,12 @@ class DisclosureCompletenessMetric(QualitativeMetric):
                 " missing=critical disclosures absent."
             ),
             label_colors={
-                "complete": "#22c55e",  # green  — all disclosures present
-                "partial": "#f59e0b",  # amber  — some omitted
-                "missing": "#ef4444",  # red    — critical disclosures absent
+                "complete": "#22c55e",  # green  - all disclosures present
+                "partial": "#f59e0b",  # amber  - some omitted
+                "missing": "#ef4444",  # red    - critical disclosures absent
             },
             llm=llm,
+            scope="conversation",
         )
 
     def evaluate(self, score_input: ScoreInput) -> QualResult:
@@ -431,10 +446,11 @@ class ProhibitedStatementsMetric(QualitativeMetric):
                 " violated=prohibited claim detected."
             ),
             label_colors={
-                "clean": "#22c55e",  # green — no violations
-                "violated": "#ef4444",  # red   — prohibited claim detected
+                "clean": "#22c55e",  # green - no violations
+                "violated": "#ef4444",  # red   - prohibited claim detected
             },
             llm=llm,
+            scope="turn",
         )
 
     def evaluate(self, score_input: ScoreInput) -> QualResult:
@@ -510,10 +526,11 @@ class AdviceBoundaryMetric(QualitativeMetric):
                 " overstepped=gave regulated advice without authorisation."
             ),
             label_colors={
-                "within_scope": "#22c55e",  # green — stayed within scope
-                "overstepped": "#ef4444",  # red   — gave unauthorised advice
+                "within_scope": "#22c55e",  # green - stayed within scope
+                "overstepped": "#ef4444",  # red   - gave unauthorised advice
             },
             llm=llm,
+            scope="turn",
         )
 
     def evaluate(self, score_input: ScoreInput) -> QualResult:
@@ -582,11 +599,12 @@ class EscalationBehaviorMetric(QualitativeMetric):
                 " under_served=failed to escalate when needed."
             ),
             label_colors={
-                "appropriate": "#22c55e",  # green  — handled correctly
-                "over_extended": "#f97316",  # orange — exceeded competence
-                "under_served": "#ef4444",  # red    — failed to escalate
+                "appropriate": "#22c55e",  # green  - handled correctly
+                "over_extended": "#f97316",  # orange - exceeded competence
+                "under_served": "#ef4444",  # red    - failed to escalate
             },
             llm=llm,
+            scope="conversation",
         )
 
     def evaluate(self, score_input: ScoreInput) -> QualResult:

--- a/examples/bank-insurance/run_pipeline.py
+++ b/examples/bank-insurance/run_pipeline.py
@@ -96,8 +96,6 @@ async def main() -> None:
             ProductSuitabilityMetric(),
             NeedsAssessmentMetric(),
             ClarityMetric(),
-        ],
-        custom_qualitative_metrics=[
             DisclosureCompletenessMetric(),
             ProhibitedStatementsMetric(),
             AdviceBoundaryMetric(),

--- a/examples/ci/pytest/test_agent_quality.py
+++ b/examples/ci/pytest/test_agent_quality.py
@@ -132,10 +132,8 @@ async def test_agent_quality() -> None:
         output_dir=evaluation_output_dir,
         num_workers=10,
         # custom_metrics=[
-        #     MyNumericMetric(),  # TODO: replace with your numeric metric instances
-        # ],
-        # custom_qualitative_metrics=[
-        #     MyQualitativeMetric(),  # TODO: replace with your qualitative metric instances
+        #     MyNumericMetric(),     # TODO: replace with QuantitativeMetric instances
+        #     MyQualitativeMetric(), # TODO: replace with QualitativeMetric instances
         # ],
     )
 

--- a/examples/customer-service/custom_metrics.py
+++ b/examples/customer-service/custom_metrics.py
@@ -11,12 +11,15 @@ argument.
 To create your own metric:
   1. Subclass ``QuantitativeMetric`` or ``QualitativeMetric``.
   2. Add ``llm=None`` to ``__init__`` and pass it to ``super().__init__(llm=llm)``.
-  3. Implement ``score()`` (quantitative) or ``evaluate()`` (qualitative).
+  3. Set ``scope="turn"`` (run once per agent response) or
+     ``scope="conversation"`` (run once after the full conversation ends).
+     Defaults to ``"turn"`` if omitted.
+  4. Implement ``score()`` (quantitative) or ``evaluate()`` (qualitative).
      Both receive a ``ScoreInput`` with ``chat_history``, ``knowledge``,
      ``user_goal``, and ``profile``. Use ``self.llm`` to call the LLM.
-  4. Return a ``QuantResult`` or ``QualResult`` with ``name``, ``value``,
+  5. Return a ``QuantResult`` or ``QualResult`` with ``name``, ``value``,
      and ``reason``.
-  5. Add the file path to ``custom_metrics_file_paths`` in config.yaml
+  6. Add the file path to ``custom_metrics_file_paths`` in config.yaml
      and (optionally) add the metric name to ``metrics_to_run``.
 """
 
@@ -96,6 +99,7 @@ class VerificationComplianceMetric(QuantitativeMetric):
                 " before sensitive actions (0=no verification, 5=full compliance)."
             ),
             llm=llm,
+            scope="conversation",
         )
 
     def score(self, score_input: ScoreInput) -> QuantResult:
@@ -175,6 +179,7 @@ class ToolUsageEfficiencyMetric(QuantitativeMetric):
                 " 5=optimal tool usage)."
             ),
             llm=llm,
+            scope="conversation",
         )
 
     def score(self, score_input: ScoreInput) -> QuantResult:
@@ -259,6 +264,7 @@ class UnauthorizedActionMetric(QualitativeMetric):
                 "violated": "#ef4444",  # red - unauthorized action detected
             },
             llm=llm,
+            scope="conversation",
         )
 
     def evaluate(self, score_input: ScoreInput) -> QualResult:
@@ -333,6 +339,7 @@ class DataPrivacyMetric(QualitativeMetric):
                 "over_collected": "#f97316",  # orange - unnecessary data requested
             },
             llm=llm,
+            scope="conversation",
         )
 
     def evaluate(self, score_input: ScoreInput) -> QualResult:

--- a/examples/customer-service/run_pipeline.py
+++ b/examples/customer-service/run_pipeline.py
@@ -94,8 +94,6 @@ async def main() -> None:
         custom_metrics=[
             VerificationComplianceMetric(),
             ToolUsageEfficiencyMetric(),
-        ],
-        custom_qualitative_metrics=[
             UnauthorizedActionMetric(),
             DataPrivacyMetric(),
         ],

--- a/examples/e-commerce/custom_metrics.py
+++ b/examples/e-commerce/custom_metrics.py
@@ -11,12 +11,15 @@ argument.
 To create your own metric:
   1. Subclass ``QuantitativeMetric`` or ``QualitativeMetric``.
   2. Add ``llm=None`` to ``__init__`` and pass it to ``super().__init__(llm=llm)``.
-  3. Implement ``score()`` (quantitative) or ``evaluate()`` (qualitative).
+  3. Set ``scope="turn"`` (run once per agent response) or
+     ``scope="conversation"`` (run once after the full conversation ends).
+     Defaults to ``"turn"`` if omitted.
+  4. Implement ``score()`` (quantitative) or ``evaluate()`` (qualitative).
      Both receive a ``ScoreInput`` with ``chat_history``, ``knowledge``,
      ``user_goal``, and ``profile``. Use ``self.llm`` to call the LLM.
-  4. Return a ``QuantResult`` or ``QualResult`` with ``name``, ``value``,
+  5. Return a ``QuantResult`` or ``QualResult`` with ``name``, ``value``,
      and ``reason``.
-  5. Add the file path to ``custom_metrics_file_paths`` in config.yaml
+  6. Add the file path to ``custom_metrics_file_paths`` in config.yaml
      and (optionally) add the metric name to ``metrics_to_run``.
 """
 
@@ -97,6 +100,7 @@ class ConversionMetric(QuantitativeMetric):
             description="Scores purchase intent strength and conversion outcome. "
             "Final score = (intent_strength + conversion_outcome) / 2, scaled to 0-5.",
             llm=llm,
+            scope="conversation",
         )
 
     def score(self, score_input: ScoreInput) -> QuantResult:
@@ -180,6 +184,7 @@ class ProductRecommendationMetric(QuantitativeMetric):
             description="Evaluates relevance and specificity of product recommendations. "
             "Final score = (relevance + specificity) / 2, scaled to 0-5.",
             llm=llm,
+            scope="conversation",
         )
 
     def score(self, score_input: ScoreInput) -> QuantResult:
@@ -260,6 +265,7 @@ class UpsellBehaviorMetric(QualitativeMetric):
                 "not_applicable": "#94a3b8",  # slate — no upsell context
             },
             llm=llm,
+            scope="conversation",
         )
 
     def evaluate(self, score_input: ScoreInput) -> QualResult:

--- a/examples/e-commerce/run_pipeline.py
+++ b/examples/e-commerce/run_pipeline.py
@@ -91,8 +91,6 @@ async def main() -> None:
         custom_metrics=[
             ConversionMetric(),
             ProductRecommendationMetric(),
-        ],
-        custom_qualitative_metrics=[
             UpsellBehaviorMetric(),
         ],
     )

--- a/tests/unit/test_evaluate.py
+++ b/tests/unit/test_evaluate.py
@@ -230,28 +230,6 @@ class TestEvaluateConversation:
         )
         assert captured["extra"]["threshold"] == 0.8
 
-    def test_custom_qual_receives_additional_input(self) -> None:
-        """additional_input on a qual metric is forwarded into ScoreInput."""
-        captured: dict = {}
-
-        class CapturingQual(QualitativeMetric):
-            def __init__(self) -> None:
-                super().__init__(name="capturing_qual")
-                self.additional_input = {"labels": ["a", "b"]}
-
-            def evaluate(self, score_input: ScoreInput) -> QualResult:
-                captured["extra"] = score_input.model_extra
-                return QualResult(name=self.name, value="a", reason="ok")
-
-        llm = _mock_llm(score=4)
-        evaluate_conversation(
-            llm,
-            _convo_item(turns=1),
-            [_turn_eval(0)],
-            custom_convo_qualitative_metrics=[CapturingQual()],
-        )
-        assert captured["extra"]["labels"] == ["a", "b"]
-
     def test_custom_metrics_receive_conversation_context(self) -> None:
         """Custom metrics receive chat_history, knowledge, user_goal, profile."""
         captured: dict = {}

--- a/tests/unit/test_evaluate.py
+++ b/tests/unit/test_evaluate.py
@@ -230,6 +230,30 @@ class TestEvaluateConversation:
         )
         assert captured["extra"]["threshold"] == 0.8
 
+    def test_custom_qual_receives_additional_input(self) -> None:
+        """additional_input on a qual metric is forwarded into ScoreInput."""
+        captured: dict = {}
+
+        class CapturingQual(QualitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(
+                    name="capturing_qual",
+                    additional_input={"threshold": 0.8},
+                )
+
+            def evaluate(self, score_input: ScoreInput) -> QualResult:
+                captured["extra"] = score_input.model_extra
+                return QualResult(name=self.name, value="pass", reason="ok")
+
+        llm = _mock_llm(score=4)
+        evaluate_conversation(
+            llm,
+            _convo_item(turns=1),
+            [_turn_eval(0)],
+            custom_convo_qualitative_metrics=[CapturingQual()],
+        )
+        assert captured["extra"]["threshold"] == 0.8
+
     def test_custom_metrics_receive_conversation_context(self) -> None:
         """Custom metrics receive chat_history, knowledge, user_goal, profile."""
         captured: dict = {}

--- a/tests/unit/test_evaluate.py
+++ b/tests/unit/test_evaluate.py
@@ -150,11 +150,11 @@ class TestEvaluateConversation:
             llm,
             _convo_item(turns=1),
             turns,
-            custom_metrics=[StubQuant()],
+            custom_convo_metrics=[StubQuant()],
         )
-        assert len(result.scores) == 1
-        assert result.scores[0].name == "stub_quant"
-        assert result.scores[0].value == 7.0
+        assert len(result.convo_scores) == 1
+        assert result.convo_scores[0].name == "stub_quant"
+        assert result.convo_scores[0].value == 7.0
 
     def test_custom_qual_metrics_run(self) -> None:
         """Custom qualitative metrics are executed and returned in qual_scores."""
@@ -172,11 +172,11 @@ class TestEvaluateConversation:
             llm,
             _convo_item(turns=1),
             turns,
-            custom_qualitative_metrics=[StubQual()],
+            custom_convo_qualitative_metrics=[StubQual()],
         )
-        assert len(result.qual_scores) == 1
-        assert result.qual_scores[0].name == "stub_qual"
-        assert result.qual_scores[0].value == "pass"
+        assert len(result.convo_qual_scores) == 1
+        assert result.convo_qual_scores[0].name == "stub_qual"
+        assert result.convo_qual_scores[0].value == "pass"
 
     def test_custom_metric_failure_logged_not_raised(self) -> None:
         """A failing custom metric is skipped, not propagated."""
@@ -194,17 +194,17 @@ class TestEvaluateConversation:
             llm,
             _convo_item(turns=1),
             turns,
-            custom_metrics=[BrokenMetric()],
+            custom_convo_metrics=[BrokenMetric()],
         )
-        assert result.scores == []
+        assert result.convo_scores == []
 
     def test_no_custom_metrics_returns_empty(self) -> None:
-        """Without custom metrics, scores and qual_scores are empty."""
+        """Without custom metrics, convo_scores and convo_qual_scores are empty."""
         llm = _mock_llm(score=4)
         turns = [_turn_eval(0)]
         result = evaluate_conversation(llm, _convo_item(turns=1), turns)
-        assert result.scores == []
-        assert result.qual_scores == []
+        assert result.convo_scores == []
+        assert result.convo_qual_scores == []
 
     def test_custom_quant_receives_additional_input(self) -> None:
         """additional_input on a quant metric is forwarded into ScoreInput."""
@@ -226,7 +226,7 @@ class TestEvaluateConversation:
             llm,
             _convo_item(turns=1),
             [_turn_eval(0)],
-            custom_metrics=[CapturingMetric()],
+            custom_convo_metrics=[CapturingMetric()],
         )
         assert captured["extra"]["threshold"] == 0.8
 
@@ -248,7 +248,7 @@ class TestEvaluateConversation:
             llm,
             _convo_item(turns=1),
             [_turn_eval(0)],
-            custom_qualitative_metrics=[CapturingQual()],
+            custom_convo_qualitative_metrics=[CapturingQual()],
         )
         assert captured["extra"]["labels"] == ["a", "b"]
 
@@ -286,7 +286,7 @@ class TestEvaluateConversation:
             llm,
             convo,
             [_turn_eval(0), _turn_eval(1)],
-            custom_metrics=[InspectingMetric()],
+            custom_convo_metrics=[InspectingMetric()],
         )
         assert captured["user_goal"] == "solve the issue"
         assert captured["profile"] == "admin"
@@ -322,13 +322,13 @@ class TestEvaluateConversation:
             llm,
             _convo_item(turns=1),
             [_turn_eval(0)],
-            custom_metrics=[Quant1(), Quant2()],
-            custom_qualitative_metrics=[Qual1()],
+            custom_convo_metrics=[Quant1(), Quant2()],
+            custom_convo_qualitative_metrics=[Qual1()],
         )
-        quant_names = {s.name for s in result.scores}
+        quant_names = {s.name for s in result.convo_scores}
         assert quant_names == {"q1", "q2"}
-        assert len(result.qual_scores) == 1
-        assert result.qual_scores[0].name == "ql1"
+        assert len(result.convo_qual_scores) == 1
+        assert result.convo_qual_scores[0].name == "ql1"
 
     def test_broken_qual_metric_skipped(self) -> None:
         """A failing qualitative metric is skipped, not propagated."""
@@ -345,6 +345,6 @@ class TestEvaluateConversation:
             llm,
             _convo_item(turns=1),
             [_turn_eval(0)],
-            custom_qualitative_metrics=[BrokenQual()],
+            custom_convo_qualitative_metrics=[BrokenQual()],
         )
-        assert result.qual_scores == []
+        assert result.convo_qual_scores == []

--- a/tests/unit/test_evaluate.py
+++ b/tests/unit/test_evaluate.py
@@ -1,16 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for arksim.evaluator.evaluate (_should_run, evaluate_goal_completion)."""
+"""Tests for arksim.evaluator.evaluate (_should_run, evaluate_conversation)."""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from arksim.evaluator.base_metric import ChatMessage, QuantResult
+from arksim.evaluator.base_metric import (
+    ChatMessage,
+    QualitativeMetric,
+    QualResult,
+    QuantitativeMetric,
+    QuantResult,
+    ScoreInput,
+)
 from arksim.evaluator.entities import (
     ConvoItem,
     TurnEvaluation,
 )
-from arksim.evaluator.evaluate import _should_run, evaluate_goal_completion
+from arksim.evaluator.evaluate import _should_run, evaluate_conversation
 from arksim.evaluator.utils.constants import (
     EVALUATION_PARTIAL_FAILURE_THRESHOLD,
     GOAL_COMPLETION_SCORE_WEIGHT,
@@ -68,11 +75,11 @@ def _turn_eval(
     )
 
 
-class TestEvaluateGoalCompletion:
+class TestEvaluateConversation:
     def test_goal_completion_runs(self) -> None:
         llm = _mock_llm(score=5, reason="perfect")
         turns = [_turn_eval(0), _turn_eval(1)]
-        result = evaluate_goal_completion(llm, _convo_item(turns=2), turns)
+        result = evaluate_conversation(llm, _convo_item(turns=2), turns)
         assert result.goal_completion_score == 5
         assert result.goal_completion_reason == "perfect"
         assert result.conversation_id == "conv-1"
@@ -80,7 +87,7 @@ class TestEvaluateGoalCompletion:
     def test_goal_completion_skipped(self) -> None:
         llm = _mock_llm()
         turns = [_turn_eval(0)]
-        result = evaluate_goal_completion(
+        result = evaluate_conversation(
             llm, _convo_item(turns=1), turns, metrics_to_run=["helpfulness"]
         )
         assert result.goal_completion_score == -1
@@ -92,14 +99,14 @@ class TestEvaluateGoalCompletion:
             _turn_eval(0),
             _turn_eval(1, failure="repetition"),
         ]
-        result = evaluate_goal_completion(llm, _convo_item(turns=2), turns)
+        result = evaluate_conversation(llm, _convo_item(turns=2), turns)
         assert result.turn_success_ratio == 0.5
 
     def test_status_done(self) -> None:
         llm = _mock_llm(score=4)
         convo = _convo_item(turns=1)
         turn = _turn_eval(0)
-        result = evaluate_goal_completion(llm, convo, [turn])
+        result = evaluate_conversation(llm, convo, [turn])
         expected_score = (
             1.0 * TURN_SUCCESS_RATIO_SCORE_WEIGHT + 4 * GOAL_COMPLETION_SCORE_WEIGHT
         )
@@ -115,7 +122,7 @@ class TestEvaluateGoalCompletion:
             _turn_eval(0, failure="false information"),
             _turn_eval(1, failure="repetition"),
         ]
-        result = evaluate_goal_completion(llm, _convo_item(turns=2), turns)
+        result = evaluate_conversation(llm, _convo_item(turns=2), turns)
         expected = (
             0.0 * TURN_SUCCESS_RATIO_SCORE_WEIGHT + 1 * GOAL_COMPLETION_SCORE_WEIGHT
         )
@@ -124,5 +131,220 @@ class TestEvaluateGoalCompletion:
 
     def test_no_turns(self) -> None:
         llm = _mock_llm(score=3)
-        result = evaluate_goal_completion(llm, _convo_item(turns=0), [])
+        result = evaluate_conversation(llm, _convo_item(turns=0), [])
         assert result.turn_success_ratio == 1.0
+
+    def test_custom_quant_metrics_run(self) -> None:
+        """Custom quantitative metrics are executed and returned in scores."""
+
+        class StubQuant(QuantitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(name="stub_quant", score_range=(0, 10))
+
+            def score(self, score_input: ScoreInput) -> QuantResult:
+                return QuantResult(name=self.name, value=7.0, reason="good")
+
+        llm = _mock_llm(score=4)
+        turns = [_turn_eval(0)]
+        result = evaluate_conversation(
+            llm,
+            _convo_item(turns=1),
+            turns,
+            custom_metrics=[StubQuant()],
+        )
+        assert len(result.scores) == 1
+        assert result.scores[0].name == "stub_quant"
+        assert result.scores[0].value == 7.0
+
+    def test_custom_qual_metrics_run(self) -> None:
+        """Custom qualitative metrics are executed and returned in qual_scores."""
+
+        class StubQual(QualitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(name="stub_qual")
+
+            def evaluate(self, score_input: ScoreInput) -> QualResult:
+                return QualResult(name=self.name, value="pass", reason="ok")
+
+        llm = _mock_llm(score=4)
+        turns = [_turn_eval(0)]
+        result = evaluate_conversation(
+            llm,
+            _convo_item(turns=1),
+            turns,
+            custom_qualitative_metrics=[StubQual()],
+        )
+        assert len(result.qual_scores) == 1
+        assert result.qual_scores[0].name == "stub_qual"
+        assert result.qual_scores[0].value == "pass"
+
+    def test_custom_metric_failure_logged_not_raised(self) -> None:
+        """A failing custom metric is skipped, not propagated."""
+
+        class BrokenMetric(QuantitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(name="broken")
+
+            def score(self, score_input: ScoreInput) -> QuantResult:
+                raise RuntimeError("boom")
+
+        llm = _mock_llm(score=4)
+        turns = [_turn_eval(0)]
+        result = evaluate_conversation(
+            llm,
+            _convo_item(turns=1),
+            turns,
+            custom_metrics=[BrokenMetric()],
+        )
+        assert result.scores == []
+
+    def test_no_custom_metrics_returns_empty(self) -> None:
+        """Without custom metrics, scores and qual_scores are empty."""
+        llm = _mock_llm(score=4)
+        turns = [_turn_eval(0)]
+        result = evaluate_conversation(llm, _convo_item(turns=1), turns)
+        assert result.scores == []
+        assert result.qual_scores == []
+
+    def test_custom_quant_receives_additional_input(self) -> None:
+        """additional_input on a quant metric is forwarded into ScoreInput."""
+        captured: dict = {}
+
+        class CapturingMetric(QuantitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(
+                    name="capturing",
+                    additional_input={"threshold": 0.8},
+                )
+
+            def score(self, score_input: ScoreInput) -> QuantResult:
+                captured["extra"] = score_input.model_extra
+                return QuantResult(name=self.name, value=3.0, reason="ok")
+
+        llm = _mock_llm(score=4)
+        evaluate_conversation(
+            llm,
+            _convo_item(turns=1),
+            [_turn_eval(0)],
+            custom_metrics=[CapturingMetric()],
+        )
+        assert captured["extra"]["threshold"] == 0.8
+
+    def test_custom_qual_receives_additional_input(self) -> None:
+        """additional_input on a qual metric is forwarded into ScoreInput."""
+        captured: dict = {}
+
+        class CapturingQual(QualitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(name="capturing_qual")
+                self.additional_input = {"labels": ["a", "b"]}
+
+            def evaluate(self, score_input: ScoreInput) -> QualResult:
+                captured["extra"] = score_input.model_extra
+                return QualResult(name=self.name, value="a", reason="ok")
+
+        llm = _mock_llm(score=4)
+        evaluate_conversation(
+            llm,
+            _convo_item(turns=1),
+            [_turn_eval(0)],
+            custom_qualitative_metrics=[CapturingQual()],
+        )
+        assert captured["extra"]["labels"] == ["a", "b"]
+
+    def test_custom_metrics_receive_conversation_context(self) -> None:
+        """Custom metrics receive chat_history, knowledge, user_goal, profile."""
+        captured: dict = {}
+
+        class InspectingMetric(QuantitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(name="inspector")
+
+            def score(self, score_input: ScoreInput) -> QuantResult:
+                captured["user_goal"] = score_input.user_goal
+                captured["profile"] = score_input.profile
+                captured["knowledge"] = score_input.knowledge
+                captured["history_len"] = len(score_input.chat_history)
+                return QuantResult(name=self.name, value=5.0, reason="ok")
+
+        convo = ConvoItem(
+            chat_id="c1",
+            chat_history=[
+                ChatMessage(role="user", content="q1"),
+                ChatMessage(role="assistant", content="a1"),
+                ChatMessage(role="user", content="q2"),
+                ChatMessage(role="assistant", content="a2"),
+            ],
+            system_prompt="sys",
+            knowledge=["doc1", "doc2"],
+            profile="admin",
+            user_goal="solve the issue",
+            turns=2,
+        )
+        llm = _mock_llm(score=4)
+        evaluate_conversation(
+            llm,
+            convo,
+            [_turn_eval(0), _turn_eval(1)],
+            custom_metrics=[InspectingMetric()],
+        )
+        assert captured["user_goal"] == "solve the issue"
+        assert captured["profile"] == "admin"
+        assert captured["history_len"] == 4
+        assert "doc1" in captured["knowledge"]
+
+    def test_multiple_quant_and_qual_metrics_together(self) -> None:
+        """Both quant and qual custom metrics run and populate their fields."""
+
+        class Quant1(QuantitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(name="q1")
+
+            def score(self, score_input: ScoreInput) -> QuantResult:
+                return QuantResult(name=self.name, value=3.0, reason="r1")
+
+        class Quant2(QuantitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(name="q2")
+
+            def score(self, score_input: ScoreInput) -> QuantResult:
+                return QuantResult(name=self.name, value=4.0, reason="r2")
+
+        class Qual1(QualitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(name="ql1")
+
+            def evaluate(self, score_input: ScoreInput) -> QualResult:
+                return QualResult(name=self.name, value="pass", reason="ok")
+
+        llm = _mock_llm(score=4)
+        result = evaluate_conversation(
+            llm,
+            _convo_item(turns=1),
+            [_turn_eval(0)],
+            custom_metrics=[Quant1(), Quant2()],
+            custom_qualitative_metrics=[Qual1()],
+        )
+        quant_names = {s.name for s in result.scores}
+        assert quant_names == {"q1", "q2"}
+        assert len(result.qual_scores) == 1
+        assert result.qual_scores[0].name == "ql1"
+
+    def test_broken_qual_metric_skipped(self) -> None:
+        """A failing qualitative metric is skipped, not propagated."""
+
+        class BrokenQual(QualitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(name="broken_qual")
+
+            def evaluate(self, score_input: ScoreInput) -> QualResult:
+                raise RuntimeError("qual boom")
+
+        llm = _mock_llm(score=4)
+        result = evaluate_conversation(
+            llm,
+            _convo_item(turns=1),
+            [_turn_eval(0)],
+            custom_qualitative_metrics=[BrokenQual()],
+        )
+        assert result.qual_scores == []

--- a/tests/unit/test_evaluator_class.py
+++ b/tests/unit/test_evaluator_class.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import os
 import textwrap
+import warnings
 
 import pytest
 
+from arksim.evaluator.base_metric import QualitativeMetric, QualResult, ScoreInput
 from arksim.evaluator.entities import (
     ConversationEvaluation,
     EvaluationParams,
@@ -179,6 +181,58 @@ class TestDisplayHelpers:
     def test_display_failure_breakdown_skips_special(self) -> None:
         ev = _make_evaluator()
         ev._display_failure_breakdown({"skipped_good_performance": 5})
+
+
+# ---------------------------------------------------------------------------
+# _load_custom_metrics
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# EvaluationParams._merge_legacy_qualitative_metrics (deprecation shim)
+# ---------------------------------------------------------------------------
+class _DummyQual(QualitativeMetric):
+    def __init__(self, name: str = "dummy_qual") -> None:
+        super().__init__(name=name)
+
+    def evaluate(self, score_input: ScoreInput) -> QualResult:
+        return QualResult(name=self.name, value="ok")
+
+
+class TestMergeLegacyQualitativeMetrics:
+    def test_deprecation_warning_fires(self) -> None:
+        metric = _DummyQual()
+        with pytest.warns(DeprecationWarning, match="custom_qualitative_metrics"):
+            EvaluationParams(
+                output_dir="/tmp",
+                custom_qualitative_metrics=[metric],
+            )
+
+    def test_legacy_list_merged_into_custom_metrics(self) -> None:
+        metric = _DummyQual()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            params = EvaluationParams(
+                output_dir="/tmp",
+                custom_qualitative_metrics=[metric],
+            )
+        assert metric in params.custom_metrics
+
+    def test_legacy_merged_with_existing_custom_metrics(self) -> None:
+        legacy = _DummyQual("legacy")
+        existing = _DummyQual("existing")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            params = EvaluationParams(
+                output_dir="/tmp",
+                custom_metrics=[existing],
+                custom_qualitative_metrics=[legacy],
+            )
+        assert existing in params.custom_metrics
+        assert legacy in params.custom_metrics
+
+    def test_no_warning_without_legacy_kwarg(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            EvaluationParams(output_dir="/tmp")  # must not raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_evaluator_class.py
+++ b/tests/unit/test_evaluator_class.py
@@ -414,8 +414,8 @@ class TestLoadCustomMetricsScope:
             f.write(code)
 
         quant, _ = _load_custom_metrics([path])
-        if quant:
-            assert quant[0].scope == "turn"
+        assert len(quant) == 1
+        assert quant[0].scope == "turn"
 
     def test_conversation_scope_preserved(self, temp_dir: str) -> None:
         """Metrics with scope='conversation' retain it after loading."""
@@ -434,8 +434,8 @@ class TestLoadCustomMetricsScope:
             f.write(code)
 
         quant, _ = _load_custom_metrics([path])
-        if quant:
-            assert quant[0].scope == "conversation"
+        assert len(quant) == 1
+        assert quant[0].scope == "conversation"
 
     def test_mixed_scopes_loaded(self, temp_dir: str) -> None:
         """File with both turn and conversation metrics loads both."""
@@ -474,17 +474,17 @@ class TestLoadCustomMetricsScope:
             f.write(code)
 
         quant, qual = _load_custom_metrics([path])
-        if quant:
-            turn_q = [m for m in quant if m.scope == "turn"]
-            convo_q = [m for m in quant if m.scope == "conversation"]
-            assert len(turn_q) == 1
-            assert turn_q[0].name == "turn_q"
-            assert len(convo_q) == 1
-            assert convo_q[0].name == "convo_q"
-        if qual:
-            turn_ql = [m for m in qual if m.scope == "turn"]
-            convo_ql = [m for m in qual if m.scope == "conversation"]
-            assert len(turn_ql) == 1
-            assert turn_ql[0].name == "turn_ql"
-            assert len(convo_ql) == 1
-            assert convo_ql[0].name == "convo_ql"
+        assert len(quant) == 2
+        assert len(qual) == 2
+        turn_q = [m for m in quant if m.scope == "turn"]
+        convo_q = [m for m in quant if m.scope == "conversation"]
+        assert len(turn_q) == 1
+        assert turn_q[0].name == "turn_q"
+        assert len(convo_q) == 1
+        assert convo_q[0].name == "convo_q"
+        turn_ql = [m for m in qual if m.scope == "turn"]
+        convo_ql = [m for m in qual if m.scope == "conversation"]
+        assert len(turn_ql) == 1
+        assert turn_ql[0].name == "turn_ql"
+        assert len(convo_ql) == 1
+        assert convo_ql[0].name == "convo_ql"

--- a/tests/unit/test_evaluator_class.py
+++ b/tests/unit/test_evaluator_class.py
@@ -392,3 +392,99 @@ class TestLoadCustomMetricsLLMInjection:
         quant, _ = _load_custom_metrics([path])
         assert len(quant) == 1
         assert quant[0].name == "ConcreteMetric"
+
+
+class TestLoadCustomMetricsScope:
+    """_load_custom_metrics preserves the scope attribute set by custom metrics."""
+
+    def test_default_scope_is_turn(self, temp_dir: str) -> None:
+        """Metrics without an explicit scope default to 'turn'."""
+        code = textwrap.dedent("""\
+            from arksim.evaluator.base_metric import QuantitativeMetric, ScoreInput, QuantResult
+
+            class DefaultScope(QuantitativeMetric):
+                def __init__(self):
+                    super().__init__(name="default_scope")
+
+                def score(self, score_input: ScoreInput) -> QuantResult:
+                    return QuantResult(name=self.name, value=1.0)
+        """)
+        path = os.path.join(temp_dir, "default_scope.py")
+        with open(path, "w") as f:
+            f.write(code)
+
+        quant, _ = _load_custom_metrics([path])
+        if quant:
+            assert quant[0].scope == "turn"
+
+    def test_conversation_scope_preserved(self, temp_dir: str) -> None:
+        """Metrics with scope='conversation' retain it after loading."""
+        code = textwrap.dedent("""\
+            from arksim.evaluator.base_metric import QuantitativeMetric, ScoreInput, QuantResult
+
+            class ConvoMetric(QuantitativeMetric):
+                def __init__(self):
+                    super().__init__(name="convo_metric", scope="conversation")
+
+                def score(self, score_input: ScoreInput) -> QuantResult:
+                    return QuantResult(name=self.name, value=1.0)
+        """)
+        path = os.path.join(temp_dir, "convo_scope.py")
+        with open(path, "w") as f:
+            f.write(code)
+
+        quant, _ = _load_custom_metrics([path])
+        if quant:
+            assert quant[0].scope == "conversation"
+
+    def test_mixed_scopes_loaded(self, temp_dir: str) -> None:
+        """File with both turn and conversation metrics loads both."""
+        code = textwrap.dedent("""\
+            from arksim.evaluator.base_metric import (
+                QuantitativeMetric, QualitativeMetric,
+                ScoreInput, QuantResult, QualResult,
+            )
+
+            class TurnQuant(QuantitativeMetric):
+                def __init__(self):
+                    super().__init__(name="turn_q", scope="turn")
+                def score(self, score_input: ScoreInput) -> QuantResult:
+                    return QuantResult(name=self.name, value=1.0)
+
+            class ConvoQuant(QuantitativeMetric):
+                def __init__(self):
+                    super().__init__(name="convo_q", scope="conversation")
+                def score(self, score_input: ScoreInput) -> QuantResult:
+                    return QuantResult(name=self.name, value=2.0)
+
+            class TurnQual(QualitativeMetric):
+                def __init__(self):
+                    super().__init__(name="turn_ql", scope="turn")
+                def evaluate(self, score_input: ScoreInput) -> QualResult:
+                    return QualResult(name=self.name, value="ok")
+
+            class ConvoQual(QualitativeMetric):
+                def __init__(self):
+                    super().__init__(name="convo_ql", scope="conversation")
+                def evaluate(self, score_input: ScoreInput) -> QualResult:
+                    return QualResult(name=self.name, value="ok")
+        """)
+        path = os.path.join(temp_dir, "mixed_scope.py")
+        with open(path, "w") as f:
+            f.write(code)
+
+        quant, qual = _load_custom_metrics([path])
+        if quant:
+            turn_q = [m for m in quant if m.scope == "turn"]
+            convo_q = [m for m in quant if m.scope == "conversation"]
+            assert len(turn_q) == 1
+            assert turn_q[0].name == "turn_q"
+            assert len(convo_q) == 1
+            assert convo_q[0].name == "convo_q"
+        if qual:
+            turn_ql = [m for m in qual if m.scope == "turn"]
+            convo_ql = [m for m in qual if m.scope == "conversation"]
+            assert len(turn_ql) == 1
+            assert turn_ql[0].name == "turn_ql"
+            assert len(convo_ql) == 1
+            assert convo_ql[0].name == "convo_ql"


### PR DESCRIPTION
## Summary

- Adds a `scope` parameter (`"turn"` | `"conversation"`) to `QuantitativeMetric` and `QualitativeMetric` so custom metrics can declare whether they run per agent response or once per full conversation. Default is `"turn"` for backward compatibility.
- Renames `evaluate_goal_completion` → `evaluate_conversation` and extends it to run conversation-level custom metrics alongside goal completion scoring.
- Routes loaded custom metrics by scope in `run_evaluation`, passing turn-level metrics to `evaluate_turn` and conversation-level metrics to `evaluate_conversation`.
- Adds `scope` field to `QuantResult` / `QualResult` so thresholds and the HTML report can identify metric origin without re-querying.
- Updates `check_numeric_thresholds` to use the per-conversation score directly for conversation-scope metrics (instead of averaging turn scores).
- Updates `check_qualitative_failure_labels` to also check `convo.qual_scores`.
- Redesigns the HTML report transcript modal scores section as an expandable list with inline reasons; qual drill-down surfaces conversation-level matches as clickable conversation chips.
- Updates docs (`evaluate-conversation.mdx`) with scope semantics and examples.
- Updates the bank-insurance example to annotate all 7 custom metrics with explicit `scope=`.

## Test plan

- [x] `pytest tests/unit/` passes (new tests cover `evaluate_conversation` custom metric execution, `additional_input` forwarding, and scope-based metric loading)
- [x] `arksim simulate-evaluate examples/bank-insurance/config.yaml` runs end-to-end without errors
- [x] HTML report shows conversation-level metrics in the transcript modal and qual drill-down
- [x] Numeric and qualitative threshold gates apply correctly for both turn- and conversation-scope metrics
- [x] Existing turn-level custom metrics continue to work unchanged (backward compat)

## Updated report screenshots
conversation modal shows all conversation level metric scores
<img width="1432" height="753" alt="Screenshot 2026-04-23 at 4 19 18 PM" src="https://github.com/user-attachments/assets/59750ba3-8571-4a00-be0a-f8906b6dbd33" />

expand (conversation-level) metric to see the linked conversations
<img width="1390" height="663" alt="Screenshot 2026-04-23 at 4 19 42 PM" src="https://github.com/user-attachments/assets/4926d796-4b89-416c-b6b3-113f574da3a3" />
