### PR TITLE
fix: skip api_config re-wrapping if already correct type

### DIFF
--- a/arksim/config/core/agent.py
+++ b/arksim/config/core/agent.py
@@ -144,12 +144,14 @@ class AgentConfig(BaseModel):
                 config_data = data.get("api_config")
                 if not config_data:
                     raise ValueError("chat_completions agent requires 'api_config'")
-                data["api_config"] = ChatCompletionsConfig(**config_data)
+                if not isinstance(config_data, ChatCompletionsConfig):
+                    data["api_config"] = ChatCompletionsConfig(**config_data)
             elif agent_type == AgentType.A2A.value:
                 config_data = data.get("api_config")
                 if not config_data:
                     raise ValueError("a2a agent requires 'api_config'")
-                data["api_config"] = A2AConfig(**config_data)
+                if not isinstance(config_data, A2AConfig):
+                    data["api_config"] = A2AConfig(**config_data)
             else:
                 raise ValueError(f"Unsupported agent type: {agent_type}")
         else:


### PR DESCRIPTION
## Summary
- Guard against double-wrapping `api_config` in `AgentConfig`'s model validator
- Checks `isinstance` before constructing `ChatCompletionsConfig` or `A2AConfig`, preventing errors when the config is already the correct type

## Test plan
- [x] Verify that passing an already-instantiated `ChatCompletionsConfig` or `A2AConfig` as `api_config` no longer raises an error
- [x] Verify that passing a raw dict still correctly constructs the config object

🤖 Generated with [Claude Code](https://claude.com/claude-code)