### PR TITLE
fix(evaluator): align builtin metric prompt template with format args

### DIFF
--- a/arksim/evaluator/base_metric.py
+++ b/arksim/evaluator/base_metric.py
@@ -42,6 +42,7 @@ class QualResult(BaseModel):
     name: str
     value: str
     reason: str | None = None
+    metadata: dict[str, Any] | None = None
     scope: MetricScope = "turn"
 
 

--- a/arksim/evaluator/builtin_metrics.py
+++ b/arksim/evaluator/builtin_metrics.py
@@ -33,6 +33,10 @@ from .utils.prompts import (
 from .utils.schema import QualSchema, ScoreSchema
 
 
+# TODO: we can define a shared metric class that inherits from quant and qual
+# metric that has the _llm, _system_prompt, and _user_prompt_template in the
+# class, a score method that calls the llm and formats the user prompt with all
+# the score_input fields instead of hardcoding the format string.
 class HelpfulnessMetric(QuantitativeMetric):
     def __init__(self, llm: LLM) -> None:
         super().__init__(name="helpfulness")
@@ -45,7 +49,7 @@ class HelpfulnessMetric(QuantitativeMetric):
                 {
                     "role": "user",
                     "content": helpfulness_user_prompt.format(
-                        full_conversation=format_chat_history(score_input.chat_history),
+                        chat_history=format_chat_history(score_input.chat_history),
                     ),
                 },
             ],
@@ -66,7 +70,7 @@ class CoherenceMetric(QuantitativeMetric):
                 {
                     "role": "user",
                     "content": coherence_user_prompt.format(
-                        full_conversation=format_chat_history(score_input.chat_history),
+                        chat_history=format_chat_history(score_input.chat_history),
                     ),
                 },
             ],
@@ -87,7 +91,7 @@ class VerbosityMetric(QuantitativeMetric):
                 {
                     "role": "user",
                     "content": verbosity_user_prompt.format(
-                        full_conversation=format_chat_history(score_input.chat_history),
+                        chat_history=format_chat_history(score_input.chat_history),
                     ),
                 },
             ],
@@ -111,7 +115,7 @@ class RelevanceMetric(QuantitativeMetric):
                 {
                     "role": "user",
                     "content": relevance_user_prompt.format(
-                        full_conversation=format_chat_history(score_input.chat_history),
+                        chat_history=format_chat_history(score_input.chat_history),
                     ),
                 },
             ],
@@ -133,7 +137,7 @@ class FaithfulnessMetric(QuantitativeMetric):
                     "role": "user",
                     "content": faithfulness_user_prompt.format(
                         knowledge=score_input.knowledge,
-                        full_conversation=format_chat_history(score_input.chat_history),
+                        chat_history=format_chat_history(score_input.chat_history),
                     ),
                 },
             ],
@@ -154,8 +158,8 @@ class GoalCompletionMetric(QuantitativeMetric):
                 {
                     "role": "user",
                     "content": goal_completion_user_prompt.format(
-                        full_conversation=format_chat_history(score_input.chat_history),
-                        goal=score_input.user_goal,
+                        chat_history=format_chat_history(score_input.chat_history),
+                        user_goal=score_input.user_goal,
                     ),
                 },
             ],
@@ -199,7 +203,7 @@ class AgentBehaviorFailureMetric(QualitativeMetric):
                     "role": "user",
                     "content": agent_behavior_failure_user_prompt.format(
                         user_goal=score_input.user_goal,
-                        conversation=format_chat_history(score_input.chat_history),
+                        chat_history=format_chat_history(score_input.chat_history),
                         knowledge=score_input.knowledge,
                     ),
                 },

--- a/arksim/evaluator/evaluate.py
+++ b/arksim/evaluator/evaluate.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 
 def _should_run(name: str, metrics_to_run: list[str] | None) -> bool:
-    return metrics_to_run is None or name in metrics_to_run
+    return not metrics_to_run or name in metrics_to_run
 
 
 def _run_metrics_parallel(

--- a/arksim/evaluator/evaluate.py
+++ b/arksim/evaluator/evaluate.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 
 def _should_run(name: str, metrics_to_run: list[str] | None) -> bool:
-    return not metrics_to_run or name in metrics_to_run
+    return metrics_to_run is None or name in metrics_to_run
 
 
 def _run_metrics_parallel(

--- a/arksim/evaluator/tool_call_metrics.py
+++ b/arksim/evaluator/tool_call_metrics.py
@@ -61,7 +61,7 @@ class ToolCallBehaviorFailureMetric(AgentBehaviorFailureMetric):
                     "role": "user",
                     "content": tool_call_behavior_failure_user_prompt.format(
                         user_goal=score_input.user_goal,
-                        chat_history=format_chat_history(score_input.current_turn),
+                        chat_history=format_chat_history(score_input.chat_history),
                         knowledge=score_input.knowledge,
                         tool_calls=json.dumps(
                             [

--- a/arksim/evaluator/tool_call_metrics.py
+++ b/arksim/evaluator/tool_call_metrics.py
@@ -61,7 +61,7 @@ class ToolCallBehaviorFailureMetric(AgentBehaviorFailureMetric):
                     "role": "user",
                     "content": tool_call_behavior_failure_user_prompt.format(
                         user_goal=score_input.user_goal,
-                        conversation=format_chat_history(score_input.current_turn),
+                        chat_history=format_chat_history(score_input.current_turn),
                         knowledge=score_input.knowledge,
                         tool_calls=json.dumps(
                             [

--- a/arksim/evaluator/utils/prompts.py
+++ b/arksim/evaluator/utils/prompts.py
@@ -24,7 +24,7 @@ Evaluation Criteria:
 
 helpfulness_user_prompt = """
 Here is the conversation between user and AI assistant:
-{full_conversation}
+{chat_history}
 
 Evaluation Form:
 """
@@ -51,7 +51,7 @@ Evaluation Criteria:
 
 coherence_user_prompt = """
 Here is the conversation between user and AI assistant:
-{full_conversation}
+{chat_history}
 
 Evaluation Form:
 """
@@ -78,7 +78,7 @@ Evaluation Criteria:
 
 verbosity_user_prompt = """
 Here is the conversation between user and AI assistant:
-{full_conversation}
+{chat_history}
 
 Evaluation Form:
 """
@@ -105,7 +105,7 @@ Evaluation Criteria:
 
 relevance_user_prompt = """
 Here is the conversation between user and AI assistant:
-{full_conversation}
+{chat_history}
 
 Evaluation Form:
 """
@@ -138,7 +138,7 @@ Here is the knowledge that assistant's response should be grounded:
 {knowledge}
 
 Here is the conversation between user and AI assistant:
-{full_conversation}
+{chat_history}
 
 Evaluation Form:
 """
@@ -156,9 +156,9 @@ Keep the "reason" to 2-3 sentences maximum. Be specific and concise.
 
 goal_completion_user_prompt = """
 Here is the conversation between user and AI assistant:
-{full_conversation}
+{chat_history}
 
-Here is user's goal: {goal}
+Here is user's goal: {user_goal}
 
 Evaluation Form:
 """
@@ -245,10 +245,8 @@ assistant: In Quebec, home insurance is mandatory for mortgage holders. Our Basi
 Output: {"label": "disobey user request", "reason": "The agent incorrectly interpreted 'in French' as a question about Quebec coverage options, instead of the user's actual request for policy documents in the French language. The agent ignored the user's request entirely."}
 
 Lack of specific information
-Definition: When the agent provides only a generic or partial answer, omitting important elements necessary to fully address the user's query. This assumes the agent has the required knowledge and tools. IMPORTANT: This category only applies when knowledge is provided — without knowledge there is no ground truth for what the agent should have included, so do not flag this category if no knowledge is given. This category only applies when the information provided is CORRECT but incomplete. If any information provided contradicts the knowledge base, use "false information" instead.
+Definition: When the agent provides only a generic or partial answer, omitting important elements necessary to fully address the user's query. This assumes the agent has the required knowledge and tools. IMPORTANT: This category only applies when the information provided is CORRECT but incomplete. If any information provided contradicts or is not supported by the knowledge base, use "false information" instead.
 Example:
-
-Knowledge: To file a water damage claim, policyholders must submit: photos of all damage, a repair estimate from a licensed contractor, and receipts for any emergency repairs already completed.
 
 Conversation up to the last assistant turn: [
 assistant: Hi there! How can I help you?
@@ -257,10 +255,10 @@ assistant: I'm sorry to hear about the flooding. You can file a claim by logging
 user: What documents do I need to submit with my claim?
 assistant: You'll need to provide documentation of the damage. Our claims team will guide you through the process. If you have any other questions, feel free to ask!
 ]
-Output: {"label": "lack of specific information", "reason": "The knowledge specifies three required documents — photos of all damage, a contractor repair estimate, and emergency repair receipts — but the assistant gave only a vague reference to 'documentation'. The response is correct but omits all the required specifics."}
+Output: {"label": "lack of specific information", "reason": "The output is missing specific details about required documentation such as photos of damage, repair estimates, and the receipts for emergency repairs that the knowledge base specifies."}
 
 False information
-Definition: When the agent provides information that directly contradicts what is stated in the provided knowledge or context.
+Definition: When the agent provides hallucinated, fabricated, or contextually inaccurate information, including facts, details, or claims that contradict or are not supported by the provided knowledge or context. This includes cases where the agent provides incorrect numerical values or other factual details that differ from what is stated in the knowledge base, even if the response is also incomplete.
 Example 1:
 Knowledge: XYZ Insurance home deductibles range from $500 to $2,500 depending on the policy tier. Basic Form has a $1,000 standard deductible. Broad Form has a $750 standard deductible. Comprehensive Form has a $500 standard deductible.
 
@@ -312,7 +310,7 @@ agent_behavior_failure_user_prompt = """
 
     Conversation up to the last assistant turn:
 
-    {conversation}
+    {chat_history}
 
     agent behavior failure on the last assistant turn:
 """
@@ -424,7 +422,7 @@ tool_call_behavior_failure_user_prompt = """
 
     Conversation up to the last assistant turn:
 
-    {conversation}
+    {chat_history}
 
     Tool calls made by the assistant in the last turn:
     {tool_calls}

--- a/tests/unit/test_builtin_metrics.py
+++ b/tests/unit/test_builtin_metrics.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from arksim.evaluator.base_metric import ChatMessage, ScoreInput
 from arksim.evaluator.builtin_metrics import (
     AgentBehaviorFailureMetric,
@@ -61,6 +63,109 @@ class TestHelpfulnessMetric:
         llm.call.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    ("factory", "method_name", "expected_fragments"),
+    [
+        (
+            HelpfulnessMetric,
+            "score",
+            [
+                "Here is the conversation between user and AI assistant:",
+                "user: Need help\nassistant: Happy to help\n",
+                "Evaluation Form:",
+            ],
+        ),
+        (
+            CoherenceMetric,
+            "score",
+            [
+                "Here is the conversation between user and AI assistant:",
+                "user: Need help\nassistant: Happy to help\n",
+                "Evaluation Form:",
+            ],
+        ),
+        (
+            VerbosityMetric,
+            "score",
+            [
+                "Here is the conversation between user and AI assistant:",
+                "user: Need help\nassistant: Happy to help\n",
+                "Evaluation Form:",
+            ],
+        ),
+        (
+            RelevanceMetric,
+            "score",
+            [
+                "Here is the conversation between user and AI assistant:",
+                "user: Need help\nassistant: Happy to help\n",
+                "Evaluation Form:",
+            ],
+        ),
+        (
+            FaithfulnessMetric,
+            "score",
+            [
+                "policy knowledge",
+                "user: Need help\nassistant: Happy to help\n",
+                "Evaluation Form:",
+            ],
+        ),
+        (
+            GoalCompletionMetric,
+            "score",
+            [
+                "Here is user's goal: resolve billing issue",
+                "user: Need help\nassistant: Happy to help\n",
+                "Evaluation Form:",
+            ],
+        ),
+        (
+            AgentBehaviorFailureMetric,
+            "evaluate",
+            [
+                "resolve billing issue",
+                "policy knowledge",
+                "user: Need help\nassistant: Happy to help\n",
+            ],
+        ),
+    ],
+)
+def test_builtin_metrics_format_generic_score_input_context(
+    factory: type[
+        HelpfulnessMetric
+        | CoherenceMetric
+        | VerbosityMetric
+        | RelevanceMetric
+        | FaithfulnessMetric
+        | GoalCompletionMetric
+        | AgentBehaviorFailureMetric
+    ],
+    method_name: str,
+    expected_fragments: list[str],
+) -> None:
+    llm = _mock_llm() if method_name == "score" else _mock_llm_qual()
+    score_input = _score_input(
+        chat_history=[
+            ChatMessage(role="user", content="Need help"),
+            ChatMessage(role="assistant", content="Happy to help"),
+        ],
+        current_turn=[
+            ChatMessage(role="user", content="Current question"),
+            ChatMessage(role="assistant", content="Current answer"),
+        ],
+        knowledge="policy knowledge",
+        user_goal="resolve billing issue",
+        profile="frustrated premium customer",
+    )
+
+    getattr(factory(llm), method_name)(score_input)
+
+    user_msg = llm.call.call_args.args[0][1]["content"]
+    for fragment in expected_fragments:
+        assert fragment in user_msg
+
+
 class TestCoherenceMetric:
     def test_name(self) -> None:
         assert CoherenceMetric(_mock_llm()).name == "coherence"
@@ -114,6 +219,23 @@ class TestFaithfulnessMetric:
         user_msg = call_args[1]["content"]
         assert "important fact" in user_msg
 
+    def test_score_includes_formatted_chat_history(self) -> None:
+        llm = _mock_llm(score=4)
+        FaithfulnessMetric(llm).score(
+            _score_input(
+                knowledge="policy knowledge",
+                chat_history=[
+                    ChatMessage(role="user", content="What is covered?"),
+                    ChatMessage(role="assistant", content="Water damage is covered."),
+                ],
+            )
+        )
+        user_msg = llm.call.call_args.args[0][1]["content"]
+        assert "policy knowledge" in user_msg
+        assert (
+            "user: What is covered?\nassistant: Water damage is covered.\n" in user_msg
+        )
+
 
 class TestGoalCompletionMetric:
     def test_name(self) -> None:
@@ -126,6 +248,7 @@ class TestGoalCompletionMetric:
         call_args = llm.call.call_args[0][0]
         user_msg = call_args[1]["content"]
         assert "book a flight" in user_msg
+        assert "user: hi\n" in user_msg
 
 
 class TestAgentBehaviorFailureMetric:
@@ -138,3 +261,27 @@ class TestAgentBehaviorFailureMetric:
         result = AgentBehaviorFailureMetric(llm).evaluate(_score_input())
         assert result.value == "repetition"
         assert result.reason == "said same thing"
+
+    def test_evaluate_includes_goal_knowledge_and_chat_history(self) -> None:
+        llm = _mock_llm_qual(label="no failure", reason="fine")
+        AgentBehaviorFailureMetric(llm).evaluate(
+            _score_input(
+                user_goal="update my address",
+                knowledge="Address changes require account verification.",
+                chat_history=[
+                    ChatMessage(role="user", content="Please update my address"),
+                    ChatMessage(
+                        role="assistant",
+                        content="I can help with that after verification.",
+                    ),
+                ],
+            )
+        )
+
+        user_msg = llm.call.call_args.args[0][1]["content"]
+        assert "update my address" in user_msg
+        assert "Address changes require account verification." in user_msg
+        assert (
+            "user: Please update my address\n"
+            "assistant: I can help with that after verification.\n"
+        ) in user_msg

--- a/tests/unit/test_evaluate_turn.py
+++ b/tests/unit/test_evaluate_turn.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from arksim.evaluator.base_metric import ChatMessage
+from arksim.evaluator.base_metric import (
+    ChatMessage,
+    QualitativeMetric,
+    QualResult,
+    QuantitativeMetric,
+    QuantResult,
+    ScoreInput,
+)
 from arksim.evaluator.entities import TurnItem
 from arksim.evaluator.evaluate import evaluate_turn
 from arksim.evaluator.utils.enums import EvaluationOutcomes
@@ -129,3 +136,57 @@ class TestEvaluateTurn:
 
         assert "previous question" in user_prompt
         assert "previous answer" in user_prompt
+
+    def test_custom_qual_metadata_is_preserved(self) -> None:
+        class StubQual(QualitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(name="stub_qual")
+
+            def evaluate(self, score_input: ScoreInput) -> QualResult:
+                return QualResult(
+                    name=self.name,
+                    value="flagged",
+                    reason="captured metadata",
+                    metadata={"source": "custom-turn-metric", "severity": "high"},
+                )
+
+        llm = _mock_llm(score=4)
+        result = evaluate_turn(
+            llm,
+            _turn_item(),
+            custom_qualitative_metrics=[StubQual()],
+        )
+
+        qual = next(q for q in result.qual_scores if q.name == "stub_qual")
+        assert qual.value == "flagged"
+        assert qual.metadata == {
+            "source": "custom-turn-metric",
+            "severity": "high",
+        }
+
+    def test_custom_quant_metadata_is_preserved(self) -> None:
+        class StubQuant(QuantitativeMetric):
+            def __init__(self) -> None:
+                super().__init__(name="stub_quant")
+
+            def score(self, score_input: ScoreInput) -> QuantResult:
+                return QuantResult(
+                    name=self.name,
+                    value=4.5,
+                    reason="captured metadata",
+                    metadata={"source": "custom-turn-metric", "band": "strong"},
+                )
+
+        llm = _mock_llm(score=4)
+        result = evaluate_turn(
+            llm,
+            _turn_item(),
+            custom_metrics=[StubQuant()],
+        )
+
+        score = next(s for s in result.scores if s.name == "stub_quant")
+        assert score.value == 4.5
+        assert score.metadata == {
+            "source": "custom-turn-metric",
+            "band": "strong",
+        }

--- a/tests/unit/test_evaluator_prompts.py
+++ b/tests/unit/test_evaluator_prompts.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for evaluator prompt templates and prompt-related models."""
+
+from __future__ import annotations
+
+from arksim.evaluator.base_metric import QualResult
+from arksim.evaluator.utils.prompts import (
+    agent_behavior_failure_system_prompt,
+    agent_behavior_failure_user_prompt,
+    goal_completion_user_prompt,
+    tool_call_behavior_failure_user_prompt,
+)
+
+
+class TestQualResult:
+    def test_accepts_metadata(self) -> None:
+        result = QualResult(
+            name="agent_behavior_failure",
+            value="false information",
+            reason="unsupported claim",
+            metadata={"failure_type": "hallucination", "severity": "critical"},
+        )
+
+        assert result.metadata == {
+            "failure_type": "hallucination",
+            "severity": "critical",
+        }
+
+    def test_metadata_round_trips_through_model_dump_and_validate(self) -> None:
+        result = QualResult(
+            name="agent_behavior_failure",
+            value="false information",
+            reason="unsupported claim",
+            metadata={"failure_type": "hallucination", "severity": "critical"},
+        )
+
+        dumped = result.model_dump()
+        restored = QualResult.model_validate(dumped)
+
+        assert restored == result
+        assert restored.metadata == result.metadata
+
+
+class TestPromptTemplates:
+    def test_goal_completion_prompt_uses_user_goal_placeholder(self) -> None:
+        assert "{user_goal}" in goal_completion_user_prompt
+        assert "{goal}" not in goal_completion_user_prompt
+
+    def test_behavior_failure_user_prompts_use_chat_history_placeholder(self) -> None:
+        assert "{chat_history}" in agent_behavior_failure_user_prompt
+        assert "{chat_history}" in tool_call_behavior_failure_user_prompt
+
+    def test_false_information_definition_mentions_unsupported_knowledge(self) -> None:
+        assert (
+            "not supported by the provided knowledge or context"
+            in agent_behavior_failure_system_prompt
+        )
+
+    def test_lack_of_specific_information_no_longer_requires_knowledge(self) -> None:
+        assert "only applies when knowledge is provided" not in (
+            agent_behavior_failure_system_prompt
+        )

--- a/tests/unit/test_tool_calls.py
+++ b/tests/unit/test_tool_calls.py
@@ -197,6 +197,44 @@ class TestToolCallBehaviorFailureMetric:
         assert result.name == "tool_call_behavior_failure"
         mock_llm.call.assert_called_once()
 
+    def test_with_tool_calls_includes_goal_knowledge_history_and_calls(self) -> None:
+        mock_llm = MagicMock()
+        mock_llm.call.return_value = QualSchema(label="no failure", reason="fine")
+
+        metric = ToolCallBehaviorFailureMetric(mock_llm)
+        tool_calls = [
+            {
+                "id": "tc-1",
+                "name": "lookup_order",
+                "arguments": {"order_id": "123"},
+                "result": '{"status": "shipped"}',
+            }
+        ]
+        score_input = ScoreInput(
+            chat_history=[
+                ChatMessage(role="user", content="Ignore this older turn"),
+                ChatMessage(role="assistant", content="Older reply"),
+            ],
+            current_turn=[
+                ChatMessage(role="user", content="Check order 123"),
+                ChatMessage(role="assistant", content="It shipped today."),
+            ],
+            knowledge="Use the order lookup tool for shipping status.",
+            user_goal="Check my order status",
+            profile="",
+            tool_calls=tool_calls,
+        )
+
+        metric.evaluate(score_input)
+
+        user_msg = mock_llm.call.call_args.args[0][1]["content"]
+        assert "Check my order status" in user_msg
+        assert "Use the order lookup tool for shipping status." in user_msg
+        assert "user: Ignore this older turn" in user_msg
+        assert "assistant: Older reply" in user_msg
+        assert '"name": "lookup_order"' in user_msg
+        assert '"order_id": "123"' in user_msg
+
     def test_unsafe_action_label(self) -> None:
         """LLM returns 'unsafe action' for a dangerous tool call."""
         mock_llm = MagicMock()


### PR DESCRIPTION
## Summary
- Rename prompt template placeholders to match the kwargs passed by builtin metrics (`full_conversation` → `chat_history`, `goal` → `user_goal`, `conversation` → `chat_history`), fixing `KeyError`s when these metrics run.
- Add `metadata: dict[str, Any] | None` field to `QualResult` so qualitative results carry the same metadata channel as `QuantResult`.
- Refine `agent_behavior_failure` prompt definitions for "lack of specific information" and "false information" categories.

## Test plan
- [x] `pytest tests/unit/`
- [x] Run a builtin-metric eval end-to-end and confirm no `KeyError` from prompt formatting
- [x] Confirm `QualResult.metadata` round-trips through serialization