### PR TITLE
fix(simulator): skip empty ids in tool-call dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to ArkSim will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* **simulator:** fix tool-call dedup incorrectly merging or dropping distinct trace-sourced calls that share empty-string ids (Gemini, A2A without per-call ids) ([#168](https://github.com/arklexai/arksim/issues/168))
+
 ## [0.3.6](https://github.com/arklexai/arksim/compare/v0.3.5...v0.3.6) (2026-05-01)
 
 

--- a/arksim/simulation_engine/simulator.py
+++ b/arksim/simulation_engine/simulator.py
@@ -232,12 +232,14 @@ class Simulator:
                 # Dedup by ID first, then by (name, arguments) to handle
                 # cases where the trace receiver falls back to spanId while
                 # AgentResponse carries an SDK-assigned tool call ID.
+                # Empty-string ids (Gemini always; A2A when absent) are excluded
+                # from the ID set so they fall through to signature-based dedup.
                 if self.trace_receiver is not None:
                     traced = await self.trace_receiver.wait_for_traces(
                         conversation_id, turn
                     )
                     if traced:
-                        existing_ids = {tc.id for tc in turn_tool_calls}
+                        existing_ids = {tc.id for tc in turn_tool_calls if tc.id}
                         sig_to_idx: dict[tuple[str, str], int] = {}
                         for i, tc in enumerate(turn_tool_calls):
                             sig = (tc.name, json.dumps(tc.arguments, sort_keys=True))

--- a/arksim/simulation_engine/simulator.py
+++ b/arksim/simulation_engine/simulator.py
@@ -232,8 +232,17 @@ class Simulator:
                 # Dedup by ID first, then by (name, arguments) to handle
                 # cases where the trace receiver falls back to spanId while
                 # AgentResponse carries an SDK-assigned tool call ID.
-                # Empty-string ids (Gemini always; A2A when absent) are excluded
-                # from the ID set so they fall through to signature-based dedup.
+                #
+                # Empty-string ids fall through to signature-based dedup because
+                # Gemini's native response format has no per-call id field, and
+                # the A2A tool-call extension treats id as optional. Both
+                # parsers fall back to "" by convention; the convention is
+                # anchored by ``ToolCall.id: str`` (not nullable), so a missing
+                # id always lands as "" and never as None.
+                #
+                # existing_ids and sig_to_idx are updated as traced calls are
+                # appended so two same-id or same-signature traced calls
+                # dedupe against each other within the loop.
                 if self.trace_receiver is not None:
                     traced = await self.trace_receiver.wait_for_traces(
                         conversation_id, turn
@@ -249,6 +258,9 @@ class Simulator:
                             sig = (tc.name, json.dumps(tc.arguments, sort_keys=True))
                             if tc.id not in existing_ids and sig not in sig_to_idx:
                                 turn_tool_calls.append(tc)
+                                sig_to_idx[sig] = len(turn_tool_calls) - 1
+                                if tc.id:
+                                    existing_ids.add(tc.id)
 
                 history.append(
                     {

--- a/tests/unit/test_trace_merge.py
+++ b/tests/unit/test_trace_merge.py
@@ -420,3 +420,112 @@ async def test_trace_merge_three_way_overlap() -> None:
     ids = [tc["id"] for tc in tc_list]
     assert "b" in ids
     assert "span-b" not in ids
+
+
+@pytest.mark.asyncio
+async def test_empty_ids_do_not_collapse_distinct_traced_calls() -> None:
+    """Empty tool-call ids must not be treated as a match in ID dedup.
+
+    Gemini (always id="") and A2A (id="" when absent) emit empty ids.
+    If turn_tool_calls contains any empty-id call, every traced call
+    with a distinct (name, arguments) signature must still be merged.
+    """
+    receiver = AsyncMock()
+    receiver.signal_turn_complete = MagicMock()
+    receiver.wait_for_traces = AsyncMock(
+        return_value=[
+            ToolCall(id="", name="c", arguments={"z": 3}),
+        ]
+    )
+
+    sim = _make_simulator(trace_receiver=receiver)
+
+    mock_agent = AsyncMock()
+    mock_agent.get_chat_id = AsyncMock(return_value="conv-1")
+    mock_agent.execute = AsyncMock(
+        return_value=AgentResponse(
+            content="result",
+            tool_calls=[
+                ToolCall(id="", name="a", arguments={"x": 1}),
+                ToolCall(id="", name="b", arguments={"y": 2}),
+            ],
+        )
+    )
+    mock_agent.close = AsyncMock()
+
+    sim.llm.call_async = AsyncMock(side_effect=["hello", "###STOP###"])
+
+    with patch(
+        "arksim.simulation_engine.simulator.create_agent",
+        return_value=mock_agent,
+    ):
+        state = await sim._run_single_conversation(
+            profile="test user",
+            goal="test goal",
+            knowledge=[{"content": "k1"}],
+            agent_context="context",
+            max_turns=3,
+            scenario_id="s1",
+        )
+
+    assert state is not None
+    agent_msgs = [m for m in state.conversation_history if m.get("role") == "user"]
+    assert len(agent_msgs) == 1
+    tc_list = agent_msgs[0].get("tool_calls", [])
+    # 2 explicit (a, b) + 1 traced (c) = 3; empty ids must not collapse them
+    assert len(tc_list) == 3
+    names = {tc["name"] for tc in tc_list}
+    assert names == {"a", "b", "c"}
+
+
+@pytest.mark.asyncio
+async def test_empty_id_signature_match_still_dedupes() -> None:
+    """Signature-based dedup fires even when both sides have empty ids.
+
+    When turn_tool_calls and traced both carry id="" for the same
+    (name, arguments), the call must appear exactly once in the result.
+    """
+    receiver = AsyncMock()
+    receiver.signal_turn_complete = MagicMock()
+    receiver.wait_for_traces = AsyncMock(
+        return_value=[
+            ToolCall(id="", name="a", arguments={"x": 1}),
+        ]
+    )
+
+    sim = _make_simulator(trace_receiver=receiver)
+
+    mock_agent = AsyncMock()
+    mock_agent.get_chat_id = AsyncMock(return_value="conv-1")
+    mock_agent.execute = AsyncMock(
+        return_value=AgentResponse(
+            content="result",
+            tool_calls=[
+                ToolCall(id="", name="a", arguments={"x": 1}),
+            ],
+        )
+    )
+    mock_agent.close = AsyncMock()
+
+    sim.llm.call_async = AsyncMock(side_effect=["hello", "###STOP###"])
+
+    with patch(
+        "arksim.simulation_engine.simulator.create_agent",
+        return_value=mock_agent,
+    ):
+        state = await sim._run_single_conversation(
+            profile="test user",
+            goal="test goal",
+            knowledge=[{"content": "k1"}],
+            agent_context="context",
+            max_turns=3,
+            scenario_id="s1",
+        )
+
+    assert state is not None
+    agent_msgs = [m for m in state.conversation_history if m.get("role") == "user"]
+    assert len(agent_msgs) == 1
+    tc_list = agent_msgs[0].get("tool_calls", [])
+    # Signature match: only 1 call, not 2
+    assert len(tc_list) == 1
+    assert tc_list[0]["name"] == "a"

--- a/tests/unit/test_trace_merge.py
+++ b/tests/unit/test_trace_merge.py
@@ -529,3 +529,54 @@ async def test_empty_id_signature_match_still_dedupes() -> None:
     # Signature match: only 1 call, not 2
     assert len(tc_list) == 1
     assert tc_list[0]["name"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_empty_id_traced_calls_dedupe_within_traced() -> None:
+    """Two same-signature empty-id traced calls dedupe even when turn_tool_calls is empty.
+
+    Without sig_to_idx updates inside the append loop, both traced calls would
+    pass id-check (empty falls through) and sig-check (sig_to_idx empty from
+    turn_tool_calls=[]), producing a duplicate. The append branch tracks each
+    newly-merged call so subsequent traced entries dedupe against it.
+    """
+    receiver = AsyncMock()
+    receiver.signal_turn_complete = MagicMock()
+    receiver.wait_for_traces = AsyncMock(
+        return_value=[
+            ToolCall(id="", name="foo", arguments={"x": 1}),
+            ToolCall(id="", name="foo", arguments={"x": 1}),
+        ]
+    )
+
+    sim = _make_simulator(trace_receiver=receiver)
+
+    mock_agent = AsyncMock()
+    mock_agent.get_chat_id = AsyncMock(return_value="conv-1")
+    mock_agent.execute = AsyncMock(
+        return_value=AgentResponse(content="result", tool_calls=[])
+    )
+    mock_agent.close = AsyncMock()
+
+    sim.llm.call_async = AsyncMock(side_effect=["hello", "###STOP###"])
+
+    with patch(
+        "arksim.simulation_engine.simulator.create_agent",
+        return_value=mock_agent,
+    ):
+        state = await sim._run_single_conversation(
+            profile="test user",
+            goal="test goal",
+            knowledge=[{"content": "k1"}],
+            agent_context="context",
+            max_turns=3,
+            scenario_id="s1",
+        )
+
+    assert state is not None
+    agent_msgs = [m for m in state.conversation_history if m.get("role") == "user"]
+    assert len(agent_msgs) == 1
+    tc_list = agent_msgs[0].get("tool_calls", [])
+    # Both traced calls share id="" and (name, args); only one survives.
+    assert len(tc_list) == 1
+    assert tc_list[0]["name"] == "foo"


### PR DESCRIPTION
## Summary

Pre-existing correctness bug in the simulator's tool-call dedup: empty-string tool-call ids collapse into a single set entry, causing distinct trace-sourced calls to be incorrectly treated as duplicates.

## Background

`simulator.py:235-249` dedupes tool calls between the agent's explicit `AgentResponse.tool_calls` and the trace receiver's captured calls in two stages: by tool-call `id`, then by `(name, json-sorted arguments)` signature. The ID-set construction did not exclude empty strings:

```python
existing_ids = {tc.id for tc in turn_tool_calls}
```

Two real cases produce `id=""`:

- Gemini's `functionCall` parts have no per-call id; the parser falls back to `""`.
- A2A's tool-call extension allows `id` to be omitted; the parser falls back to `""`.

When two or more such calls land in `turn_tool_calls`, `existing_ids = {""}`. Every subsequent traced call with `id=""` then evaluates `tc.id not in existing_ids` as False and gets gated on the signature check alone. Distinct trace-sourced calls unique in `(name, arguments)` but sharing `id=""` with anything already in the turn are silently dropped.

Latent since the `id=""` fallbacks landed in #140; impacts Gemini + trace receiver and A2A-without-ids + trace receiver combinations.

## Fix

Exclude empty strings from the ID set so they fall through to signature-based dedup:

```python
existing_ids = {tc.id for tc in turn_tool_calls if tc.id}
```

The signature stage continues to handle legitimate matches.

## Test plan

- [x] Two regression tests in `tests/unit/test_trace_merge.py`:
  - `test_empty_ids_do_not_collapse_distinct_traced_calls`: turn has two empty-id calls (`a`, `b`); traced has one empty-id call (`c`); merged result has all three.
  - `test_empty_id_signature_match_still_dedupes`: turn and traced both have `id=""` with the same `(name, arguments)`; merged result has one call.
- [x] Full unit suite: 818 passed / 4 skipped.
- [x] `ruff check` + `ruff format --check` clean.