### PR TITLE
feat(tracing): add per-SDK tracing adapters for 9 frameworks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,4 @@ jobs:
         with:
           python-version: "3.13"
       - name: Resolve all SDK adapter extras together
-        run: python -m pip install -e ".[langchain,crewai,llamaindex,claude-agent,google-adk,livekit,strands,smolagents]" --dry-run
+        run: python -m pip install -e ".[langchain,crewai,llamaindex,claude-agent,google-adk,livekit-agents,strands,smolagents]" --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,14 @@ jobs:
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+  multi-extra-resolver:
+    name: Multi-extra resolver check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Resolve all SDK adapter extras together
+        run: python -m pip install -e ".[langchain,crewai,llamaindex,claude-agent,google-adk,livekit,strands,smolagents]" --dry-run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,20 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: |
+          (?x)^(
+            package-lock\.json|
+            pnpm-lock\.yaml|
+            yarn\.lock|
+            poetry\.lock|
+            uv\.lock|
+            Cargo\.lock|
+            .*/node_modules/.*|
+            \.secrets\.baseline
+          )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,13 +34,13 @@ repos:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
         exclude: |
-          (?x)^(
+          (?x)(^|/)(
             package-lock\.json|
             pnpm-lock\.yaml|
             yarn\.lock|
             poetry\.lock|
             uv\.lock|
             Cargo\.lock|
-            .*/node_modules/.*|
+            node_modules/.*|
             \.secrets\.baseline
           )$

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,182 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 50
+      }
+    ],
+    "docs/main/quickstart.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/main/quickstart.mdx",
+        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "docs/v0.2.0/quickstart.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/v0.2.0/quickstart.mdx",
+        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
+    "docs/v0.3.x/quickstart.mdx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/v0.3.x/quickstart.mdx",
+        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "tests/conftest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/conftest.py",
+        "hashed_secret": "69dba6dfc0be932d10cdbfaae770c300cd7e0e3c",
+        "is_verified": false,
+        "line_number": 72
+      }
+    ],
+    "tests/unit/test_cli_extended.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_cli_extended.py",
+        "hashed_secret": "b653891162a040e1bfe6e436bdcd93827e0c56e5",
+        "is_verified": false,
+        "line_number": 225
+      }
+    ]
+  },
+  "generated_at": "2026-05-15T17:53:57Z"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * **build:** rename the `livekit` pip extra to `livekit-agents` for naming consistency with the underlying package (`livekit-agents`); users with `arksim[livekit]` in their environment must reinstall with `arksim[livekit-agents]`.
-* **examples:** every integration example's agent now honors the `OPENAI_MODEL` environment variable; set it to override the example's default model without editing `config.yaml`.
+* **examples:** the OpenAI-based integration example agents (autogen, crewai, langchain, langgraph, livekit, llamaindex, mastra, openai-agents-sdk, strands, vercel-ai-sdk) now honor the `OPENAI_MODEL` environment variable; set it to override the example's default model without editing `config.yaml`. Examples using non-OpenAI providers (claude-agent-sdk, google-adk, pydantic-ai, dify, rasa, smolagents) are unaffected.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* **tracing:** add per-SDK tracing adapters for LangChain (covers LangGraph), CrewAI, Claude Agent SDK, Google ADK, LiveKit Agents, Strands Agents, LlamaIndex, and Smolagents. Each adapter ships as an optional extra (`pip install 'arksim[<sdk>]'`) and registers through the framework's native callback or hook interface. Tool calls captured through these adapters carry `source=ToolCallSource.<SDK>` for downstream metric filtering.
+* **tracing:** add `arksim/tracing/integrations/` package with `BaseTracingAdapter` (contextvars-based submission), `PendingToolCalls` (split-event correlation for LangChain and LlamaIndex), and `parse_tool_arguments` (shared argument normalization across adapters).
+* **tracing:** add `ToolCallSource` enum variants for LangChain, CrewAI, Claude Agent SDK, Google ADK, LiveKit, Strands, LlamaIndex, Smolagents, Dify, and Rasa.
+* **examples:** add LiveKit and Strands integration example projects under `examples/integrations/`. Update the existing 13 integration examples (langchain, langgraph, crewai, claude-agent-sdk, google-adk, llamaindex, smolagents, autogen, pydantic-ai, mastra, dify, rasa, vercel-ai-sdk) to fire mock `lookup_order` and `book_table` tools and capture them via the appropriate path (per-SDK adapter, native OTel, or HTTP wrapper).
+* **ci:** add multi-extra resolver check that installs all SDK adapter extras together to catch dependency-resolution conflicts.
+
 ### Fixed
 
 * **simulator:** fix tool-call dedup incorrectly merging or dropping distinct trace-sourced calls that share empty-string ids (Gemini, A2A without per-call ids) ([#168](https://github.com/arklexai/arksim/issues/168))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * **build:** rename the `livekit` pip extra to `livekit-agents` for naming consistency with the underlying package (`livekit-agents`); users with `arksim[livekit]` in their environment must reinstall with `arksim[livekit-agents]`.
-* **examples:** the OpenAI-based integration example agents (autogen, crewai, langchain, langgraph, livekit, llamaindex, mastra, openai-agents-sdk, strands, vercel-ai-sdk) now honor the `OPENAI_MODEL` environment variable; set it to override the example's default model without editing `config.yaml`. Examples using non-OpenAI providers (claude-agent-sdk, google-adk, pydantic-ai, dify, rasa, smolagents) are unaffected.
+* **examples:** the OpenAI-based integration example agents (autogen, crewai, langchain, langgraph, livekit, llamaindex, mastra, openai-agents-sdk, pydantic-ai, smolagents, strands, vercel-ai-sdk) now honor the `OPENAI_MODEL` environment variable; set it to override the example's default model without editing `config.yaml`. Examples using non-OpenAI providers (claude-agent-sdk, google-adk, dify, rasa) are unaffected.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **examples:** add LiveKit and Strands integration example projects under `examples/integrations/`. Update the existing 13 integration examples (langchain, langgraph, crewai, claude-agent-sdk, google-adk, llamaindex, smolagents, autogen, pydantic-ai, mastra, dify, rasa, vercel-ai-sdk) to fire mock `lookup_order` and `book_table` tools and capture them via the appropriate path (per-SDK adapter, native OTel, or HTTP wrapper).
 * **ci:** add multi-extra resolver check that installs all SDK adapter extras together to catch dependency-resolution conflicts.
 
+### Changed
+
+* **build:** rename the `livekit` pip extra to `livekit-agents` for naming consistency with the underlying package (`livekit-agents`); users with `arksim[livekit]` in their environment must reinstall with `arksim[livekit-agents]`.
+* **examples:** every integration example's agent now honors the `OPENAI_MODEL` environment variable; set it to override the example's default model without editing `config.yaml`.
+
 ### Fixed
 
 * **simulator:** fix tool-call dedup incorrectly merging or dropping distinct trace-sourced calls that share empty-string ids (Gemini, A2A without per-call ids) ([#168](https://github.com/arklexai/arksim/issues/168))

--- a/arksim/simulation_engine/tool_types.py
+++ b/arksim/simulation_engine/tool_types.py
@@ -53,6 +53,14 @@ class ToolCallSource(str, Enum):
     #: Captured from a Smolagents run (via the Smolagents tracing adapter).
     SMOLAGENTS = "smolagents"
 
+    #: Captured from a Dify app response (extracted from ``agent_thoughts``
+    #: in the Dify Chat API blocking-mode payload).
+    DIFY = "dify"
+
+    #: Captured from a Rasa conversation tracker (extracted from custom
+    #: action events on ``/conversations/{sender_id}/tracker``).
+    RASA = "rasa"
+
 
 class A2AToolCaptureExtension:
     """A2A AgentExtension URI for arksim's tool call capture convention.

--- a/arksim/simulation_engine/tool_types.py
+++ b/arksim/simulation_engine/tool_types.py
@@ -29,6 +29,30 @@ class ToolCallSource(str, Enum):
     #: Captured from an OTLP / OpenInference span (via the trace receiver).
     OTEL_TRACE = "otel_trace"
 
+    #: Captured from a LangChain run (via the LangChain tracing adapter).
+    LANGCHAIN = "langchain"
+
+    #: Captured from a CrewAI run (via the CrewAI tracing adapter).
+    CREWAI = "crewai"
+
+    #: Captured from a Claude Agent SDK run (via the Claude Agent SDK tracing adapter).
+    CLAUDE_AGENT_SDK = "claude_agent_sdk"
+
+    #: Captured from a Google ADK run (via the Google ADK tracing adapter).
+    GOOGLE_ADK = "google_adk"
+
+    #: Captured from a LiveKit run (via the LiveKit tracing adapter).
+    LIVEKIT = "livekit"
+
+    #: Captured from a Strands Agents run (via the Strands tracing adapter).
+    STRANDS = "strands"
+
+    #: Captured from a LlamaIndex run (via the LlamaIndex tracing adapter).
+    LLAMAINDEX = "llamaindex"
+
+    #: Captured from a Smolagents run (via the Smolagents tracing adapter).
+    SMOLAGENTS = "smolagents"
+
 
 class A2AToolCaptureExtension:
     """A2A AgentExtension URI for arksim's tool call capture convention.

--- a/arksim/tracing/integrations/__init__.py
+++ b/arksim/tracing/integrations/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-SDK tracing adapters for arksim's Python connector.
+
+Each adapter ships as an optional install (``pip install 'arksim[<sdk>]'``)
+and is imported explicitly by the user; this package does NOT eagerly
+import any SDK at package import time.
+"""
+
+from __future__ import annotations

--- a/arksim/tracing/integrations/_args.py
+++ b/arksim/tracing/integrations/_args.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Argument normalization for SDK-emitted tool-call inputs.
+
+SDKs vary in how they hand tool arguments to callbacks: LangChain emits a
+JSON string, Claude Agent SDK and Google ADK hand a dict directly, Strands
+gives a ``tool_use`` mapping. ``parse_tool_arguments`` normalizes all of
+these to a plain ``dict[str, Any]`` so adapters stay one-liners and the
+downstream ``ToolCall.arguments`` schema is consistent across sources.
+
+Scalar or list JSON values get wrapped in ``{"_value": <parsed>}`` rather
+than discarded - they're rare in real tool schemas but should round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def parse_tool_arguments(raw: str | dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize SDK tool-call arguments to a dict.
+
+    - ``dict`` -> returned as-is
+    - ``None`` or empty string -> ``{}``
+    - JSON string parsing to a ``dict`` -> the parsed dict
+    - JSON string parsing to a non-dict (number, list, ``null``, scalar)
+      -> ``{"_value": <parsed>}``
+    - non-JSON string -> ``{"_value": <raw>}``
+    """
+    if raw is None or raw == "":
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed: Any = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {"_value": raw}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"_value": parsed}

--- a/arksim/tracing/integrations/_base.py
+++ b/arksim/tracing/integrations/_base.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared submission logic for SDK-specific tracing adapters."""
+
+from __future__ import annotations
+
+import logging
+
+from arksim.simulation_engine.tool_types import ToolCall
+from arksim.tracing.context import (
+    trace_conversation_id,
+    trace_receiver_ref,
+    trace_turn_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BaseTracingAdapter:
+    """Shared submission logic for SDK-specific tool-call adapters.
+
+    Subclasses translate SDK events into ToolCall instances and call _submit.
+    Routing context (conversation_id, turn_id, receiver) comes from contextvars
+    set by the simulator. The adapter holds no per-conversation state.
+    """
+
+    def _submit(self, tool_call: ToolCall) -> None:
+        conversation_id = trace_conversation_id.get()
+        turn_id = trace_turn_id.get()
+        if conversation_id is None or turn_id is None:
+            return
+        receiver = trace_receiver_ref.get()
+        if receiver is None:
+            logger.debug(
+                "Tracing adapter has routing ids but no receiver; "
+                "tool call %r dropped.",
+                tool_call.name,
+            )
+            return
+        receiver.submit_tool_calls(conversation_id, turn_id, [tool_call])

--- a/arksim/tracing/integrations/_base.py
+++ b/arksim/tracing/integrations/_base.py
@@ -21,12 +21,33 @@ class BaseTracingAdapter:
     Subclasses translate SDK events into ToolCall instances and call _submit.
     Routing context (conversation_id, turn_id, receiver) comes from contextvars
     set by the simulator. The adapter holds no per-conversation state.
+
+    Subclass contract for ToolCall construction:
+
+    * Pass ``result=str(tool_output) if tool_output is not None else None``
+      so empty-string and falsy results (``False``, ``0``, ``""``) are
+      preserved as their string form rather than coerced to ``None``.
+    * Pass ``error=str(error_value) if error_value is not None else None``
+      on the error path. Use the same ``str(...)`` coercion when the SDK
+      types the field as ``Any``, since ``ToolCall.error`` is strict
+      ``str | None`` (Pydantic raises ``ValidationError`` on non-string
+      inputs).
+    * Downstream consumers should treat ``result=""`` as "tool returned
+      an empty string" and ``result=None`` as "no result captured".
+
+    Observability never breaks the observed: ``_submit`` catches and logs
+    any exception raised by the receiver, so a misbehaving receiver
+    cannot propagate back into the SDK callback that invoked the adapter.
     """
 
     def _submit(self, tool_call: ToolCall) -> None:
         conversation_id = trace_conversation_id.get()
         turn_id = trace_turn_id.get()
         if conversation_id is None or turn_id is None:
+            logger.debug(
+                "Tracing adapter has no routing context; tool call %r dropped.",
+                tool_call.name,
+            )
             return
         receiver = trace_receiver_ref.get()
         if receiver is None:
@@ -36,4 +57,16 @@ class BaseTracingAdapter:
                 tool_call.name,
             )
             return
-        receiver.submit_tool_calls(conversation_id, turn_id, [tool_call])
+        try:
+            receiver.submit_tool_calls(conversation_id, turn_id, [tool_call])
+        except Exception:
+            # Observability must never break the observed. Swallow the
+            # receiver's exception, log it with full routing context, and
+            # let the SDK callback that invoked us return normally.
+            logger.exception(
+                "Tracing receiver raised while submitting tool call "
+                "(conversation_id=%s, turn_id=%s, tool=%r); dropped.",
+                conversation_id,
+                turn_id,
+                tool_call.name,
+            )

--- a/arksim/tracing/integrations/_pending.py
+++ b/arksim/tracing/integrations/_pending.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Track in-flight tool calls keyed by SDK run id (split-event correlation)."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+
+class PendingToolCalls:
+    """Bounded-growth pending map for split-event correlation.
+
+    Stale entries are eagerly swept on every add() and pop() call,
+    evicting anything older than max_age_seconds (default 60s).
+    Per-adapter-instance, not class-level.
+    """
+
+    def __init__(self, max_age_seconds: float = 60.0) -> None:
+        self._pending: dict[str, tuple[dict[str, Any], float]] = {}
+        self._max_age = max_age_seconds
+
+    def add(self, run_id: str, payload: dict[str, Any]) -> None:
+        self._sweep_stale()
+        self._pending[run_id] = (payload, time.monotonic())
+
+    def pop(self, run_id: str) -> dict[str, Any] | None:
+        self._sweep_stale()
+        entry = self._pending.pop(run_id, None)
+        return entry[0] if entry else None
+
+    def _sweep_stale(self) -> None:
+        now = time.monotonic()
+        stale = [
+            rid for rid, (_, t) in self._pending.items() if now - t > self._max_age
+        ]
+        for rid in stale:
+            self._pending.pop(rid, None)

--- a/arksim/tracing/integrations/_pending.py
+++ b/arksim/tracing/integrations/_pending.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from typing import Any
 
@@ -13,22 +14,31 @@ class PendingToolCalls:
     Stale entries are eagerly swept on every add() and pop() call,
     evicting anything older than max_age_seconds (default 60s).
     Per-adapter-instance, not class-level.
+
+    Thread-safe: a ``threading.Lock`` guards every read and write of the
+    internal dict so concurrent ``add``/``pop`` calls from LangChain's
+    thread-pool dispatch (where blocking tools run on a worker thread)
+    cannot race. The lock scope covers only in-memory dict operations.
     """
 
     def __init__(self, max_age_seconds: float = 60.0) -> None:
         self._pending: dict[str, tuple[dict[str, Any], float]] = {}
         self._max_age = max_age_seconds
+        self._lock = threading.Lock()
 
     def add(self, run_id: str, payload: dict[str, Any]) -> None:
-        self._sweep_stale()
-        self._pending[run_id] = (payload, time.monotonic())
+        with self._lock:
+            self._sweep_stale_locked()
+            self._pending[run_id] = (payload, time.monotonic())
 
     def pop(self, run_id: str) -> dict[str, Any] | None:
-        self._sweep_stale()
-        entry = self._pending.pop(run_id, None)
+        with self._lock:
+            self._sweep_stale_locked()
+            entry = self._pending.pop(run_id, None)
         return entry[0] if entry else None
 
-    def _sweep_stale(self) -> None:
+    def _sweep_stale_locked(self) -> None:
+        """Evict stale entries. Caller must hold ``self._lock``."""
         now = time.monotonic()
         stale = [
             rid for rid, (_, t) in self._pending.items() if now - t > self._max_age

--- a/arksim/tracing/integrations/_pending.py
+++ b/arksim/tracing/integrations/_pending.py
@@ -21,6 +21,9 @@ class PendingToolCalls:
     cannot race. The lock scope covers only in-memory dict operations.
     """
 
+    # 60s default covers typical tool-call durations (LLM-side
+    # generation + tool execution + network round trip). Bump via the
+    # constructor for long-running RAG queries or external API tools.
     def __init__(self, max_age_seconds: float = 60.0) -> None:
         self._pending: dict[str, tuple[dict[str, Any], float]] = {}
         self._max_age = max_age_seconds

--- a/arksim/tracing/integrations/claude_agent_sdk.py
+++ b/arksim/tracing/integrations/claude_agent_sdk.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Claude Agent SDK tracing adapter (source=ToolCallSource.CLAUDE_AGENT_SDK).
+
+Verified against claude-agent-sdk 0.1.48. The SDK invokes hooks as
+``async`` callables with the signature
+``(input_data: PostToolUseHookInput, tool_use_id: str | None, context: HookContext)``
+and expects an awaitable JSON-shaped return value (``{}`` is a valid
+"no-op" response). Hooks are registered on ``ClaudeAgentOptions`` as a
+dict keyed by event name, with each value a list of ``HookMatcher``
+instances; ``HookMatcher(matcher=None, hooks=[callable])`` runs the
+callable for every event of that kind.
+
+Use::
+
+    hooks = ArksimClaudeHooks()
+    options = ClaudeAgentOptions(hooks=hooks.hooks_dict())
+
+The ``input_data`` payload (``PostToolUseHookInput``) carries the tool
+name, the tool input dict, the tool response, and a stable
+``tool_use_id`` that arksim copies onto ``ToolCall.id`` for downstream
+correlation. ``tool_response`` is typed ``Any``; we stringify so
+``ToolCall.result`` is a printable string regardless of whether the tool
+returned a scalar, a dict, or a structured Pydantic model.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from claude_agent_sdk import HookMatcher
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "ArksimClaudeHooks requires the 'claude-agent' extra. "
+        "Install with: pip install 'arksim[claude-agent]'"
+    ) from exc
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.integrations._args import parse_tool_arguments
+from arksim.tracing.integrations._base import BaseTracingAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class ArksimClaudeHooks(BaseTracingAdapter):
+    """Claude Agent SDK hooks producer capturing tool calls into arksim.
+
+    Stateless across emissions; safe to share one instance across
+    concurrent simulator agents because routing context comes from
+    contextvars set by the simulator on each conversation.
+    """
+
+    async def post_tool_use(
+        self,
+        input_data: dict[str, Any],
+        tool_use_id: str | None,
+        context: Any,  # noqa: ANN401, ARG002  (signature fixed by SDK)
+    ) -> dict[str, Any]:
+        tool_name = input_data.get("tool_name", "") or ""
+        tool_input = input_data.get("tool_input")
+        tool_response = input_data.get("tool_response")
+        self._submit(
+            ToolCall(
+                id=str(tool_use_id or ""),
+                name=tool_name,
+                arguments=parse_tool_arguments(tool_input),
+                result=str(tool_response) if tool_response is not None else None,
+                source=ToolCallSource.CLAUDE_AGENT_SDK,
+            )
+        )
+        return {}
+
+    def hooks_dict(self) -> dict[str, list[HookMatcher]]:
+        """Return the hooks dict to pass to ``ClaudeAgentOptions(hooks=...)``."""
+        return {"PostToolUse": [HookMatcher(hooks=[self.post_tool_use])]}

--- a/arksim/tracing/integrations/crewai.py
+++ b/arksim/tracing/integrations/crewai.py
@@ -53,6 +53,17 @@ class ArksimCrewEventListener(BaseTracingAdapter, BaseEventListener):
     """
 
     def setup_listeners(self, crewai_event_bus: CrewAIEventsBus) -> None:
+        # Note: CrewAI's event bus dispatches handlers via
+        # ``ThreadPoolExecutor.submit(ctx.run, ...)`` after
+        # ``contextvars.copy_context()``, which preserves arksim's routing
+        # context (trace_conversation_id, trace_turn_id,
+        # trace_receiver_ref) across the thread boundary. The adapter's
+        # correctness depends on that copy. If CrewAI ever drops the
+        # ``copy_context()`` step (or switches to a non-context-preserving
+        # dispatch path), every CrewAI tool call will start dropping
+        # silently because the contextvars will read as None on the worker
+        # thread. The cross-adapter contract test would catch that
+        # regression.
         @crewai_event_bus.on(ToolUsageFinishedEvent)
         def _on_tool_finished(
             source: Any,  # noqa: ANN401, ARG001  (signature fixed by crewai bus)

--- a/arksim/tracing/integrations/crewai.py
+++ b/arksim/tracing/integrations/crewai.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CrewAI tracing adapter (source=ToolCallSource.CREWAI).
+
+Verified against crewai 1.6.1. Subscribes to ``ToolUsageFinishedEvent``
+and ``ToolUsageErrorEvent`` on the CrewAI event bus; each emission becomes
+one ``ToolCall`` with the captured tool name, arguments (normalized via
+``parse_tool_arguments``), and result-or-error.
+
+Deviations from the original plan template:
+
+* Import path is ``crewai.events`` in crewai 1.6+ (was
+  ``crewai.utilities.events`` in older releases).
+* ``ToolUsageFinishedEvent`` carries the tool result in the ``output``
+  field, not ``result``.
+* The event model has no ``event_id``/correlation id, so ``ToolCall.id``
+  is left empty - a single completion-style event is self-contained and
+  needs no correlation across emissions.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from crewai.events import (
+        BaseEventListener,
+        ToolUsageErrorEvent,
+        ToolUsageFinishedEvent,
+    )
+    from crewai.events.event_bus import CrewAIEventsBus
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "ArksimCrewEventListener requires the 'crewai' extra. "
+        "Install with: pip install 'arksim[crewai]'"
+    ) from exc
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.integrations._args import parse_tool_arguments
+from arksim.tracing.integrations._base import BaseTracingAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class ArksimCrewEventListener(BaseTracingAdapter, BaseEventListener):
+    """CrewAI event listener capturing tool calls into arksim.
+
+    Construct one per simulator agent: ``ArksimCrewEventListener()``. The
+    base class registers handlers eagerly against the global
+    ``crewai_event_bus`` in ``__init__``, so simply instantiating the
+    listener is enough; no explicit ``Crew(event_listeners=[...])`` wiring
+    is required. The adapter is stateless across emissions.
+    """
+
+    def setup_listeners(self, crewai_event_bus: CrewAIEventsBus) -> None:
+        @crewai_event_bus.on(ToolUsageFinishedEvent)
+        def _on_tool_finished(
+            source: Any,  # noqa: ANN401, ARG001  (signature fixed by crewai bus)
+            event: ToolUsageFinishedEvent,
+        ) -> None:
+            output = event.output
+            self._submit(
+                ToolCall(
+                    id="",
+                    name=event.tool_name,
+                    arguments=parse_tool_arguments(event.tool_args),
+                    result=str(output) if output is not None else None,
+                    source=ToolCallSource.CREWAI,
+                )
+            )
+
+        @crewai_event_bus.on(ToolUsageErrorEvent)
+        def _on_tool_error(
+            source: Any,  # noqa: ANN401, ARG001  (signature fixed by crewai bus)
+            event: ToolUsageErrorEvent,
+        ) -> None:
+            error = event.error
+            if isinstance(error, BaseException):
+                error_str = f"{type(error).__name__}: {error}"
+            else:
+                error_str = str(error)
+            self._submit(
+                ToolCall(
+                    id="",
+                    name=event.tool_name,
+                    arguments=parse_tool_arguments(event.tool_args),
+                    error=error_str,
+                    source=ToolCallSource.CREWAI,
+                )
+            )

--- a/arksim/tracing/integrations/google_adk.py
+++ b/arksim/tracing/integrations/google_adk.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Google ADK tracing adapter (source=ToolCallSource.GOOGLE_ADK).
+
+Verified against google-adk 1.26.0. Subclasses ``BasePlugin`` and
+overrides ``after_tool_callback`` to emit one ``ToolCall`` after every
+tool invocation. ADK calls plugin callbacks in registration order; this
+adapter never returns a value, so the original tool result is preserved
+for downstream plugins and the agent itself.
+
+Use::
+
+    plugin = ArksimADKPlugin()
+    runner = Runner(app_name="my-app", agent=root_agent, plugins=[plugin])
+
+``BasePlugin.__init__`` requires a ``name``; the adapter defaults to
+``"arksim_tracing"`` which is fine for the common single-plugin case and
+can be overridden if multiple instances are registered.
+
+Deviations from the original plan template:
+
+* ``BasePlugin.__init__`` is ``__init__(self, name: str)`` (not no-arg),
+  so the adapter forwards a default ``name``.
+* ``ToolContext`` resolves to ``google.adk.agents.context.Context`` in
+  this release; the imported alias from ``google.adk.tools`` remains the
+  public re-export and is what the SDK passes at runtime.
+* ``after_tool_callback`` returns ``None`` (the SDK accepts
+  ``Optional[dict]``; a non-``None`` return would short-circuit
+  remaining plugins and replace the tool result, which observation-only
+  tracing must never do).
+
+InMemoryRunner may not invoke plugin callbacks (per adk-python issue
+#4464). Production runs use the real ``Runner``. Unit tests call
+``await plugin.after_tool_callback(...)`` directly with synthetic
+keyword arguments.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from google.adk.plugins import BasePlugin
+    from google.adk.tools import BaseTool, ToolContext
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "ArksimADKPlugin requires the 'google-adk' extra. "
+        "Install with: pip install 'arksim[google-adk]'"
+    ) from exc
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.integrations._args import parse_tool_arguments
+from arksim.tracing.integrations._base import BaseTracingAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class ArksimADKPlugin(BaseTracingAdapter, BasePlugin):
+    """Google ADK plugin capturing tool calls into arksim.
+
+    Stateless across emissions; safe to share one instance across
+    concurrent simulator agents because routing context comes from
+    contextvars set by the simulator on each conversation.
+    """
+
+    def __init__(self, name: str = "arksim_tracing") -> None:
+        super().__init__(name=name)
+
+    async def after_tool_callback(
+        self,
+        *,
+        tool: BaseTool,
+        tool_args: dict[str, Any],
+        tool_context: ToolContext,
+        result: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        self._submit(
+            ToolCall(
+                id=str(getattr(tool_context, "invocation_id", "") or ""),
+                name=getattr(tool, "name", "") or "",
+                arguments=parse_tool_arguments(tool_args),
+                result=str(result) if result is not None else None,
+                source=ToolCallSource.GOOGLE_ADK,
+            )
+        )
+        return None

--- a/arksim/tracing/integrations/langchain.py
+++ b/arksim/tracing/integrations/langchain.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LangChain / LangGraph tracing adapter (source=ToolCallSource.LANGCHAIN).
+
+Inherits from ``AsyncCallbackHandler`` (which itself subclasses
+``BaseCallbackHandler``) so the same instance satisfies both sync and
+async dispatch paths: ``chain.invoke()`` and ``chain.ainvoke()`` both
+accept it via ``callbacks=[...]``. LangGraph routes tool execution
+through the same LangChain callback bus, so this one adapter covers both
+frameworks. We do NOT list ``BaseCallbackHandler`` separately in the bases
+because that produces an MRO conflict (it is already an ancestor of
+``AsyncCallbackHandler``).
+
+Verified against langchain-core 1.3.0 callback signatures:
+
+    on_tool_start(serialized, input_str, *, run_id, parent_run_id=None,
+                  tags=None, metadata=None, inputs=None, **kwargs)
+    on_tool_end(output, *, run_id, parent_run_id=None, **kwargs)
+    on_tool_error(error, *, run_id, parent_run_id=None, **kwargs)
+
+``AsyncCallbackHandler.on_tool_*`` are declared ``async def``. We override
+each with a sync ``def`` to shadow both the sync and async base methods.
+On the async path the callback manager dispatches via
+``getattr(handler, "on_tool_start")`` and inspects ``iscoroutinefunction``;
+finding a sync method, it runs it under ``copy_context().run(...)`` so
+contextvars propagate, which is what ``BaseTracingAdapter._submit`` needs.
+``run_inline = True`` keeps that execution on the event loop instead of a
+thread pool because the work is pure in-memory bookkeeping.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+from uuid import UUID
+
+try:
+    from langchain_core.callbacks import AsyncCallbackHandler
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "ArksimLangChainHandler requires the 'langchain' extra. "
+        "Install with: pip install 'arksim[langchain]'"
+    ) from exc
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.integrations._base import BaseTracingAdapter
+from arksim.tracing.integrations._pending import PendingToolCalls
+
+logger = logging.getLogger(__name__)
+
+
+class ArksimLangChainHandler(BaseTracingAdapter, AsyncCallbackHandler):
+    """LangChain callback handler that captures tool calls into arksim.
+
+    Pass via ``callbacks=[ArksimLangChainHandler()]`` to ``chain.invoke()``
+    or ``chain.ainvoke()``. Each instance maintains its own pending-call
+    map; do not share across concurrent conversations (use one per
+    simulator agent).
+    """
+
+    # Run inline on the event loop instead of in a thread executor;
+    # all work is in-memory bookkeeping with no blocking I/O.
+    run_inline = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._pending = PendingToolCalls()
+
+    def on_tool_start(
+        self,
+        serialized: dict[str, Any],
+        input_str: str,
+        *,
+        run_id: UUID,
+        **kwargs: Any,  # noqa: ANN401  (signature fixed by LangChain protocol)
+    ) -> None:
+        name = serialized.get("name") or kwargs.get("name") or ""
+        try:
+            arguments: Any = json.loads(input_str) if input_str else {}
+        except (json.JSONDecodeError, TypeError):
+            arguments = {"_value": input_str} if input_str else {}
+        if not isinstance(arguments, dict):
+            arguments = {"_value": arguments}
+        self._pending.add(str(run_id), {"name": name, "arguments": arguments})
+
+    def on_tool_end(
+        self,
+        output: Any,  # noqa: ANN401  (signature fixed by LangChain protocol)
+        *,
+        run_id: UUID,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> None:
+        payload = self._pending.pop(str(run_id))
+        if payload is None:
+            logger.debug("unmatched on_tool_end for run_id=%s", run_id)
+            return
+        self._submit(
+            ToolCall(
+                id=str(run_id),
+                name=payload["name"],
+                arguments=payload["arguments"],
+                result=str(output) if output is not None else None,
+                source=ToolCallSource.LANGCHAIN,
+            )
+        )
+
+    def on_tool_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        **kwargs: Any,  # noqa: ANN401  (signature fixed by LangChain protocol)
+    ) -> None:
+        payload = self._pending.pop(str(run_id))
+        if payload is None:
+            logger.debug("unmatched on_tool_error for run_id=%s", run_id)
+            return
+        self._submit(
+            ToolCall(
+                id=str(run_id),
+                name=payload["name"],
+                arguments=payload["arguments"],
+                error=str(error),
+                source=ToolCallSource.LANGCHAIN,
+            )
+        )

--- a/arksim/tracing/integrations/langchain.py
+++ b/arksim/tracing/integrations/langchain.py
@@ -83,7 +83,7 @@ class ArksimLangChainHandler(BaseTracingAdapter, AsyncCallbackHandler):
         output: Any,  # noqa: ANN401  (signature fixed by LangChain protocol)
         *,
         run_id: UUID,
-        **kwargs: Any,  # noqa: ANN401
+        **kwargs: Any,  # noqa: ANN401  (signature fixed by LangChain protocol)
     ) -> None:
         payload = self._pending.pop(str(run_id))
         if payload is None:

--- a/arksim/tracing/integrations/langchain.py
+++ b/arksim/tracing/integrations/langchain.py
@@ -29,7 +29,6 @@ thread pool because the work is pure in-memory bookkeeping.
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 from uuid import UUID
@@ -43,6 +42,7 @@ except ImportError as exc:  # pragma: no cover
     ) from exc
 
 from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.integrations._args import parse_tool_arguments
 from arksim.tracing.integrations._base import BaseTracingAdapter
 from arksim.tracing.integrations._pending import PendingToolCalls
 
@@ -75,12 +75,7 @@ class ArksimLangChainHandler(BaseTracingAdapter, AsyncCallbackHandler):
         **kwargs: Any,  # noqa: ANN401  (signature fixed by LangChain protocol)
     ) -> None:
         name = serialized.get("name") or kwargs.get("name") or ""
-        try:
-            arguments: Any = json.loads(input_str) if input_str else {}
-        except (json.JSONDecodeError, TypeError):
-            arguments = {"_value": input_str} if input_str else {}
-        if not isinstance(arguments, dict):
-            arguments = {"_value": arguments}
+        arguments = parse_tool_arguments(input_str)
         self._pending.add(str(run_id), {"name": name, "arguments": arguments})
 
     def on_tool_end(
@@ -120,7 +115,7 @@ class ArksimLangChainHandler(BaseTracingAdapter, AsyncCallbackHandler):
                 id=str(run_id),
                 name=payload["name"],
                 arguments=payload["arguments"],
-                error=str(error),
+                error=f"{type(error).__name__}: {error}",
                 source=ToolCallSource.LANGCHAIN,
             )
         )

--- a/arksim/tracing/integrations/livekit.py
+++ b/arksim/tracing/integrations/livekit.py
@@ -42,8 +42,8 @@ try:
     from livekit.agents.voice.events import FunctionToolsExecutedEvent
 except ImportError as exc:  # pragma: no cover
     raise ImportError(
-        "ArksimLiveKitHandler requires the 'livekit' extra. "
-        "Install with: pip install 'arksim[livekit]'"
+        "ArksimLiveKitHandler requires the 'livekit-agents' extra. "
+        "Install with: pip install 'arksim[livekit-agents]'"
     ) from exc
 
 from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource

--- a/arksim/tracing/integrations/livekit.py
+++ b/arksim/tracing/integrations/livekit.py
@@ -79,13 +79,14 @@ class ArksimLiveKitHandler(BaseTracingAdapter):
                 )
                 continue
 
+            output = fn_output.output
             if fn_output.is_error:
                 self._submit(
                     ToolCall(
                         id=call_id,
                         name=name,
                         arguments=arguments,
-                        error=fn_output.output,
+                        error=str(output) if output is not None else None,
                         source=ToolCallSource.LIVEKIT,
                     )
                 )
@@ -96,7 +97,7 @@ class ArksimLiveKitHandler(BaseTracingAdapter):
                     id=call_id,
                     name=name,
                     arguments=arguments,
-                    result=fn_output.output,
+                    result=str(output) if output is not None else None,
                     source=ToolCallSource.LIVEKIT,
                 )
             )

--- a/arksim/tracing/integrations/livekit.py
+++ b/arksim/tracing/integrations/livekit.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LiveKit Agents tracing adapter (source=ToolCallSource.LIVEKIT).
+
+Verified against livekit-agents 1.5.9. Subscribes to the
+``function_tools_executed`` event on ``AgentSession``; each fired
+``FunctionToolsExecutedEvent`` is a *batch* carrying parallel
+``FunctionCall`` / ``FunctionCallOutput`` pairs, and the adapter emits
+one ``ToolCall`` per pair.
+
+Notes on the event shape:
+
+* ``FunctionCall.arguments`` is a JSON-encoded string, normalized via
+  ``parse_tool_arguments``.
+* ``FunctionCallOutput`` may be ``None`` for a given call - LiveKit
+  emits ``None`` when a tool raises ``StopResponse`` (no value should
+  be sent back to the LLM). Those pairs produce a ``ToolCall`` with
+  both ``result`` and ``error`` unset.
+* When a tool raises, LiveKit produces a ``FunctionCallOutput`` with
+  ``is_error=True`` and the error message in ``output``. We forward
+  that string verbatim into ``ToolCall.error`` - LiveKit has already
+  formatted it (typically as the exception's string form), and the
+  exception type is not exposed on the event.
+* ``ToolCall.id`` is populated from ``FunctionCall.call_id`` so arksim
+  trace consumers can correlate emissions with LiveKit tool-use records.
+
+Usage:
+
+    from livekit.agents.voice import AgentSession
+    from arksim.tracing.integrations.livekit import ArksimLiveKitHandler
+
+    handler = ArksimLiveKitHandler()
+    session = AgentSession(...)
+    handler.attach_to(session)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from livekit.agents.voice.events import FunctionToolsExecutedEvent
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "ArksimLiveKitHandler requires the 'livekit' extra. "
+        "Install with: pip install 'arksim[livekit]'"
+    ) from exc
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.integrations._args import parse_tool_arguments
+from arksim.tracing.integrations._base import BaseTracingAdapter
+
+logger = logging.getLogger(__name__)
+
+EVENT_NAME = "function_tools_executed"
+
+
+class ArksimLiveKitHandler(BaseTracingAdapter):
+    """LiveKit ``AgentSession`` event handler for tool-call capture.
+
+    Construct one per simulator agent and call ``attach_to(session)``.
+    Stateless across emissions.
+    """
+
+    def on_function_tools_executed(self, event: FunctionToolsExecutedEvent) -> None:
+        for fn_call, fn_output in event.zipped():
+            call_id = fn_call.call_id
+            name = fn_call.name
+            arguments = parse_tool_arguments(fn_call.arguments)
+
+            if fn_output is None:
+                self._submit(
+                    ToolCall(
+                        id=call_id,
+                        name=name,
+                        arguments=arguments,
+                        source=ToolCallSource.LIVEKIT,
+                    )
+                )
+                continue
+
+            if fn_output.is_error:
+                self._submit(
+                    ToolCall(
+                        id=call_id,
+                        name=name,
+                        arguments=arguments,
+                        error=fn_output.output,
+                        source=ToolCallSource.LIVEKIT,
+                    )
+                )
+                continue
+
+            self._submit(
+                ToolCall(
+                    id=call_id,
+                    name=name,
+                    arguments=arguments,
+                    result=fn_output.output,
+                    source=ToolCallSource.LIVEKIT,
+                )
+            )
+
+    def attach_to(
+        self,
+        session: Any,  # noqa: ANN401  (livekit AgentSession)
+    ) -> None:
+        """Subscribe to ``function_tools_executed`` on the given session."""
+        session.on(EVENT_NAME, self.on_function_tools_executed)

--- a/arksim/tracing/integrations/llamaindex.py
+++ b/arksim/tracing/integrations/llamaindex.py
@@ -125,12 +125,13 @@ class ArksimLlamaIndexObserver(BaseTracingAdapter):
             return
 
         tool_output = event.tool_output
+        content = tool_output.content
         if tool_output.is_error:
             exception = tool_output.exception
             if exception is not None:
-                error_str = f"{type(exception).__name__}: {exception}"
+                error_str: str | None = f"{type(exception).__name__}: {exception}"
             else:
-                error_str = tool_output.content
+                error_str = str(content) if content is not None else None
             self._submit(
                 ToolCall(
                     id=event.tool_id,
@@ -147,7 +148,7 @@ class ArksimLlamaIndexObserver(BaseTracingAdapter):
                 id=event.tool_id,
                 name=payload["name"],
                 arguments=payload["arguments"],
-                result=tool_output.content,
+                result=str(content) if content is not None else None,
                 source=ToolCallSource.LLAMAINDEX,
             )
         )

--- a/arksim/tracing/integrations/llamaindex.py
+++ b/arksim/tracing/integrations/llamaindex.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LlamaIndex tracing adapter (source=ToolCallSource.LLAMAINDEX).
+
+Verified against llama-index-core 0.14.15. LlamaIndex's modern
+``AgentWorkflow`` (``FunctionAgent``, ``ReActAgent``, ``CodeActAgent``)
+emits tool calls as workflow stream events, not through the
+``llama_index_instrumentation`` dispatcher. Specifically,
+``base_agent.call_tool`` writes ``ToolCall`` and ``ToolCallResult``
+events into ``ctx.write_event_to_stream``; consumers read them via
+``handler.stream_events()``.
+
+Deviations from the original plan template:
+
+* The plan suggested ``class ArksimLlamaIndexObserver(BaseTracingAdapter,
+  BaseEventHandler)`` to receive events via the instrumentation
+  dispatcher. We do NOT subclass ``BaseEventHandler`` because the
+  instrumentation dispatcher does not receive ``ToolCall`` /
+  ``ToolCallResult`` events for ``AgentWorkflow`` in 0.14.x. The
+  legacy ``AgentToolCallEvent`` class is defined but no longer emitted
+  anywhere in core.
+* The adapter exposes a plain ``observe(event)`` entry point and an
+  ``async consume_stream(handler)`` convenience method. Users either
+  forward stream events in their existing loop or hand a workflow
+  handler to the adapter.
+
+Event shapes:
+
+* ``ToolCall``: ``tool_name`` (str), ``tool_kwargs`` (dict),
+  ``tool_id`` (str) - emitted before the tool runs.
+* ``ToolCallResult``: same three fields plus ``tool_output``
+  (``ToolOutput`` with ``content`` property and ``exception`` accessor)
+  and ``is_error`` via ``tool_output.is_error``.
+
+Correlation is by ``tool_id``. ``PendingToolCalls`` holds in-flight
+calls and sweeps anything older than 60s, so a workflow that crashes
+between ``ToolCall`` and ``ToolCallResult`` cannot leak memory.
+
+Usage:
+
+    from llama_index.core.agent.workflow import FunctionAgent
+    from arksim.tracing.integrations.llamaindex import ArksimLlamaIndexObserver
+
+    observer = ArksimLlamaIndexObserver()
+    workflow = FunctionAgent(tools=..., llm=...)
+    handler = workflow.run(user_msg="...")
+    async for event in handler.stream_events():
+        observer.observe(event)
+    final = await handler
+
+Or, if you do not need to inspect stream events yourself:
+
+    handler = workflow.run(user_msg="...")
+    await observer.consume_stream(handler)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from llama_index.core.agent.workflow import ToolCall as LIToolCall
+    from llama_index.core.agent.workflow import ToolCallResult as LIToolCallResult
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "ArksimLlamaIndexObserver requires the 'llamaindex' extra. "
+        "Install with: pip install 'arksim[llamaindex]'"
+    ) from exc
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.integrations._args import parse_tool_arguments
+from arksim.tracing.integrations._base import BaseTracingAdapter
+from arksim.tracing.integrations._pending import PendingToolCalls
+
+logger = logging.getLogger(__name__)
+
+
+class ArksimLlamaIndexObserver(BaseTracingAdapter):
+    """Observe LlamaIndex ``AgentWorkflow`` tool-call stream events.
+
+    Construct one per simulator agent. The observer maintains its own
+    pending-call map keyed by ``tool_id``; do not share across
+    concurrent conversations (use one per simulator agent).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._pending = PendingToolCalls()
+
+    def observe(self, event: Any) -> None:  # noqa: ANN401  (workflow Event union)
+        """Forward a workflow stream event to the adapter.
+
+        Non-tool events are ignored. Call this for every event yielded
+        by ``handler.stream_events()``.
+        """
+        if isinstance(event, LIToolCallResult):
+            self._on_result(event)
+            return
+        if isinstance(event, LIToolCall):
+            self._on_start(event)
+
+    async def consume_stream(self, handler: Any) -> None:  # noqa: ANN401
+        """Iterate a workflow handler's stream and forward all events.
+
+        Convenience wrapper for users who do not need to inspect events
+        themselves. Does not await the handler's final result; callers
+        are expected to ``await handler`` afterwards if they need it.
+        """
+        async for event in handler.stream_events():
+            self.observe(event)
+
+    def _on_start(self, event: LIToolCall) -> None:
+        self._pending.add(
+            event.tool_id,
+            {
+                "name": event.tool_name,
+                "arguments": parse_tool_arguments(event.tool_kwargs),
+            },
+        )
+
+    def _on_result(self, event: LIToolCallResult) -> None:
+        payload = self._pending.pop(event.tool_id)
+        if payload is None:
+            logger.debug("unmatched ToolCallResult for tool_id=%s", event.tool_id)
+            return
+
+        tool_output = event.tool_output
+        if tool_output.is_error:
+            exception = tool_output.exception
+            if exception is not None:
+                error_str = f"{type(exception).__name__}: {exception}"
+            else:
+                error_str = tool_output.content
+            self._submit(
+                ToolCall(
+                    id=event.tool_id,
+                    name=payload["name"],
+                    arguments=payload["arguments"],
+                    error=error_str,
+                    source=ToolCallSource.LLAMAINDEX,
+                )
+            )
+            return
+
+        self._submit(
+            ToolCall(
+                id=event.tool_id,
+                name=payload["name"],
+                arguments=payload["arguments"],
+                result=tool_output.content,
+                source=ToolCallSource.LLAMAINDEX,
+            )
+        )

--- a/arksim/tracing/integrations/smolagents.py
+++ b/arksim/tracing/integrations/smolagents.py
@@ -54,7 +54,7 @@ class ArksimSmolagentsCallback(BaseTracingAdapter):
             return
         tool_calls = memory_step.tool_calls or []
         observations = memory_step.observations
-        result = observations if observations else None
+        result = str(observations) if observations is not None else None
         for tc in tool_calls:
             self._submit(
                 ToolCall(

--- a/arksim/tracing/integrations/smolagents.py
+++ b/arksim/tracing/integrations/smolagents.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Smolagents tracing adapter (source=ToolCallSource.SMOLAGENTS).
+
+Verified against smolagents 1.24.0. Pass via the ``step_callbacks`` list on
+``MultiStepAgent``; the SDK invokes ``__call__`` after each ``ActionStep``.
+Only ``ActionStep`` instances carry tool calls; other step types
+(``PlanningStep``, ``TaskStep``, ``FinalAnswerStep``, ``SystemPromptStep``)
+are ignored. The adapter is stateless across emissions.
+
+When a callback is registered for ``ActionStep`` via the list-form
+``step_callbacks=[...]``, smolagents already filters by step class through
+``CallbackRegistry``. The explicit ``isinstance`` check below preserves
+correctness if a user instead registers this callback for a broader step
+type via the dict form.
+
+Tool wrapping fallback for users with framework-instantiated tools that
+aren't observable via ``step_callbacks`` is documented in the example
+README, not shipped here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from smolagents.memory import ActionStep, MemoryStep
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "ArksimSmolagentsCallback requires the 'smolagents' extra. "
+        "Install with: pip install 'arksim[smolagents]'"
+    ) from exc
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.integrations._args import parse_tool_arguments
+from arksim.tracing.integrations._base import BaseTracingAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class ArksimSmolagentsCallback(BaseTracingAdapter):
+    """Smolagents step callback capturing tool calls into arksim.
+
+    Pass via ``MultiStepAgent(step_callbacks=[ArksimSmolagentsCallback()])``.
+    Stateless across emissions.
+    """
+
+    def __call__(
+        self,
+        memory_step: MemoryStep,
+        agent: Any = None,  # noqa: ANN401, ARG002  (signature fixed by smolagents)
+    ) -> None:
+        if not isinstance(memory_step, ActionStep):
+            return
+        tool_calls = memory_step.tool_calls or []
+        observations = memory_step.observations
+        result = observations if observations else None
+        for tc in tool_calls:
+            self._submit(
+                ToolCall(
+                    id=str(tc.id) if tc.id else "",
+                    name=tc.name or "",
+                    arguments=parse_tool_arguments(tc.arguments),
+                    result=result,
+                    source=ToolCallSource.SMOLAGENTS,
+                )
+            )

--- a/arksim/tracing/integrations/strands.py
+++ b/arksim/tracing/integrations/strands.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Strands Agents tracing adapter (source=ToolCallSource.STRANDS).
+
+Verified against strands-agents 1.33.0. Registers a callback on
+``AfterToolCallEvent`` via the ``HookProvider`` protocol; each event
+becomes one ``ToolCall`` with success/error branching driven by the
+event's ``exception`` field.
+
+Deviations from the original plan template:
+
+* The event's ``tool_use`` is a ``ToolUse`` TypedDict with shape
+  ``{"name": str, "toolUseId": str, "input": Any}``. The tool arguments
+  live in ``tool_use["input"]`` (not in ``tool_use`` directly), so we
+  pass that field to ``parse_tool_arguments``.
+* The tool name is sourced from ``tool_use["name"]`` rather than
+  ``event.selected_tool.tool_name``; the former is always present, while
+  ``selected_tool`` can be ``None`` when tool lookup fails.
+* Success/error branching uses the dedicated ``event.exception`` field
+  (``Exception | None``). ``event.result`` is always a ``ToolResult``
+  TypedDict, never a union with ``Exception``.
+* The ``ToolCall.id`` is populated from ``tool_use["toolUseId"]`` so
+  arksim trace consumers can correlate emissions with Strands tool-use
+  records.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from strands.hooks import AfterToolCallEvent, HookProvider, HookRegistry
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "ArksimStrandsHookProvider requires the 'strands' extra. "
+        "Install with: pip install 'arksim[strands]'"
+    ) from exc
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.integrations._args import parse_tool_arguments
+from arksim.tracing.integrations._base import BaseTracingAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class ArksimStrandsHookProvider(BaseTracingAdapter, HookProvider):
+    """Strands HookProvider capturing tool calls into arksim.
+
+    Pass via ``Agent(hooks=[ArksimStrandsHookProvider()])``. Stateless
+    across emissions.
+    """
+
+    def register_hooks(
+        self,
+        registry: HookRegistry,
+        **kwargs: Any,  # noqa: ANN401  (signature fixed by Strands protocol)
+    ) -> None:
+        registry.add_callback(AfterToolCallEvent, self._on_after_tool_call)
+
+    def _on_after_tool_call(self, event: AfterToolCallEvent) -> None:
+        tool_use = event.tool_use or {}
+        tool_name = tool_use.get("name", "") or ""
+        tool_use_id = tool_use.get("toolUseId", "") or ""
+        arguments = parse_tool_arguments(tool_use.get("input"))
+
+        exception = event.exception
+        if exception is not None:
+            self._submit(
+                ToolCall(
+                    id=tool_use_id,
+                    name=tool_name,
+                    arguments=arguments,
+                    error=f"{type(exception).__name__}: {exception}",
+                    source=ToolCallSource.STRANDS,
+                )
+            )
+            return
+
+        result = event.result
+        self._submit(
+            ToolCall(
+                id=tool_use_id,
+                name=tool_name,
+                arguments=arguments,
+                result=str(result) if result is not None else None,
+                source=ToolCallSource.STRANDS,
+            )
+        )

--- a/arksim/tracing/openai.py
+++ b/arksim/tracing/openai.py
@@ -12,6 +12,12 @@ by agents built on the OpenAI Agents SDK:
 
 Both require ``pip install openai-agents``.
 
+Note on package layout: this module predates the ``arksim.tracing.integrations``
+subpackage where the 8 SDK-specific tracing adapters (LangChain, CrewAI, Claude
+Agent SDK, Google ADK, LiveKit, Strands, LlamaIndex, Smolagents) now live. The
+OpenAI Agents SDK adapter is kept at this path for import stability; new SDK
+adapters added to arksim should live under ``arksim.tracing.integrations.<sdk>``.
+
 ---
 
 ``ArksimTracingProcessor``

--- a/docs/main/tool-call-capture.mdx
+++ b/docs/main/tool-call-capture.mdx
@@ -70,6 +70,10 @@ These keys are always present for Python connector agents regardless of which ca
 
 ## Automatic Capture (Python Connector)
 
+<Info>
+**Per-SDK adapter vs OTel path.** When an SDK exposes both a native callback path and OTel emission, the per-SDK adapter is canonical because it captures fields the OTel semconv doesn't standardize (e.g. LangChain's `run_id`-keyed split events). Use the OTel path when the SDK doesn't ship a Python-side adapter (Mastra, Vercel AI SDK JS, AutoGen direct invocation).
+</Info>
+
 For agents using the OpenAI Agents SDK with the Python connector, add two things:
 
 **1. Register the processor at module level in your agent file:**

--- a/examples/integrations/autogen/README.md
+++ b/examples/integrations/autogen/README.md
@@ -1,13 +1,14 @@
 # AutoGen Integration
 
-This example demonstrates how to connect a [Microsoft AutoGen](https://github.com/microsoft/autogen) agent to ArkSim using the custom agent connector.
+A [Microsoft AutoGen](https://github.com/microsoft/autogen) `AssistantAgent` with two mock tools (`lookup_order`, `book_table`) whose calls are exported as OpenTelemetry spans and captured by arksim's built-in OTLP receiver, landing in `simulation.json`.
 
-## Prerequisites
+## Setup
 
-1. Install AutoGen:
+1. Install AutoGen and the OTel exporter:
 
    ```bash
    pip install autogen-agentchat autogen-ext[openai]
+   pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
    ```
 
 2. Set your API key:
@@ -16,18 +17,44 @@ This example demonstrates how to connect a [Microsoft AutoGen](https://github.co
    export OPENAI_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-From this example directory, run:
+From this example directory:
 
 ```bash
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+AutoGen does not emit `gen_ai.tool.*` spans natively when `AssistantAgent.on_messages` runs directly (no runtime), so `tools.py` wraps each tool body in an OpenTelemetry span that follows the OTel GenAI semantic conventions. The agent constructs a `TracerProvider` that exports through `OTLPSpanExporter` to `127.0.0.1:4318/v1/traces`, which is where arksim's built-in OTLP receiver listens when `trace_receiver.enabled: true` is set in `config.yaml`. A small `_ArksimRoutingProcessor` reads `arksim.turn_id` from arksim's contextvar and stamps it on every span; `arksim.conversation_id` is pinned to the agent's `chat_id` via a `Resource` attribute. No extra arksim adapter is needed: the receiver decodes the OTLP payload, picks the routing attributes, and lands each tool span as a `ToolCall` on the correct turn in `results/simulation/simulation.json`.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "otel_trace"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "otel_trace"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                         |
-| ------------------ | ----------------------------------- |
-| `custom_agent.py`  | AutoGen integration                 |
-| `config.yaml`      | Simulator configuration             |
-| `scenarios.json`   | Simulation scenarios                |
+| File              | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `custom_agent.py` | AutoGen `AssistantAgent` + OTLP tracer provider          |
+| `tools.py`        | `lookup_order` and `book_table` with OTel span wrappers  |
+| `config.yaml`     | Simulator configuration with `trace_receiver` enabled    |
+| `scenarios.json`  | Two scenarios, one per tool                              |

--- a/examples/integrations/autogen/README.md
+++ b/examples/integrations/autogen/README.md
@@ -4,14 +4,20 @@ A [Microsoft AutoGen](https://github.com/microsoft/autogen) `AssistantAgent` wit
 
 ## Setup
 
-1. Install AutoGen and the OTel exporter:
+1. Install arksim with the OTel extra (required for the trace receiver this example uses):
+
+   ```bash
+   pip install 'arksim[otel]'
+   ```
+
+2. Install AutoGen and the OTel exporter:
 
    ```bash
    pip install autogen-agentchat autogen-ext[openai]
    pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
    ```
 
-2. Set your API key:
+3. Set your API key:
 
    ```bash
    export OPENAI_API_KEY="<your-key>"

--- a/examples/integrations/autogen/README.md
+++ b/examples/integrations/autogen/README.md
@@ -23,6 +23,8 @@ A [Microsoft AutoGen](https://github.com/microsoft/autogen) `AssistantAgent` wit
    export OPENAI_API_KEY="<your-key>"
    ```
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 From this example directory:

--- a/examples/integrations/autogen/config.yaml
+++ b/examples/integrations/autogen/config.yaml
@@ -36,3 +36,9 @@ provider: openai
 
 # Workers for parallel processing
 num_workers: 50
+
+# ── TRACE RECEIVER ───────────────────────────────────────────────────────────
+# Receives OTel spans emitted by the AutoGen agent's tool wrappers.
+trace_receiver:
+  enabled: true
+  wait_timeout: 5

--- a/examples/integrations/autogen/custom_agent.py
+++ b/examples/integrations/autogen/custom_agent.py
@@ -1,8 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""AutoGen integration for ArkSim.
+"""AutoGen integration for arksim.
 
-Install: pip install autogen-agentchat autogen-ext[openai]
-Auth:    export OPENAI_API_KEY="<your-key>"
+Install:
+    pip install autogen-agentchat autogen-ext[openai]
+    pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+Auth:
+    export OPENAI_API_KEY="<your-key>"
+
+Wires two mock tools (``lookup_order``, ``book_table``) into an
+``AssistantAgent`` and exports OTel spans to arksim's OTLP/HTTP trace
+receiver. Each tool wraps its body in a ``gen_ai.tool.*`` span; a custom
+span processor stamps ``arksim.conversation_id`` and ``arksim.turn_id``
+on every span so the receiver can route tool calls to the right turn.
 """
 
 from __future__ import annotations
@@ -13,26 +22,79 @@ from autogen_agentchat.agents import AssistantAgent
 from autogen_agentchat.messages import TextMessage
 from autogen_core import CancellationToken
 from autogen_ext.models.openai import OpenAIChatCompletionClient
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import Span, SpanProcessor, TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from tools import book_table, lookup_order
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.context import trace_turn_id
+
+_OTLP_ENDPOINT = "http://127.0.0.1:4318/v1/traces"
+
+
+class _ArksimRoutingProcessor(SpanProcessor):
+    """Stamp ``arksim.turn_id`` on every span from the current contextvar.
+
+    ``arksim.conversation_id`` is set once on the ``Resource`` because each
+    ``BaseAgent`` is bound to a single conversation. The turn id changes
+    per execute() call and is read from arksim's contextvar.
+    """
+
+    def on_start(self, span: Span, parent_context: Context | None = None) -> None:
+        turn_id = trace_turn_id.get()
+        if turn_id is not None:
+            span.set_attribute("arksim.turn_id", turn_id)
+
+    def on_end(self, span: Span) -> None:
+        return
+
+    def shutdown(self) -> None:
+        return
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
 
 
 class AutoGenAgent(BaseAgent):
-    """AutoGen agent wrapper.
+    """AutoGen ``AssistantAgent`` with tool calls captured via OTel.
 
-    AssistantAgent maintains internal model context across on_messages
+    ``AssistantAgent`` maintains internal model context across ``on_messages``
     calls, so only the new user message is passed each turn.
     """
 
     def __init__(self, agent_config: AgentConfig) -> None:
         super().__init__(agent_config)
         self._chat_id = str(uuid.uuid4())
+
+        resource = Resource.create(
+            {
+                "service.name": "arksim-autogen-example",
+                "arksim.conversation_id": self._chat_id,
+            }
+        )
+        self._provider = TracerProvider(resource=resource)
+        self._provider.add_span_processor(_ArksimRoutingProcessor())
+        self._provider.add_span_processor(
+            BatchSpanProcessor(OTLPSpanExporter(endpoint=_OTLP_ENDPOINT))
+        )
+        # Set as global so tools.py picks it up via trace.get_tracer().
+        trace.set_tracer_provider(self._provider)
+
         model_client = OpenAIChatCompletionClient(model="gpt-4o")
         self._agent = AssistantAgent(
             name="assistant",
-            system_message="You are a helpful assistant.",
+            system_message=(
+                "You are a helpful assistant with access to two tools: "
+                "lookup_order(order_id) and book_table(party_size, time). "
+                "Call them when relevant to answer the user."
+            ),
             model_client=model_client,
+            tools=[lookup_order, book_table],
         )
 
     async def get_chat_id(self) -> str:
@@ -43,4 +105,8 @@ class AutoGenAgent(BaseAgent):
             [TextMessage(content=user_query, source="user")],
             cancellation_token=CancellationToken(),
         )
+        self._provider.force_flush()
         return response.chat_message.content
+
+    async def close(self) -> None:
+        self._provider.shutdown()

--- a/examples/integrations/autogen/custom_agent.py
+++ b/examples/integrations/autogen/custom_agent.py
@@ -87,7 +87,7 @@ class AutoGenAgent(BaseAgent):
         trace.set_tracer_provider(self._provider)
 
         model_client = OpenAIChatCompletionClient(
-            model=os.environ.get("OPENAI_MODEL", "gpt-4o")
+            model=os.environ.get("OPENAI_MODEL", "gpt-5.1")
         )
         self._agent = AssistantAgent(
             name="assistant",

--- a/examples/integrations/autogen/custom_agent.py
+++ b/examples/integrations/autogen/custom_agent.py
@@ -16,6 +16,7 @@ on every span so the receiver can route tool calls to the right turn.
 
 from __future__ import annotations
 
+import os
 import uuid
 
 from autogen_agentchat.agents import AssistantAgent
@@ -85,7 +86,9 @@ class AutoGenAgent(BaseAgent):
         # Set as global so tools.py picks it up via trace.get_tracer().
         trace.set_tracer_provider(self._provider)
 
-        model_client = OpenAIChatCompletionClient(model="gpt-4o")
+        model_client = OpenAIChatCompletionClient(
+            model=os.environ.get("OPENAI_MODEL", "gpt-4o")
+        )
         self._agent = AssistantAgent(
             name="assistant",
             system_message=(

--- a/examples/integrations/autogen/scenarios.json
+++ b/examples/integrations/autogen/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/autogen/tools.py
+++ b/examples/integrations/autogen/tools.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the AutoGen integration example.
+
+Each tool is wrapped in an OpenTelemetry span that follows the OTel GenAI
+semantic conventions (``gen_ai.tool.name``, ``gen_ai.tool.call.arguments``,
+``gen_ai.tool.call.result``). Arksim's OTLP receiver converts these spans
+into ``ToolCall`` records on the appropriate turn.
+
+AutoGen does not emit ``gen_ai.tool.*`` spans natively for direct
+``AssistantAgent.on_messages`` calls, so the wrapper is what produces the
+captured tool calls.
+
+Outputs are deterministic so the example runs offline (apart from the LLM
+call) and produces predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+import json
+
+from opentelemetry import trace
+
+_tracer = trace.get_tracer("arksim.examples.autogen")
+
+
+def lookup_order(order_id: str) -> str:
+    """Look up an order by ID and return its status."""
+    arguments = {"order_id": order_id}
+    with _tracer.start_as_current_span("execute_tool lookup_order") as span:
+        span.set_attribute("gen_ai.tool.name", "lookup_order")
+        span.set_attribute("gen_ai.tool.call.arguments", json.dumps(arguments))
+        result = f"Order {order_id}: shipped, arrives Tuesday."
+        span.set_attribute("gen_ai.tool.call.result", result)
+        return result
+
+
+def book_table(party_size: int, time: str) -> str:
+    """Book a restaurant table for the given party size and time."""
+    arguments = {"party_size": party_size, "time": time}
+    with _tracer.start_as_current_span("execute_tool book_table") as span:
+        span.set_attribute("gen_ai.tool.name", "book_table")
+        span.set_attribute("gen_ai.tool.call.arguments", json.dumps(arguments))
+        result = f"Booked table for {party_size} at {time}."
+        span.set_attribute("gen_ai.tool.call.result", result)
+        return result

--- a/examples/integrations/claude-agent-sdk/README.md
+++ b/examples/integrations/claude-agent-sdk/README.md
@@ -1,13 +1,13 @@
 # Claude Agent SDK Integration
 
-This example demonstrates how to connect a [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) agent to ArkSim using the custom agent connector.
+A [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) client with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimClaudeHooks` so every tool call is captured in `simulation.json`. The Claude Agent SDK uses Anthropic models, so this example runs against `claude-sonnet-4-6` rather than an OpenAI model.
 
-## Prerequisites
+## Setup
 
-1. Install the Claude Agent SDK:
+1. Install arksim with the Claude Agent extra:
 
    ```bash
-   pip install claude-agent-sdk
+   pip install 'arksim[claude-agent]'
    ```
 
 2. Set your API key:
@@ -16,18 +16,44 @@ This example demonstrates how to connect a [Claude Agent SDK](https://github.com
    export ANTHROPIC_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-From this example directory, run:
+From this example directory:
 
 ```bash
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+`ArksimClaudeHooks` exposes a `PostToolUse` hook through its `hooks_dict()` method, which the agent passes straight into `ClaudeAgentOptions(hooks=...)`. The two mock tools are decorated with `@tool` and registered via `create_sdk_mcp_server` as an in-process MCP server named `arksim_tools`; Claude sees them as `mcp__arksim_tools__lookup_order` and `mcp__arksim_tools__book_table`, which `allowed_tools` whitelists. Before each turn the simulator binds `conversation_id`, `turn_id`, and the trace receiver into contextvars, so when the hook fires after each tool invocation it emits `ToolCall` records that land in the `tool_calls` field of every turn in `results/simulation/simulation.json`.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "mcp__arksim_tools__lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "[{'type': 'text', 'text': 'Order ORD-1001: shipped, arrives Tuesday.'}]",
+    "source": "claude_agent_sdk"
+  },
+  {
+    "name": "mcp__arksim_tools__book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "[{'type': 'text', 'text': 'Booked table for 4 at 7pm.'}]",
+    "source": "claude_agent_sdk"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                         |
-| ------------------ | ----------------------------------- |
-| `custom_agent.py`  | Claude Agent SDK integration        |
-| `config.yaml`      | Simulator configuration             |
-| `scenarios.json`   | Simulation scenarios                |
+| File              | Description                                |
+| ----------------- | ------------------------------------------ |
+| `custom_agent.py` | `ClaudeSDKClient` + `ArksimClaudeHooks`    |
+| `tools.py`        | `lookup_order` and `book_table` mock tools |
+| `config.yaml`     | Simulator configuration                    |
+| `scenarios.json`  | Two scenarios, one per tool                |

--- a/examples/integrations/claude-agent-sdk/README.md
+++ b/examples/integrations/claude-agent-sdk/README.md
@@ -1,6 +1,6 @@
 # Claude Agent SDK Integration
 
-A [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) client with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimClaudeHooks` so every tool call is captured in `simulation.json`. The Claude Agent SDK uses Anthropic models, so this example runs against `claude-sonnet-4-6` rather than an OpenAI model.
+A [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk) client with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimClaudeHooks` so every tool call is captured in `simulation.json`. The Claude Agent SDK uses Anthropic models, so this example uses Anthropic's `claude-sonnet-4-6` model by default; change in `config.yaml` if your account uses a different model name.
 
 ## Setup
 

--- a/examples/integrations/claude-agent-sdk/custom_agent.py
+++ b/examples/integrations/claude-agent-sdk/custom_agent.py
@@ -1,8 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Claude Agent SDK integration for ArkSim.
+"""Claude Agent SDK integration for arksim.
 
-Install: pip install claude-agent-sdk
-Auth:    export ANTHROPIC_API_KEY="<your-key>"
+Install:
+    pip install 'arksim[claude-agent]'
+Auth:
+    export ANTHROPIC_API_KEY="<your-key>"
+
+Wires arksim's Claude Agent SDK tracing adapter into a ``ClaudeSDKClient``
+with two mock tools (lookup_order, book_table) registered through an
+in-process SDK MCP server. Running ``arksim simulate-evaluate`` produces a
+simulation.json whose ``tool_calls`` field is populated by the captured
+invocations.
 """
 
 from __future__ import annotations
@@ -15,18 +23,42 @@ from claude_agent_sdk import (
     ClaudeSDKClient,
     ResultMessage,
     TextBlock,
+    create_sdk_mcp_server,
 )
+from tools import book_table, lookup_order
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.integrations.claude_agent_sdk import ArksimClaudeHooks
 
 
 class ClaudeAgentSDKAgent(BaseAgent):
+    """Claude Agent SDK client wired with arksim's PostToolUse hook.
+
+    The two mock tools are exposed to Claude via an in-process SDK MCP
+    server named ``arksim_tools``. Inside the SDK they are presented as
+    ``mcp__arksim_tools__lookup_order`` and
+    ``mcp__arksim_tools__book_table``; ``allowed_tools`` whitelists those
+    fully-qualified names so the client only invokes our mock tools.
+    """
+
     def __init__(self, agent_config: AgentConfig) -> None:
         super().__init__(agent_config)
         self._chat_id = str(uuid.uuid4())
+        self._hooks = ArksimClaudeHooks()
+        server = create_sdk_mcp_server(
+            name="arksim_tools",
+            tools=[lookup_order, book_table],
+        )
         self._client = ClaudeSDKClient(
-            options=ClaudeAgentOptions(allowed_tools=[]),
+            options=ClaudeAgentOptions(
+                mcp_servers={"arksim_tools": server},
+                allowed_tools=[
+                    "mcp__arksim_tools__lookup_order",
+                    "mcp__arksim_tools__book_table",
+                ],
+                hooks=self._hooks.hooks_dict(),
+            ),
         )
         self._connected = False
 

--- a/examples/integrations/claude-agent-sdk/scenarios.json
+++ b/examples/integrations/claude-agent-sdk/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/claude-agent-sdk/tools.py
+++ b/examples/integrations/claude-agent-sdk/tools.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the Claude Agent SDK integration example.
+
+Both tools showcase tool-call capture by ``ArksimClaudeHooks``. They are
+registered with an in-process SDK MCP server via ``create_sdk_mcp_server``
+and return deterministic strings so the example runs offline (apart from
+the LLM call) and produces predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from claude_agent_sdk import tool
+
+
+@tool(
+    "lookup_order",
+    "Look up an order by ID and return its status.",
+    {"order_id": str},
+)
+async def lookup_order(args: dict[str, Any]) -> dict[str, Any]:
+    text = f"Order {args['order_id']}: shipped, arrives Tuesday."
+    return {"content": [{"type": "text", "text": text}]}
+
+
+@tool(
+    "book_table",
+    "Book a restaurant table for the given party size and time.",
+    {"party_size": int, "time": str},
+)
+async def book_table(args: dict[str, Any]) -> dict[str, Any]:
+    text = f"Booked table for {args['party_size']} at {args['time']}."
+    return {"content": [{"type": "text", "text": text}]}

--- a/examples/integrations/crewai/README.md
+++ b/examples/integrations/crewai/README.md
@@ -1,13 +1,13 @@
 # CrewAI Integration
 
-This example demonstrates how to connect a [CrewAI](https://github.com/crewAIInc/crewAI) agent to ArkSim using the custom agent connector.
+A single-agent [CrewAI](https://github.com/crewAIInc/crewAI) `Crew` with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimCrewEventListener` so every tool call is captured in `simulation.json`.
 
-## Prerequisites
+## Setup
 
-1. Install CrewAI:
+1. Install arksim with the CrewAI extra:
 
    ```bash
-   pip install crewai
+   pip install 'arksim[crewai]'
    ```
 
 2. Set your API key:
@@ -16,18 +16,44 @@ This example demonstrates how to connect a [CrewAI](https://github.com/crewAIInc
    export OPENAI_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-From this example directory, run:
+From this example directory:
 
 ```bash
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+`ArksimCrewEventListener` extends CrewAI's `BaseEventListener`, which registers its handlers eagerly against the global `crewai_event_bus` from its constructor. Instantiating one listener per agent is enough; no `Crew(event_listeners=[...])` wiring is required. Before each turn the simulator binds `conversation_id`, `turn_id`, and the trace receiver into contextvars, so when the listener receives `ToolUsageFinishedEvent` or `ToolUsageErrorEvent` from inside `kickoff_async` it emits `ToolCall` records that land in the `tool_calls` field of every turn in `results/simulation/simulation.json`.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "crewai"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "crewai"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                         |
-| ------------------ | ----------------------------------- |
-| `custom_agent.py`  | CrewAI integration                  |
-| `config.yaml`      | Simulator configuration             |
-| `scenarios.json`   | Simulation scenarios                |
+| File              | Description                                |
+| ----------------- | ------------------------------------------ |
+| `custom_agent.py` | CrewAI `Crew` + `ArksimCrewEventListener`  |
+| `tools.py`        | `lookup_order` and `book_table` mock tools |
+| `config.yaml`     | Simulator configuration                    |
+| `scenarios.json`  | Two scenarios, one per tool                |

--- a/examples/integrations/crewai/README.md
+++ b/examples/integrations/crewai/README.md
@@ -16,6 +16,8 @@ A single-agent [CrewAI](https://github.com/crewAIInc/crewAI) `Crew` with two moc
    export OPENAI_API_KEY="<your-key>"
    ```
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 From this example directory:

--- a/examples/integrations/crewai/custom_agent.py
+++ b/examples/integrations/crewai/custom_agent.py
@@ -14,6 +14,7 @@ two mock tools (lookup_order, book_table). Running
 
 from __future__ import annotations
 
+import os
 import uuid
 
 from crewai import Agent as CrewAgent
@@ -23,6 +24,8 @@ from tools import book_table, lookup_order
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
 from arksim.tracing.integrations.crewai import ArksimCrewEventListener
+
+_MODEL = os.environ.get("OPENAI_MODEL", "gpt-5.1")
 
 
 class CrewAIAgent(BaseAgent):
@@ -50,7 +53,7 @@ class CrewAIAgent(BaseAgent):
             tools=[lookup_order, book_table],
             allow_delegation=False,
             verbose=False,
-            llm="gpt-5.1",
+            llm=_MODEL,
         )
         self._history: list[dict[str, str]] = []
 

--- a/examples/integrations/crewai/custom_agent.py
+++ b/examples/integrations/crewai/custom_agent.py
@@ -1,8 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CrewAI integration for ArkSim.
+"""CrewAI integration for arksim.
 
-Install: pip install crewai
-Auth:    export OPENAI_API_KEY="<your-key>"
+Install:
+    pip install 'arksim[crewai]'
+Auth:
+    export OPENAI_API_KEY="<your-key>"
+
+Wires arksim's CrewAI tracing adapter into a single-agent ``Crew`` with
+two mock tools (lookup_order, book_table). Running
+``arksim simulate-evaluate`` produces a simulation.json whose
+``tool_calls`` field is populated by the captured invocations.
 """
 
 from __future__ import annotations
@@ -11,19 +18,38 @@ import uuid
 
 from crewai import Agent as CrewAgent
 from crewai import Crew, Task
+from tools import book_table, lookup_order
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.integrations.crewai import ArksimCrewEventListener
 
 
 class CrewAIAgent(BaseAgent):
+    """CrewAI agent with conversation history and tool-call tracing.
+
+    CrewAI is task-oriented, so the agent threads prior turns into each
+    new ``Task`` description to preserve conversational memory.
+    Instantiating ``ArksimCrewEventListener`` registers its handlers on
+    the global ``crewai_event_bus`` eagerly; no explicit ``Crew``
+    constructor argument is required.
+    """
+
     def __init__(self, agent_config: AgentConfig) -> None:
         super().__init__(agent_config)
         self._chat_id = str(uuid.uuid4())
+        # Instantiating registers the listener on the global event bus.
+        self._listener = ArksimCrewEventListener()
         self._agent = CrewAgent(
-            role="Assistant",
-            goal="Answer user questions helpfully",
-            backstory="You are a helpful assistant.",
+            role="Customer service assistant",
+            goal="Help customers with their orders and bookings.",
+            backstory=(
+                "An efficient customer service assistant for an online "
+                "retailer that also takes restaurant reservations."
+            ),
+            tools=[lookup_order, book_table],
+            allow_delegation=False,
+            verbose=False,
             llm="gpt-5.1",
         )
         self._history: list[dict[str, str]] = []
@@ -41,7 +67,7 @@ class CrewAIAgent(BaseAgent):
         )
         task = Task(
             description=description,
-            expected_output="A clear, helpful answer",
+            expected_output="A short, helpful response.",
             agent=self._agent,
         )
         crew = Crew(agents=[self._agent], tasks=[task], verbose=False)

--- a/examples/integrations/crewai/scenarios.json
+++ b/examples/integrations/crewai/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/crewai/tools.py
+++ b/examples/integrations/crewai/tools.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the CrewAI integration example.
+
+Both tools showcase tool-call capture by ``ArksimCrewEventListener``.
+They return deterministic strings so the example runs offline (apart
+from the LLM call) and produces predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+from crewai.tools import tool
+
+
+@tool("lookup_order")
+def lookup_order(order_id: str) -> str:
+    """Look up an order by ID and return its status."""
+    return f"Order {order_id}: shipped, arrives Tuesday."
+
+
+@tool("book_table")
+def book_table(party_size: int, time: str) -> str:
+    """Book a restaurant table for the given party size and time."""
+    return f"Booked table for {party_size} at {time}."

--- a/examples/integrations/dify/README.md
+++ b/examples/integrations/dify/README.md
@@ -12,12 +12,15 @@ This example connects a [Dify](https://dify.ai) Agent app to arksim. The Python 
 
 2. Create an **Agent** app in Dify (Cloud or self-hosted). Agent apps emit `agent_thoughts` in their blocking-mode responses, which is the payload this wrapper parses. A Chatbot app returns plain text only and will produce empty `tool_calls`.
 
-3. In Dify Studio, open the Agent app and attach two tools matching the scenarios:
+3. In Dify Studio, create the Agent app and attach two tools matching the scenarios. Dify's docs are the source of truth for the current UI:
 
-   - `lookup_order(order_id: string) -> string` returning a status string.
-   - `book_table(party_size: integer, time: string) -> string` returning a confirmation string.
+   - Create the Agent app following [Build an Agent application](https://docs.dify.ai/en/use-dify/build/agent). Use any model you have credits for; the wrapper only reads `agent_thoughts` from the response.
+   - Add the two tools following [Build a tool plugin](https://docs.dify.ai/develop-plugin/dev-guides-and-walkthroughs/tool-plugin). Each tool returns a deterministic string so the simulation is reproducible:
+     - `lookup_order(order_id: string) -> string` returning a status string (e.g. `"Order ORD-1001: shipped, arrives Tuesday."`).
+     - `book_table(party_size: integer, time: string) -> string` returning a confirmation string (e.g. `"Booked table for 4 at 7pm."`).
+   - In the Agent app's **Tools** panel, attach both tools and authorize them so the agent can call them.
 
-   Use any tool surface Dify supports (custom tool, workflow tool, or built-in). The wrapper does not care how the tools are implemented; it only reads what Dify reports back in `agent_thoughts`.
+   The wrapper does not care how the tools are implemented (custom tool, workflow tool, or built-in); it only reads what Dify reports back in `agent_thoughts`.
 
 4. Publish the app and copy the API key from **API Access** in the dashboard:
 

--- a/examples/integrations/dify/README.md
+++ b/examples/integrations/dify/README.md
@@ -1,51 +1,73 @@
 # Dify Integration
 
-This example connects a [Dify](https://dify.ai) Chatbot app to ArkSim using the custom agent connector. It uses Dify's Chat API directly via httpx with no SDK dependency.
+This example connects a [Dify](https://dify.ai) Agent app to arksim. The Python wrapper drives Dify's Chat API over HTTP and extracts tool invocations from the response so they land in `simulation.json` as `ToolCall` instances.
 
-> **Note:** This integration uses blocking mode, which requires a **Chatbot** app in Dify (not an Agent, Workflow, or Text Generator app).
+## Setup
 
-## Prerequisites
-
-1. Install ArkSim:
+1. Install arksim:
 
    ```bash
    pip install arksim
    ```
 
-2. Create a **Chatbot** app in Dify (Cloud or self-hosted) and add a knowledge base with your documents. The included scenarios assume a home improvement store knowledge base, but you can adapt them to match your own content.
+2. Create an **Agent** app in Dify (Cloud or self-hosted). Agent apps emit `agent_thoughts` in their blocking-mode responses, which is the payload this wrapper parses. A Chatbot app returns plain text only and will produce empty `tool_calls`.
 
-3. Publish the app, then copy the API key from **API Access** in the Dify dashboard:
+3. In Dify Studio, open the Agent app and attach two tools matching the scenarios:
+
+   - `lookup_order(order_id: string) -> string` returning a status string.
+   - `book_table(party_size: integer, time: string) -> string` returning a confirmation string.
+
+   Use any tool surface Dify supports (custom tool, workflow tool, or built-in). The wrapper does not care how the tools are implemented; it only reads what Dify reports back in `agent_thoughts`.
+
+4. Publish the app and copy the API key from **API Access** in the dashboard:
 
    ```bash
    export DIFY_API_KEY="<your-app-api-key>"
    ```
 
-4. Set your OpenAI key (used by ArkSim's simulated user and evaluator, not your Dify app):
+5. Set your OpenAI key (used by arksim's simulated user and evaluator, not by your Dify app):
 
    ```bash
    export OPENAI_API_KEY="<your-key>"
    ```
 
-5. If you are using a self-hosted Dify instance, also set:
+6. For self-hosted Dify, also set:
 
    ```bash
    export DIFY_BASE_URL="http://your-dify-host/v1"
    ```
 
-## Usage
-
-From this example directory, run:
+## Run
 
 ```bash
 arksim simulate-evaluate config.yaml
 ```
 
-Results are written to `./results/simulation/simulation.json`. The evaluation report is printed to stdout with per-scenario metric scores and failure analysis.
+Results are written to `./results/simulation/simulation.json`.
+
+## How it works
+
+Dify has no Python SDK callback surface for tool calls, so arksim drives Dify through the REST Chat API and reads tool metadata back from the response. For Agent apps in blocking mode, Dify includes an `agent_thoughts` list where each entry records the tool name, the arguments the agent passed, and the observation returned by the tool. The wrapper in `custom_agent.py` parses that list into `ToolCall(name, arguments, result, source="dify")` and returns an `AgentResponse` carrying both the assistant text and the captured tool calls. The actual tool execution still happens inside Dify; the Python side only transports requests and surfaces what the Dify response reveals. If you point the wrapper at a Chatbot app, the `agent_thoughts` field is absent and `tool_calls` will be empty; the conversation still runs but trajectory-based metrics lose tool-call signal.
+
+## Expected output
+
+For a turn that invoked `lookup_order`, `simulation.json` contains:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "dify"
+  }
+]
+```
 
 ## Files
 
-| File              | Description                                              |
-| ----------------- | -------------------------------------------------------- |
-| `custom_agent.py` | ArkSim agent that connects to Dify via HTTP (httpx)      |
-| `config.yaml`     | ArkSim simulation and evaluation settings                |
-| `scenarios.json`  | Test scenarios for a home improvement customer service bot |
+| File              | Description                                                 |
+| ----------------- | ----------------------------------------------------------- |
+| `custom_agent.py` | arksim agent that drives Dify and extracts `agent_thoughts` |
+| `config.yaml`     | arksim simulation and evaluation settings                   |
+| `scenarios.json`  | Two scenarios, one per tool                                 |

--- a/examples/integrations/dify/custom_agent.py
+++ b/examples/integrations/dify/custom_agent.py
@@ -1,24 +1,110 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Dify integration for ArkSim.
+"""Dify integration for arksim.
 
-Connects to a Dify Chatbot app via the Chat API using httpx.
-Uses Dify's non-streaming (blocking) response mode.
+Connects to a Dify Agent app via the Chat API using httpx and surfaces any
+tool invocations the Dify-side agent emits as ``ToolCall`` instances on
+the returned ``AgentResponse``.
+
+Dify's blocking-mode response for Agent apps includes an
+``agent_thoughts`` list. Each thought records a tool name, the JSON
+arguments the agent passed, and the observation returned by the tool.
+This wrapper parses that list into arksim's ``ToolCall`` shape so
+``simulation.json`` gets populated tool-call data without any tracing.
 
 Auth: export DIFY_API_KEY="<your-app-api-key>"
 """
 
 from __future__ import annotations
 
+import json
+import logging
 import os
 import uuid
+from typing import Any
 
 import httpx
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.simulation_engine.tool_types import (
+    AgentResponse,
+    ToolCall,
+    ToolCallSource,
+)
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_BASE_URL = "https://api.dify.ai/v1"
 _REQUEST_TIMEOUT = httpx.Timeout(120.0)
+
+
+def _parse_arguments(raw: object) -> dict[str, Any]:
+    """Coerce Dify's ``tool_input`` (string or dict) into a JSON dict.
+
+    Dify returns ``tool_input`` as either a JSON-encoded string or a
+    pre-parsed object depending on the tool and the Dify version.
+    """
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {"raw": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"value": parsed}
+    return {}
+
+
+def _extract_tool_calls(payload: dict[str, Any]) -> list[ToolCall]:
+    """Build ``ToolCall`` instances from a Dify Chat API response.
+
+    Looks for ``agent_thoughts`` (Agent app blocking-mode shape). Each
+    thought may bundle multiple tools in a single ``tool`` field
+    (comma-separated) with a parallel ``tool_input`` dict, so we expand
+    those into one ``ToolCall`` per tool.
+    """
+    thoughts = payload.get("agent_thoughts") or []
+    if not isinstance(thoughts, list):
+        return []
+
+    tool_calls: list[ToolCall] = []
+    for thought in thoughts:
+        if not isinstance(thought, dict):
+            continue
+        tool_field = thought.get("tool")
+        if not tool_field:
+            continue
+        tool_input = thought.get("tool_input")
+        observation = thought.get("observation")
+
+        # Dify joins multiple tools in one thought with commas; the
+        # tool_input dict is keyed by tool name in that case.
+        names = [n.strip() for n in str(tool_field).split(",") if n.strip()]
+        for name in names:
+            if isinstance(tool_input, dict) and name in tool_input:
+                arguments = _parse_arguments(tool_input[name])
+            else:
+                arguments = _parse_arguments(tool_input)
+
+            if isinstance(observation, dict) and name in observation:
+                result: str | None = str(observation[name])
+            elif observation is None:
+                result = None
+            else:
+                result = str(observation)
+
+            tool_calls.append(
+                ToolCall(
+                    id=str(thought.get("id") or uuid.uuid4()),
+                    name=name,
+                    arguments=arguments,
+                    result=result,
+                    source=ToolCallSource.DIFY,
+                )
+            )
+    return tool_calls
 
 
 class DifyAgent(BaseAgent):
@@ -43,7 +129,7 @@ class DifyAgent(BaseAgent):
     async def get_chat_id(self) -> str:
         return self._chat_id
 
-    async def execute(self, user_query: str, **kwargs: object) -> str:
+    async def execute(self, user_query: str, **kwargs: object) -> AgentResponse:
         body: dict[str, object] = {
             "inputs": {},
             "query": user_query,
@@ -86,7 +172,17 @@ class DifyAgent(BaseAgent):
             raise RuntimeError(
                 f"Dify response missing 'answer' field. Response: {data}"
             )
-        return answer
+
+        tool_calls = _extract_tool_calls(data)
+        if not tool_calls:
+            # Chatbot apps (vs Agent apps) never emit agent_thoughts. Log
+            # once at debug so the user can spot the mismatch without
+            # noise on every turn.
+            logger.debug(
+                "No agent_thoughts in Dify response; ensure you are running "
+                "an Agent app with tools configured to capture tool calls."
+            )
+        return AgentResponse(content=answer, tool_calls=tool_calls)
 
     async def close(self) -> None:
         await self._client.aclose()

--- a/examples/integrations/dify/scenarios.json
+++ b/examples/integrations/dify/scenarios.json
@@ -2,32 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "return_policy_inquiry",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You recently bought a cordless drill online but it stopped working after two weeks. You want to understand the return and warranty policy. Ask about the return window, whether you need the original packaging, and what the warranty covers. If the agent gives vague answers, push for specifics.",
-            "agent_context": "You are a customer service assistant for a home improvement store. You help customers with product questions, return policies, and warranty claims using your knowledge base.",
-            "user_profile": "You are Maria, a 42-year-old homeowner who recently started doing DIY projects around the house. You are practical and straightforward. You get frustrated when answers are vague or overly generic and prefer clear, actionable steps."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant for a Dify Agent app with two tools configured: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "product_comparison",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You are refinishing your backyard deck and need help choosing between oil-based and water-based deck stain. Ask about durability, drying time, ease of application, and which works better in humid climates. You have a slight preference for low maintenance but are open to being convinced.",
-            "agent_context": "You are a customer service assistant for a home improvement store. You help customers with product recommendations, comparisons, and project guidance using your knowledge base.",
-            "user_profile": "You are James, a 55-year-old retired contractor who knows construction but is less familiar with newer product formulations. You ask pointed technical questions and expect knowledgeable answers. You respect expertise and will push back on generic marketing language."
-        },
-        {
-            "scenario_id": "out_of_scope_question",
-            "user_id": "user_0003",
-            "goal": "Ask the agent about something completely outside the store's domain, like investment advice or medical questions. Observe whether the agent admits it cannot help or fabricates an answer. Then pivot to a legitimate product question to test recovery.",
-            "agent_context": "You are a customer service assistant for a home improvement store. You help customers with product questions, return policies, and warranty claims using your knowledge base.",
-            "user_profile": "You are David, a 38-year-old engineer who likes to test system boundaries. You are polite but deliberate in asking off-topic questions to see how the system responds."
-        },
-        {
-            "scenario_id": "multi_turn_reference",
-            "user_id": "user_0004",
-            "goal": "Ask about exterior paint options for a wooden fence. After getting recommendations, ask follow-up questions that reference earlier answers: 'How long does the one you recommended take to dry?' and 'Is it safe for the pets I mentioned?' Test whether the agent maintains conversational context across turns.",
-            "agent_context": "You are a customer service assistant for a home improvement store. You help customers with product recommendations and project guidance using your knowledge base.",
-            "user_profile": "You are Priya, a 29-year-old first-time homeowner with two dogs. You ask questions conversationally and expect the agent to remember details you shared earlier without repeating yourself."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant for a Dify Agent app with two tools configured: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/google-adk/README.md
+++ b/examples/integrations/google-adk/README.md
@@ -1,13 +1,13 @@
 # Google ADK Integration
 
-This example demonstrates how to connect a [Google ADK](https://github.com/google/adk-python) agent to ArkSim using the custom agent connector.
+A [Google ADK](https://github.com/google/adk-python) `LlmAgent` with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimADKPlugin` so every tool call is captured in `simulation.json`.
 
-## Prerequisites
+## Setup
 
-1. Install Google ADK:
+1. Install arksim with the Google ADK extra:
 
    ```bash
-   pip install google-adk
+   pip install 'arksim[google-adk]'
    ```
 
 2. Set your API key:
@@ -16,18 +16,46 @@ This example demonstrates how to connect a [Google ADK](https://github.com/googl
    export GOOGLE_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-From this example directory, run:
+From this example directory:
 
 ```bash
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+`ArksimADKPlugin` extends ADK's `BasePlugin` and overrides `after_tool_callback` to emit a `ToolCall` after every tool invocation. The agent registers it on the runner via `InMemoryRunner(plugins=[plugin])` so one instance covers the `LlmAgent` and any sub-agents it spawns. Before each turn the simulator binds `conversation_id`, `turn_id`, and the trace receiver into contextvars, so when ADK invokes the plugin callback it submits records that land in the `tool_calls` field of every turn in `results/simulation/simulation.json`.
+
+> Note: ADK's `InMemoryRunner` historically did not invoke plugin callbacks in some releases (see [adk-python issue #4464](https://github.com/google/adk-python/issues/4464)). If you find empty `tool_calls` arrays, swap `InMemoryRunner` for the production `Runner` with explicit `session_service`, `artifact_service`, and `memory_service` arguments.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "{'result': 'Order ORD-1001: shipped, arrives Tuesday.'}",
+    "source": "google_adk"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "{'result': 'Booked table for 4 at 7pm.'}",
+    "source": "google_adk"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                         |
-| ------------------ | ----------------------------------- |
-| `custom_agent.py`  | Google ADK integration              |
-| `config.yaml`      | Simulator configuration             |
-| `scenarios.json`   | Simulation scenarios                |
+| File              | Description                                |
+| ----------------- | ------------------------------------------ |
+| `custom_agent.py` | ADK `LlmAgent` + `ArksimADKPlugin`         |
+| `tools.py`        | `lookup_order` and `book_table` mock tools |
+| `config.yaml`     | Simulator configuration                    |
+| `scenarios.json`  | Two scenarios, one per tool                |

--- a/examples/integrations/google-adk/custom_agent.py
+++ b/examples/integrations/google-adk/custom_agent.py
@@ -1,8 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Google ADK integration for ArkSim.
+"""Google ADK integration for arksim.
 
-Install: pip install google-adk
-Auth:    export GOOGLE_API_KEY="<your-key>"
+Install:
+    pip install 'arksim[google-adk]'
+Auth:
+    export GOOGLE_API_KEY="<your-key>"
+
+Wires arksim's Google ADK tracing adapter into an ``LlmAgent`` with two
+mock tools (lookup_order, book_table). Running ``arksim simulate-evaluate``
+produces a simulation.json whose ``tool_calls`` field is populated by the
+captured invocations.
 """
 
 from __future__ import annotations
@@ -12,20 +19,40 @@ import uuid
 from google.adk.agents import LlmAgent
 from google.adk.runners import InMemoryRunner
 from google.genai import types
+from tools import book_table, lookup_order
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.integrations.google_adk import ArksimADKPlugin
 
 
 class GoogleADKAgent(BaseAgent):
+    """ADK ``LlmAgent`` with conversation history and tool-call tracing.
+
+    ``ArksimADKPlugin`` extends ``BasePlugin`` and overrides
+    ``after_tool_callback`` to emit one ``ToolCall`` per invocation. It is
+    registered on the runner via ``plugins=[...]`` rather than on the agent,
+    so the same instance can cover any sub-agents the ``LlmAgent`` spawns.
+    """
+
     def __init__(self, agent_config: AgentConfig) -> None:
         super().__init__(agent_config)
+        self._plugin = ArksimADKPlugin()
         adk_agent = LlmAgent(
             name="assistant",
             model="gemini-2.5-flash",
-            instruction="You are a helpful assistant.",
+            instruction=(
+                "You are a helpful assistant with access to two tools: "
+                "lookup_order(order_id) and book_table(party_size, time). "
+                "Use them when relevant to answer the user."
+            ),
+            tools=[lookup_order, book_table],
         )
-        self._runner = InMemoryRunner(agent=adk_agent, app_name="arksim")
+        self._runner = InMemoryRunner(
+            agent=adk_agent,
+            app_name="arksim",
+            plugins=[self._plugin],
+        )
         self._user_id = f"arksim_{uuid.uuid4()}"
         self._session_id: str | None = None
 

--- a/examples/integrations/google-adk/scenarios.json
+++ b/examples/integrations/google-adk/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/google-adk/tools.py
+++ b/examples/integrations/google-adk/tools.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the Google ADK integration example.
+
+Both tools showcase tool-call capture by ``ArksimADKPlugin``. They are
+plain Python callables; ADK auto-wraps them as ``FunctionTool`` instances
+when they are listed in ``LlmAgent(tools=...)``. They return deterministic
+strings so the example runs offline (apart from the LLM call) and produces
+predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+
+def lookup_order(order_id: str) -> str:
+    """Look up an order by ID and return its status."""
+    return f"Order {order_id}: shipped, arrives Tuesday."
+
+
+def book_table(party_size: int, time: str) -> str:
+    """Book a restaurant table for the given party size and time."""
+    return f"Booked table for {party_size} at {time}."

--- a/examples/integrations/langchain/README.md
+++ b/examples/integrations/langchain/README.md
@@ -1,12 +1,13 @@
-# LangChain/LangGraph Integration
+# LangChain / LangGraph Integration
 
-This example demonstrates how to connect a [LangChain](https://github.com/langchain-ai/langchain)/[LangGraph](https://github.com/langchain-ai/langgraph) agent to ArkSim using the custom agent connector.
+A LangGraph ReAct agent with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimLangChainHandler` so every tool call is captured in `simulation.json`.
 
-## Prerequisites
+## Setup
 
-1. Install LangGraph and the OpenAI integration:
+1. Install arksim with the LangChain extra plus LangGraph:
 
    ```bash
+   pip install 'arksim[langchain]'
    pip install langgraph langchain-openai
    ```
 
@@ -16,18 +17,44 @@ This example demonstrates how to connect a [LangChain](https://github.com/langch
    export OPENAI_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-From this example directory, run:
+From this example directory:
 
 ```bash
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+`ArksimLangChainHandler` is a LangChain `AsyncCallbackHandler`. The agent registers one instance per conversation and passes it via `callbacks=[self._handler]` inside the `chain.ainvoke()` config. Before each agent turn the simulator binds `conversation_id`, `turn_id`, and the trace receiver into contextvars, so when the handler's `on_tool_start` and `on_tool_end` fire from inside LangGraph's tool node they emit `ToolCall` records on the correct turn. The captured calls land in the `tool_calls` field of every turn in `results/simulation/simulation.json`.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "langchain"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "langchain"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                         |
-| ------------------ | ----------------------------------- |
-| `custom_agent.py`  | LangChain/LangGraph integration     |
-| `config.yaml`      | Simulator configuration             |
-| `scenarios.json`   | Simulation scenarios                |
+| File              | Description                                      |
+| ----------------- | ------------------------------------------------ |
+| `custom_agent.py` | LangGraph ReAct agent + `ArksimLangChainHandler` |
+| `tools.py`        | `lookup_order` and `book_table` mock tools       |
+| `config.yaml`     | Simulator configuration                          |
+| `scenarios.json`  | Two scenarios, one per tool                      |

--- a/examples/integrations/langchain/README.md
+++ b/examples/integrations/langchain/README.md
@@ -17,6 +17,8 @@ A LangGraph ReAct agent with two mock tools (`lookup_order`, `book_table`), wire
    export OPENAI_API_KEY="<your-key>"
    ```
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 From this example directory:

--- a/examples/integrations/langchain/custom_agent.py
+++ b/examples/integrations/langchain/custom_agent.py
@@ -15,6 +15,7 @@ with two mock tools (lookup_order, book_table). Running
 
 from __future__ import annotations
 
+import os
 import uuid
 
 from langchain_core.messages import HumanMessage
@@ -27,6 +28,8 @@ from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
 from arksim.tracing.integrations.langchain import ArksimLangChainHandler
 
+_MODEL = os.environ.get("OPENAI_MODEL", "gpt-5.1")
+
 
 class LangChainAgent(BaseAgent):
     def __init__(self, agent_config: AgentConfig) -> None:
@@ -34,7 +37,7 @@ class LangChainAgent(BaseAgent):
         self._chat_id = str(uuid.uuid4())
         self._handler = ArksimLangChainHandler()
         self._graph = create_react_agent(
-            ChatOpenAI(model="gpt-5.1"),
+            ChatOpenAI(model=_MODEL),
             tools=[lookup_order, book_table],
             checkpointer=InMemorySaver(),
         )

--- a/examples/integrations/langchain/custom_agent.py
+++ b/examples/integrations/langchain/custom_agent.py
@@ -1,8 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-"""LangChain/LangGraph integration for ArkSim.
+"""LangChain / LangGraph integration for arksim.
 
-Install: pip install langgraph langchain-openai
-Auth:    export OPENAI_API_KEY="<your-key>"
+Install:
+    pip install 'arksim[langchain]'
+    pip install langgraph langchain-openai
+Auth:
+    export OPENAI_API_KEY="<your-key>"
+
+Wires arksim's LangChain tracing adapter into a LangGraph ReAct agent
+with two mock tools (lookup_order, book_table). Running
+``arksim simulate-evaluate`` produces a simulation.json whose
+``tool_calls`` field is populated by the captured invocations.
 """
 
 from __future__ import annotations
@@ -12,32 +20,33 @@ import uuid
 from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import InMemorySaver
-from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.prebuilt import create_react_agent
+from tools import book_table, lookup_order
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.integrations.langchain import ArksimLangChainHandler
 
 
 class LangChainAgent(BaseAgent):
     def __init__(self, agent_config: AgentConfig) -> None:
         super().__init__(agent_config)
         self._chat_id = str(uuid.uuid4())
-        llm = ChatOpenAI(model="gpt-5.1")
-
-        def agent_node(state: MessagesState) -> dict:
-            return {"messages": [llm.invoke(state["messages"])]}
-
-        graph = StateGraph(MessagesState)
-        graph.add_node("agent", agent_node)
-        graph.add_edge(START, "agent")
-        graph.add_edge("agent", END)
-        self._graph = graph.compile(checkpointer=InMemorySaver())
+        self._handler = ArksimLangChainHandler()
+        self._graph = create_react_agent(
+            ChatOpenAI(model="gpt-5.1"),
+            tools=[lookup_order, book_table],
+            checkpointer=InMemorySaver(),
+        )
 
     async def get_chat_id(self) -> str:
         return self._chat_id
 
     async def execute(self, user_query: str, **kwargs: object) -> str:
-        config = {"configurable": {"thread_id": self._chat_id}}
+        config = {
+            "configurable": {"thread_id": self._chat_id},
+            "callbacks": [self._handler],
+        }
         result = await self._graph.ainvoke(
             {"messages": [HumanMessage(content=user_query)]}, config
         )

--- a/examples/integrations/langchain/scenarios.json
+++ b/examples/integrations/langchain/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/langchain/tools.py
+++ b/examples/integrations/langchain/tools.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the LangChain integration example.
+
+Both tools showcase tool-call capture by ``ArksimLangChainHandler``.
+They return deterministic strings so the example runs offline (apart
+from the LLM call) and produces predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+from langchain_core.tools import tool
+
+
+@tool
+def lookup_order(order_id: str) -> str:
+    """Look up an order by ID and return its status."""
+    return f"Order {order_id}: shipped, arrives Tuesday."
+
+
+@tool
+def book_table(party_size: int, time: str) -> str:
+    """Book a restaurant table for the given party size and time."""
+    return f"Booked table for {party_size} at {time}."

--- a/examples/integrations/langgraph/README.md
+++ b/examples/integrations/langgraph/README.md
@@ -17,6 +17,8 @@ A hand-built [LangGraph](https://github.com/langchain-ai/langgraph) `StateGraph`
    export OPENAI_API_KEY="<your-key>"
    ```
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 From this example directory:

--- a/examples/integrations/langgraph/README.md
+++ b/examples/integrations/langgraph/README.md
@@ -1,12 +1,13 @@
 # LangGraph Integration
 
-This example demonstrates how to connect a [LangGraph](https://github.com/langchain-ai/langgraph) agent to ArkSim using the custom agent connector.
+A hand-built [LangGraph](https://github.com/langchain-ai/langgraph) `StateGraph` with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimLangChainHandler` so every tool call is captured in `simulation.json`.
 
-## Prerequisites
+## Setup
 
-1. Install LangGraph:
+1. Install arksim with the LangChain extra plus LangGraph:
 
    ```bash
+   pip install 'arksim[langchain]'
    pip install langgraph langchain-openai
    ```
 
@@ -16,18 +17,44 @@ This example demonstrates how to connect a [LangGraph](https://github.com/langch
    export OPENAI_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-From this example directory, run:
+From this example directory:
 
 ```bash
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+LangGraph reuses LangChain's callback bus, so `ArksimLangChainHandler` (a LangChain `AsyncCallbackHandler`) captures tool calls from inside the graph. The agent builds a `StateGraph` with a `chatbot` LLM node and a `ToolNode` for `lookup_order` and `book_table`, with a `tools_condition` conditional edge that routes between them. Before each turn the simulator binds `conversation_id`, `turn_id`, and the trace receiver into contextvars, and the agent passes the handler via `callbacks=[self._handler]` on `ainvoke` so tool invocations land in the `tool_calls` field of every turn in `results/simulation/simulation.json`.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "langchain"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "langchain"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                         |
-| ------------------ | ----------------------------------- |
-| `custom_agent.py`  | LangGraph integration               |
-| `config.yaml`      | Simulator configuration             |
-| `scenarios.json`   | Simulation scenarios                |
+| File              | Description                                       |
+| ----------------- | ------------------------------------------------- |
+| `custom_agent.py` | LangGraph `StateGraph` + `ArksimLangChainHandler` |
+| `tools.py`        | `lookup_order` and `book_table` mock tools        |
+| `config.yaml`     | Simulator configuration                           |
+| `scenarios.json`  | Two scenarios, one per tool                       |

--- a/examples/integrations/langgraph/custom_agent.py
+++ b/examples/integrations/langgraph/custom_agent.py
@@ -1,8 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""LangGraph integration for ArkSim.
+"""LangGraph integration for arksim.
 
-Install: pip install langgraph langchain-openai
-Auth:    export OPENAI_API_KEY="<your-key>"
+Install:
+    pip install 'arksim[langchain]'
+    pip install langgraph langchain-openai
+Auth:
+    export OPENAI_API_KEY="<your-key>"
+
+Wires arksim's LangChain tracing adapter into a hand-built LangGraph
+``StateGraph`` with an LLM node, a ``ToolNode`` for ``lookup_order`` and
+``book_table``, and a conditional edge that routes between them. Running
+``arksim simulate-evaluate`` produces a simulation.json whose
+``tool_calls`` field is populated by the captured invocations.
 """
 
 from __future__ import annotations
@@ -10,14 +19,18 @@ from __future__ import annotations
 import uuid
 from typing import Annotated
 
+from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
-from langgraph.graph import START, StateGraph
+from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import add_messages
+from langgraph.prebuilt import ToolNode, tools_condition
+from tools import book_table, lookup_order
 from typing_extensions import TypedDict
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.integrations.langchain import ArksimLangChainHandler
 
 
 class State(TypedDict):
@@ -27,30 +40,43 @@ class State(TypedDict):
 class LangGraphAgent(BaseAgent):
     """LangGraph agent with built-in session management via MemorySaver.
 
-    LangGraph's checkpointer handles conversation history internally
-    using the thread_id, similar to Google ADK's InMemoryRunner.
+    The graph routes between an LLM node and a ``ToolNode`` using
+    ``tools_condition``. ``ArksimLangChainHandler`` is passed through
+    ``callbacks`` on every ``ainvoke`` call, capturing tool invocations
+    into the simulator's ``tool_calls`` field via LangChain's callback bus
+    (which LangGraph reuses).
     """
 
     def __init__(self, agent_config: AgentConfig) -> None:
         super().__init__(agent_config)
         self._thread_id = str(uuid.uuid4())
-        llm = ChatOpenAI(model="gpt-4o")
+        self._handler = ArksimLangChainHandler()
+        tools = [lookup_order, book_table]
+        llm = ChatOpenAI(model="gpt-5.1").bind_tools(tools)
 
         def chatbot(state: State) -> State:
             return {"messages": [llm.invoke(state["messages"])]}
 
         graph = StateGraph(State)
         graph.add_node("chatbot", chatbot)
+        graph.add_node("tools", ToolNode(tools))
         graph.add_edge(START, "chatbot")
+        graph.add_conditional_edges(
+            "chatbot", tools_condition, {"tools": "tools", END: END}
+        )
+        graph.add_edge("tools", "chatbot")
         self._app = graph.compile(checkpointer=MemorySaver())
 
     async def get_chat_id(self) -> str:
         return self._thread_id
 
     async def execute(self, user_query: str, **kwargs: object) -> str:
-        config = {"configurable": {"thread_id": self._thread_id}}
+        config = {
+            "configurable": {"thread_id": self._thread_id},
+            "callbacks": [self._handler],
+        }
         result = await self._app.ainvoke(
-            {"messages": [{"role": "user", "content": user_query}]},
+            {"messages": [HumanMessage(content=user_query)]},
             config=config,
         )
         return result["messages"][-1].content

--- a/examples/integrations/langgraph/custom_agent.py
+++ b/examples/integrations/langgraph/custom_agent.py
@@ -16,6 +16,7 @@ Wires arksim's LangChain tracing adapter into a hand-built LangGraph
 
 from __future__ import annotations
 
+import os
 import uuid
 from typing import Annotated
 
@@ -31,6 +32,8 @@ from typing_extensions import TypedDict
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
 from arksim.tracing.integrations.langchain import ArksimLangChainHandler
+
+_MODEL = os.environ.get("OPENAI_MODEL", "gpt-5.1")
 
 
 class State(TypedDict):
@@ -52,7 +55,7 @@ class LangGraphAgent(BaseAgent):
         self._thread_id = str(uuid.uuid4())
         self._handler = ArksimLangChainHandler()
         tools = [lookup_order, book_table]
-        llm = ChatOpenAI(model="gpt-5.1").bind_tools(tools)
+        llm = ChatOpenAI(model=_MODEL).bind_tools(tools)
 
         def chatbot(state: State) -> State:
             return {"messages": [llm.invoke(state["messages"])]}

--- a/examples/integrations/langgraph/scenarios.json
+++ b/examples/integrations/langgraph/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/langgraph/tools.py
+++ b/examples/integrations/langgraph/tools.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the LangGraph integration example.
+
+Both tools showcase tool-call capture by ``ArksimLangChainHandler``.
+They return deterministic strings so the example runs offline (apart
+from the LLM call) and produces predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+from langchain_core.tools import tool
+
+
+@tool
+def lookup_order(order_id: str) -> str:
+    """Look up an order by ID and return its status."""
+    return f"Order {order_id}: shipped, arrives Tuesday."
+
+
+@tool
+def book_table(party_size: int, time: str) -> str:
+    """Book a restaurant table for the given party size and time."""
+    return f"Booked table for {party_size} at {time}."

--- a/examples/integrations/livekit/README.md
+++ b/examples/integrations/livekit/README.md
@@ -1,0 +1,63 @@
+# LiveKit Agents Integration
+
+A LiveKit Agents text-mode session with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimLiveKitHandler` so every tool call is captured in `simulation.json`.
+
+## Setup
+
+1. Install arksim with the LiveKit extra:
+
+   ```bash
+   pip install 'arksim[livekit]'
+   ```
+
+2. Set your credentials:
+
+   ```bash
+   export OPENAI_API_KEY="<your-key>"
+   export LIVEKIT_API_KEY="<your-livekit-key>"
+   export LIVEKIT_API_SECRET="<your-livekit-secret>"
+   ```
+
+   The LiveKit credentials are required by `livekit.agents.inference.LLM`, which proxies LLM calls through LiveKit Cloud. Free credentials are available at <https://cloud.livekit.io>.
+
+## Run
+
+From this example directory:
+
+```bash
+arksim simulate-evaluate config.yaml
+```
+
+## How it works
+
+LiveKit Agents is voice-first, but `AgentSession.run(user_input=..., input_modality="text")` exposes a text-in / text-out path that needs no audio room. The agent starts the session without a `room` argument so no RTC plumbing is set up. `ArksimLiveKitHandler` subscribes to the `function_tools_executed` event on `AgentSession`; LiveKit emits one event per parallel tool-call batch, and the handler turns each call into a `ToolCall` record on the active turn. Before each agent turn the simulator binds `conversation_id`, `turn_id`, and the trace receiver into contextvars, so the captured calls land in the `tool_calls` field of every turn in `results/simulation/simulation.json`.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "livekit"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "livekit"
+  }
+]
+```
+
+## Files
+
+| File              | Description                                       |
+| ----------------- | ------------------------------------------------- |
+| `custom_agent.py` | LiveKit `AgentSession` + `ArksimLiveKitHandler`   |
+| `tools.py`        | `lookup_order` and `book_table` mock tools        |
+| `config.yaml`     | Simulator configuration                           |
+| `scenarios.json`  | Two scenarios, one per tool                       |

--- a/examples/integrations/livekit/README.md
+++ b/examples/integrations/livekit/README.md
@@ -18,7 +18,7 @@ A LiveKit Agents text-mode session with two mock tools (`lookup_order`, `book_ta
    export LIVEKIT_API_SECRET="<your-livekit-secret>"
    ```
 
-   The LiveKit credentials are required by `livekit.agents.inference.LLM`, which proxies LLM calls through LiveKit Cloud. Free credentials are available at <https://cloud.livekit.io>.
+   The LiveKit credentials are required by `livekit.agents.inference.LLM`, which proxies LLM calls through LiveKit Cloud. Free credentials are available at <https://cloud.livekit.io>. LiveKit Cloud routes the LLM call through to OpenAI, but the inference cost is billed against your `OPENAI_API_KEY`, not your LiveKit credits.
 
 If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
 

--- a/examples/integrations/livekit/README.md
+++ b/examples/integrations/livekit/README.md
@@ -7,7 +7,7 @@ A LiveKit Agents text-mode session with two mock tools (`lookup_order`, `book_ta
 1. Install arksim with the LiveKit extra:
 
    ```bash
-   pip install 'arksim[livekit]'
+   pip install 'arksim[livekit-agents]'
    ```
 
 2. Set your credentials:

--- a/examples/integrations/livekit/README.md
+++ b/examples/integrations/livekit/README.md
@@ -20,6 +20,8 @@ A LiveKit Agents text-mode session with two mock tools (`lookup_order`, `book_ta
 
    The LiveKit credentials are required by `livekit.agents.inference.LLM`, which proxies LLM calls through LiveKit Cloud. Free credentials are available at <https://cloud.livekit.io>.
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 From this example directory:

--- a/examples/integrations/livekit/config.yaml
+++ b/examples/integrations/livekit/config.yaml
@@ -1,0 +1,38 @@
+# Simulate + Evaluate Configuration File
+# Configuration for 'arksim simulate-evaluate' command
+
+# ── AGENT CONFIGURATION ────────────────────────────────────────────────────
+
+agent_config:
+  agent_type: custom
+  agent_name: livekit
+  custom_config:
+    module_path: ./custom_agent.py
+
+# ── SIMULATION SETTINGS ──────────────────────────────────────────────────────
+
+# Path to the scenarios file
+scenario_file_path: ./scenarios.json
+
+# Number of conversations per scenario to generate
+num_conversations_per_scenario: 1
+
+# Maximum turns per conversation
+max_turns: 5
+
+# Output file path for simulation results
+output_file_path: ./results/simulation/simulation.json
+
+# Jinja template for the simulated user's system prompt
+simulated_user_prompt_template: null
+
+# ── SHARED SETTINGS ──────────────────────────────────────────────────────────
+
+# LLM model
+model: gpt-5.1
+
+# LLM provider
+provider: openai
+
+# Workers for parallel processing
+num_workers: 50

--- a/examples/integrations/livekit/custom_agent.py
+++ b/examples/integrations/livekit/custom_agent.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LiveKit Agents integration for arksim.
+
+Install:
+    pip install 'arksim[livekit]'
+Auth:
+    export OPENAI_API_KEY="<your-key>"          # required by LiveKit Cloud inference
+    export LIVEKIT_API_KEY="<your-livekit-key>"
+    export LIVEKIT_API_SECRET="<your-livekit-secret>"
+
+Wires arksim's LiveKit tracing adapter into a LiveKit Agents text-mode
+session with two mock tools (lookup_order, book_table). Running
+``arksim simulate-evaluate`` produces a simulation.json whose
+``tool_calls`` field is populated by the captured invocations.
+
+Note on text-only mode: LiveKit Agents is voice-first, but
+``AgentSession.run(user_input=..., input_modality="text")`` exposes a
+text-in / text-out path that does not require an audio room. We start
+the session without a ``room`` argument so no RTC plumbing is needed.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from livekit.agents.inference import LLM as InferenceLLM
+from livekit.agents.voice import Agent, AgentSession
+from tools import book_table, lookup_order
+
+from arksim.config import AgentConfig
+from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.integrations.livekit import ArksimLiveKitHandler
+
+
+class LiveKitAgent(BaseAgent):
+    def __init__(self, agent_config: AgentConfig) -> None:
+        super().__init__(agent_config)
+        self._chat_id = str(uuid.uuid4())
+        self._handler = ArksimLiveKitHandler()
+        self._agent = Agent(
+            instructions="You are a helpful assistant.",
+            tools=[lookup_order, book_table],
+            llm=InferenceLLM(model="openai/gpt-5.1"),
+        )
+        self._session = AgentSession()
+        self._handler.attach_to(self._session)
+        self._started = False
+
+    async def get_chat_id(self) -> str:
+        return self._chat_id
+
+    async def execute(self, user_query: str, **kwargs: object) -> str:
+        if not self._started:
+            await self._session.start(self._agent)
+            self._started = True
+        result = await self._session.run(user_input=user_query, input_modality="text")
+        return str(result.final_output)

--- a/examples/integrations/livekit/custom_agent.py
+++ b/examples/integrations/livekit/custom_agent.py
@@ -2,7 +2,7 @@
 """LiveKit Agents integration for arksim.
 
 Install:
-    pip install 'arksim[livekit]'
+    pip install 'arksim[livekit-agents]'
 Auth:
     export OPENAI_API_KEY="<your-key>"          # required by LiveKit Cloud inference
     export LIVEKIT_API_KEY="<your-livekit-key>"

--- a/examples/integrations/livekit/custom_agent.py
+++ b/examples/integrations/livekit/custom_agent.py
@@ -21,6 +21,7 @@ the session without a ``room`` argument so no RTC plumbing is needed.
 
 from __future__ import annotations
 
+import os
 import uuid
 
 from livekit.agents.inference import LLM as InferenceLLM
@@ -31,6 +32,8 @@ from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
 from arksim.tracing.integrations.livekit import ArksimLiveKitHandler
 
+_MODEL = os.environ.get("OPENAI_MODEL", "gpt-5.1")
+
 
 class LiveKitAgent(BaseAgent):
     def __init__(self, agent_config: AgentConfig) -> None:
@@ -40,7 +43,7 @@ class LiveKitAgent(BaseAgent):
         self._agent = Agent(
             instructions="You are a helpful assistant.",
             tools=[lookup_order, book_table],
-            llm=InferenceLLM(model="openai/gpt-5.1"),
+            llm=InferenceLLM(model=f"openai/{_MODEL}"),
         )
         self._session = AgentSession()
         self._handler.attach_to(self._session)

--- a/examples/integrations/livekit/scenarios.json
+++ b/examples/integrations/livekit/scenarios.json
@@ -1,0 +1,19 @@
+{
+    "schema_version": "v1",
+    "scenarios": [
+        {
+            "scenario_id": "order_status_lookup",
+            "user_id": "user_0001",
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
+        },
+        {
+            "scenario_id": "dinner_reservation",
+            "user_id": "user_0002",
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
+        }
+    ]
+}

--- a/examples/integrations/livekit/tools.py
+++ b/examples/integrations/livekit/tools.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the LiveKit integration example.
+
+Both tools showcase tool-call capture by ``ArksimLiveKitHandler``.
+They return deterministic strings so the example runs offline (apart
+from the LLM call) and produces predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+from livekit.agents.llm import function_tool
+
+
+@function_tool
+async def lookup_order(order_id: str) -> str:
+    """Look up an order by ID and return its status."""
+    return f"Order {order_id}: shipped, arrives Tuesday."
+
+
+@function_tool
+async def book_table(party_size: int, time: str) -> str:
+    """Book a restaurant table for the given party size and time."""
+    return f"Booked table for {party_size} at {time}."

--- a/examples/integrations/llamaindex/README.md
+++ b/examples/integrations/llamaindex/README.md
@@ -17,6 +17,8 @@ A [LlamaIndex](https://github.com/run-llama/llama_index) `FunctionAgent` with tw
    export OPENAI_API_KEY="<your-key>"
    ```
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 From this example directory:

--- a/examples/integrations/llamaindex/README.md
+++ b/examples/integrations/llamaindex/README.md
@@ -1,13 +1,14 @@
 # LlamaIndex Integration
 
-This example demonstrates how to connect a [LlamaIndex](https://github.com/run-llama/llama_index) agent to ArkSim using the custom agent connector.
+A [LlamaIndex](https://github.com/run-llama/llama_index) `FunctionAgent` with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimLlamaIndexObserver` so every tool call is captured in `simulation.json`.
 
-## Prerequisites
+## Setup
 
-1. Install LlamaIndex and the OpenAI integration:
+1. Install arksim with the LlamaIndex extra plus the OpenAI LLM:
 
    ```bash
-   pip install llama-index llama-index-llms-openai
+   pip install 'arksim[llamaindex]'
+   pip install llama-index-core llama-index-llms-openai
    ```
 
 2. Set your API key:
@@ -16,18 +17,44 @@ This example demonstrates how to connect a [LlamaIndex](https://github.com/run-l
    export OPENAI_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-From this example directory, run:
+From this example directory:
 
 ```bash
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+Unlike the other integrations that register a callback on the agent, LlamaIndex emits tool-call events through the workflow stream rather than through the `llama_index_instrumentation` dispatcher. The agent calls `self._workflow.run(user_msg=...)` to get a `WorkflowHandler`, hands it to `ArksimLlamaIndexObserver.consume_stream(handler)` to forward every `ToolCall` and `ToolCallResult` event into arksim, then `await`s the handler to collect the final `AgentOutput`. Before each agent turn the simulator binds `conversation_id`, `turn_id`, and the trace receiver into contextvars, so the observer's submissions land in the `tool_calls` field of every turn in `results/simulation/simulation.json`.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "_lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "llamaindex"
+  },
+  {
+    "name": "_book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "llamaindex"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                         |
-| ------------------ | ----------------------------------- |
-| `custom_agent.py`  | LlamaIndex integration              |
-| `config.yaml`      | Simulator configuration             |
-| `scenarios.json`   | Simulation scenarios                |
+| File              | Description                                             |
+| ----------------- | ------------------------------------------------------- |
+| `custom_agent.py` | LlamaIndex `FunctionAgent` + `ArksimLlamaIndexObserver` |
+| `tools.py`        | `lookup_order` and `book_table` mock tools              |
+| `config.yaml`     | Simulator configuration                                 |
+| `scenarios.json`  | Two scenarios, one per tool                             |

--- a/examples/integrations/llamaindex/README.md
+++ b/examples/integrations/llamaindex/README.md
@@ -36,13 +36,13 @@ After running the example, each turn that invoked a tool contains entries like t
 ```json
 "tool_calls": [
   {
-    "name": "_lookup_order",
+    "name": "lookup_order",
     "arguments": {"order_id": "ORD-1001"},
     "result": "Order ORD-1001: shipped, arrives Tuesday.",
     "source": "llamaindex"
   },
   {
-    "name": "_book_table",
+    "name": "book_table",
     "arguments": {"party_size": 4, "time": "7pm"},
     "result": "Booked table for 4 at 7pm.",
     "source": "llamaindex"

--- a/examples/integrations/llamaindex/custom_agent.py
+++ b/examples/integrations/llamaindex/custom_agent.py
@@ -19,6 +19,7 @@ invocations.
 
 from __future__ import annotations
 
+import os
 import uuid
 
 from llama_index.core.agent.workflow import FunctionAgent
@@ -29,6 +30,8 @@ from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
 from arksim.tracing.integrations.llamaindex import ArksimLlamaIndexObserver
 
+_MODEL = os.environ.get("OPENAI_MODEL", "gpt-5.1")
+
 
 class LlamaIndexAgent(BaseAgent):
     def __init__(self, agent_config: AgentConfig) -> None:
@@ -37,7 +40,7 @@ class LlamaIndexAgent(BaseAgent):
         self._observer = ArksimLlamaIndexObserver()
         self._workflow = FunctionAgent(
             tools=[lookup_order, book_table],
-            llm=OpenAI(model="gpt-5.1"),
+            llm=OpenAI(model=_MODEL),
             system_prompt=(
                 "You are a helpful assistant with access to two tools: "
                 "lookup_order(order_id) and book_table(party_size, time). "

--- a/examples/integrations/llamaindex/custom_agent.py
+++ b/examples/integrations/llamaindex/custom_agent.py
@@ -1,8 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
-"""LlamaIndex integration for ArkSim.
+"""LlamaIndex integration for arksim.
 
-Install: pip install llama-index llama-index-llms-openai
-Auth:    export OPENAI_API_KEY="<your-key>"
+Install:
+    pip install 'arksim[llamaindex]'
+    pip install llama-index-core llama-index-llms-openai
+Auth:
+    export OPENAI_API_KEY="<your-key>"
+
+Wires arksim's LlamaIndex tracing adapter into a ``FunctionAgent`` with
+two mock tools (lookup_order, book_table). Unlike the other integrations
+that register a callback on the agent, LlamaIndex emits tool-call events
+through the workflow stream, so we use
+``ArksimLlamaIndexObserver.consume_stream(handler)`` to forward those
+events into arksim. Running ``arksim simulate-evaluate`` produces a
+simulation.json whose ``tool_calls`` field is populated by the captured
+invocations.
 """
 
 from __future__ import annotations
@@ -10,28 +22,34 @@ from __future__ import annotations
 import uuid
 
 from llama_index.core.agent.workflow import FunctionAgent
-from llama_index.core.memory import ChatMemoryBuffer
 from llama_index.llms.openai import OpenAI
+from tools import book_table, lookup_order
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.integrations.llamaindex import ArksimLlamaIndexObserver
 
 
 class LlamaIndexAgent(BaseAgent):
     def __init__(self, agent_config: AgentConfig) -> None:
         super().__init__(agent_config)
         self._chat_id = str(uuid.uuid4())
-        llm = OpenAI(model="gpt-5.1")
-        self._memory = ChatMemoryBuffer.from_defaults()
-        self._agent = FunctionAgent(
-            tools=[],
-            llm=llm,
-            system_prompt="You are a helpful assistant.",
+        self._observer = ArksimLlamaIndexObserver()
+        self._workflow = FunctionAgent(
+            tools=[lookup_order, book_table],
+            llm=OpenAI(model="gpt-5.1"),
+            system_prompt=(
+                "You are a helpful assistant with access to two tools: "
+                "lookup_order(order_id) and book_table(party_size, time). "
+                "Use them when relevant to answer the user."
+            ),
         )
 
     async def get_chat_id(self) -> str:
         return self._chat_id
 
     async def execute(self, user_query: str, **kwargs: object) -> str:
-        response = await self._agent.run(user_query, memory=self._memory)
-        return str(response)
+        handler = self._workflow.run(user_msg=user_query)
+        await self._observer.consume_stream(handler)
+        result = await handler
+        return str(result)

--- a/examples/integrations/llamaindex/scenarios.json
+++ b/examples/integrations/llamaindex/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/llamaindex/tools.py
+++ b/examples/integrations/llamaindex/tools.py
@@ -21,5 +21,5 @@ def _book_table(party_size: int, time: str) -> str:
     return f"Booked table for {party_size} at {time}."
 
 
-lookup_order = FunctionTool.from_defaults(_lookup_order)
-book_table = FunctionTool.from_defaults(_book_table)
+lookup_order = FunctionTool.from_defaults(_lookup_order, name="lookup_order")
+book_table = FunctionTool.from_defaults(_book_table, name="book_table")

--- a/examples/integrations/llamaindex/tools.py
+++ b/examples/integrations/llamaindex/tools.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the LlamaIndex integration example.
+
+Both tools showcase tool-call capture by ``ArksimLlamaIndexObserver``.
+They return deterministic strings so the example runs offline (apart
+from the LLM call) and produces predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+from llama_index.core.tools import FunctionTool
+
+
+def _lookup_order(order_id: str) -> str:
+    """Look up an order by ID and return its status."""
+    return f"Order {order_id}: shipped, arrives Tuesday."
+
+
+def _book_table(party_size: int, time: str) -> str:
+    """Book a restaurant table for the given party size and time."""
+    return f"Booked table for {party_size} at {time}."
+
+
+lookup_order = FunctionTool.from_defaults(_lookup_order)
+book_table = FunctionTool.from_defaults(_book_table)

--- a/examples/integrations/mastra/README.md
+++ b/examples/integrations/mastra/README.md
@@ -4,7 +4,13 @@ A [Mastra](https://github.com/mastra-ai/mastra) agent running as a Node.js servi
 
 ## Setup
 
-1. Install Node dependencies:
+1. Install arksim with the OTel extra (required for the trace receiver this example uses):
+
+   ```bash
+   pip install 'arksim[otel]'
+   ```
+
+2. Install Node dependencies:
 
    ```bash
    npm install
@@ -12,7 +18,7 @@ A [Mastra](https://github.com/mastra-ai/mastra) agent running as a Node.js servi
 
    This installs `@mastra/core`, `@ai-sdk/openai`, `hono`, the OpenTelemetry SDK and OTLP exporter, and `zod`.
 
-2. Set your API key:
+3. Set your API key:
 
    ```bash
    export OPENAI_API_KEY="<your-key>"

--- a/examples/integrations/mastra/README.md
+++ b/examples/integrations/mastra/README.md
@@ -24,6 +24,8 @@ A [Mastra](https://github.com/mastra-ai/mastra) agent running as a Node.js servi
    export OPENAI_API_KEY="<your-key>"
    ```
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 Start the Mastra agent server in one terminal:

--- a/examples/integrations/mastra/README.md
+++ b/examples/integrations/mastra/README.md
@@ -1,16 +1,16 @@
 # Mastra Integration
 
-This example demonstrates how to connect a [Mastra](https://github.com/mastra-ai/mastra) agent to ArkSim via an HTTP server exposing an OpenAI-compatible chat completions endpoint.
+A [Mastra](https://github.com/mastra-ai/mastra) agent running as a Node.js service with two mock tools (`lookup_order`, `book_table`) whose calls are exported as OpenTelemetry spans and captured by arksim's built-in OTLP receiver, landing in `simulation.json`. Arksim drives the agent via an OpenAI-compatible chat completions endpoint.
 
-## Prerequisites
+## Setup
 
-1. Install dependencies:
+1. Install Node dependencies:
 
    ```bash
    npm install
    ```
 
-   This installs `@mastra/core`, `@ai-sdk/openai`, `hono`, and `@hono/node-server`.
+   This installs `@mastra/core`, `@ai-sdk/openai`, `hono`, the OpenTelemetry SDK and OTLP exporter, and `zod`.
 
 2. Set your API key:
 
@@ -18,9 +18,9 @@ This example demonstrates how to connect a [Mastra](https://github.com/mastra-ai
    export OPENAI_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-Start the agent server:
+Start the Mastra agent server in one terminal:
 
 ```bash
 npm start
@@ -32,11 +32,38 @@ In a separate terminal, run the simulation and evaluation:
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+Mastra is TypeScript-only, so arksim drives it through its `chat_completions` agent connector: each turn becomes an HTTP POST to `http://localhost:8888/v1/chat/completions` carrying the conversation history plus a `metadata` block with `chat_id` and `turn_id` (`enable_metadata: true` in `config.yaml` switches on that forward). On the Node side, the server starts an OpenTelemetry SDK pointed at arksim's OTLP receiver (`127.0.0.1:4318/v1/traces`) and threads `chat_id` and `turn_id` through an `AsyncLocalStorage`. A custom `ArksimRoutingProcessor` reads that store and stamps `arksim.conversation_id` and `arksim.turn_id` on every span it sees. Both tools are registered with `createTool({ ... })`; their bodies are wrapped in `tracer.startActiveSpan("execute_tool ...")` with the OTel GenAI semantic conventions (`gen_ai.tool.name`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`). The receiver decodes the OTLP payload, routes by the two arksim attributes, and lands each tool span as a `ToolCall` on the correct turn in `results/simulation/simulation.json`.
+
+**Tracing note:** Mastra is migrating away from OpenTelemetry toward a proprietary AI Tracing system (see [Mastra GitHub issue #8577](https://github.com/mastra-ai/mastra/issues/8577)). The OTel path used in this example works today and is independent of Mastra's internal tracing, but the upstream direction may change. If you adopt Mastra's new tracing surface in the future, point its exporter at the same OTLP endpoint or write a small bridge.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "otel_trace"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "otel_trace"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                                |
-| ------------------ | ------------------------------------------ |
-| `agent_server.ts`  | Mastra agent as an HTTP server             |
-| `config.yaml`      | Simulator configuration (chat_completions) |
-| `scenarios.json`   | Simulation scenarios                       |
-| `package.json`     | Node.js dependencies                       |
+| File              | Description                                                       |
+| ----------------- | ----------------------------------------------------------------- |
+| `agent_server.ts` | Mastra agent + OTLP exporter + tool wrappers                      |
+| `config.yaml`     | Simulator config (`chat_completions` + `trace_receiver` enabled)  |
+| `scenarios.json`  | Two scenarios, one per tool                                       |
+| `package.json`    | Node.js dependencies (Mastra, OTel SDK, Zod)                      |

--- a/examples/integrations/mastra/README.md
+++ b/examples/integrations/mastra/README.md
@@ -24,7 +24,7 @@ A [Mastra](https://github.com/mastra-ai/mastra) agent running as a Node.js servi
    export OPENAI_API_KEY="<your-key>"
    ```
 
-If `gpt-4o` isn't available in your account, set `OPENAI_MODEL=<your-model>` before starting the server to override the agent's model. The simulator's own model (used for the simulated user and evaluation) is set separately by the top-level `model:` field in `config.yaml`.
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` before starting the server to override the agent's model. The simulator's own model (used for the simulated user and evaluation) is set separately by the top-level `model:` field in `config.yaml`.
 
 ## Run
 

--- a/examples/integrations/mastra/README.md
+++ b/examples/integrations/mastra/README.md
@@ -24,7 +24,7 @@ A [Mastra](https://github.com/mastra-ai/mastra) agent running as a Node.js servi
    export OPENAI_API_KEY="<your-key>"
    ```
 
-If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+If `gpt-4o` isn't available in your account, set `OPENAI_MODEL=<your-model>` before starting the server to override the agent's model. The simulator's own model (used for the simulated user and evaluation) is set separately by the top-level `model:` field in `config.yaml`.
 
 ## Run
 

--- a/examples/integrations/mastra/agent_server.ts
+++ b/examples/integrations/mastra/agent_server.ts
@@ -1,59 +1,188 @@
 // SPDX-License-Identifier: Apache-2.0
-// Mastra integration for ArkSim.
+// Mastra integration for arksim.
 //
-// Install: npm install @mastra/core @ai-sdk/openai hono @hono/node-server
+// Install: npm install
 // Auth:    export OPENAI_API_KEY="<your-key>"
+//
+// Exposes a Mastra Agent with two mock tools (lookup_order, book_table)
+// over an OpenAI-compatible chat completions endpoint. Each tool wraps
+// its body in an OpenTelemetry span following the OTel GenAI semantic
+// conventions; spans are exported via OTLP/HTTP to arksim's trace
+// receiver on 127.0.0.1:4318. The Python wrapper passes
+// metadata.chat_id and metadata.turn_id in every request; this process
+// threads them through an AsyncLocalStorage and a custom span
+// processor stamps them on every span as arksim.conversation_id and
+// arksim.turn_id so the receiver can route tool calls to the right turn.
+//
+// Note: Mastra is migrating away from OpenTelemetry toward a proprietary
+// AI Tracing system (see Mastra GitHub issue #8577). This example uses
+// the stdlib OTel path (@opentelemetry/sdk-node) directly, which works
+// today and is independent of Mastra's tracing internals.
 
+import { AsyncLocalStorage } from "node:async_hooks";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import {
+  BatchSpanProcessor,
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { Context } from "@opentelemetry/api";
+import { Resource } from "@opentelemetry/resources";
+import { trace } from "@opentelemetry/api";
 import { Mastra } from "@mastra/core";
 import { Agent } from "@mastra/core/agent";
+import { createTool } from "@mastra/core/tools";
 import { openai } from "@ai-sdk/openai";
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
+import { z } from "zod";
+
+type Routing = { chatId: string; turnId?: number };
+const routingStore = new AsyncLocalStorage<Routing>();
+
+// Stamp arksim.conversation_id and arksim.turn_id on every span from
+// the routing AsyncLocalStorage. Mirrors the Python contextvar-driven
+// processor used by the autogen and pydantic-ai examples.
+class ArksimRoutingProcessor implements SpanProcessor {
+  onStart(span: Span, _parentContext: Context): void {
+    const routing = routingStore.getStore();
+    if (!routing) return;
+    span.setAttribute("arksim.conversation_id", routing.chatId);
+    if (routing.turnId !== undefined) {
+      span.setAttribute("arksim.turn_id", routing.turnId);
+    }
+  }
+  onEnd(_span: ReadableSpan): void {}
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}
+
+// Start the OTel SDK before any spans are produced.
+const otelSdk = new NodeSDK({
+  resource: new Resource({
+    "service.name": "arksim-mastra-example",
+  }),
+  spanProcessors: [
+    new ArksimRoutingProcessor(),
+    new BatchSpanProcessor(
+      new OTLPTraceExporter({
+        url: "http://127.0.0.1:4318/v1/traces",
+      }),
+    ),
+  ],
+});
+otelSdk.start();
+
+const tracer = trace.getTracer("arksim.examples.mastra");
+
+const lookup_order = createTool({
+  id: "lookup_order",
+  description: "Look up an order by ID and return its status.",
+  inputSchema: z.object({
+    order_id: z.string().describe("The order identifier to look up."),
+  }),
+  outputSchema: z.string(),
+  execute: async ({ context }) => {
+    const args = { order_id: context.order_id };
+    return tracer.startActiveSpan("execute_tool lookup_order", (span) => {
+      try {
+        span.setAttribute("gen_ai.tool.name", "lookup_order");
+        span.setAttribute("gen_ai.tool.call.arguments", JSON.stringify(args));
+        const result = `Order ${context.order_id}: shipped, arrives Tuesday.`;
+        span.setAttribute("gen_ai.tool.call.result", result);
+        return result;
+      } finally {
+        span.end();
+      }
+    });
+  },
+});
+
+const book_table = createTool({
+  id: "book_table",
+  description: "Book a restaurant table for the given party size and time.",
+  inputSchema: z.object({
+    party_size: z.number().int().describe("Number of people to seat."),
+    time: z.string().describe("Time to book for, for example '7pm'."),
+  }),
+  outputSchema: z.string(),
+  execute: async ({ context }) => {
+    const args = { party_size: context.party_size, time: context.time };
+    return tracer.startActiveSpan("execute_tool book_table", (span) => {
+      try {
+        span.setAttribute("gen_ai.tool.name", "book_table");
+        span.setAttribute("gen_ai.tool.call.arguments", JSON.stringify(args));
+        const result = `Booked table for ${context.party_size} at ${context.time}.`;
+        span.setAttribute("gen_ai.tool.call.result", result);
+        return result;
+      } finally {
+        span.end();
+      }
+    });
+  },
+});
 
 const agent = new Agent({
   id: "assistant",
   name: "assistant",
-  instructions: "You are a helpful assistant.",
+  instructions:
+    "You are a helpful assistant with access to two tools: " +
+    "lookup_order(order_id) and book_table(party_size, time). " +
+    "Call them when relevant to answer the user.",
   model: openai("gpt-4o"),
+  tools: { lookup_order, book_table },
 });
 
 const mastra = new Mastra({ agents: { assistant: agent } });
 
-// In-memory session storage for multi-turn conversations
+// In-memory session storage for multi-turn conversations.
 const sessions: Record<string, Array<{ role: string; content: string }>> = {};
 
 const app = new Hono();
 
-// OpenAI-compatible chat completions endpoint
+// OpenAI-compatible chat completions endpoint.
 app.post("/v1/chat/completions", async (c) => {
   const body = await c.req.json();
   const messages: Array<{ role: string; content: string }> = body.messages ?? [];
 
-  const sessionKey = body.session_id ?? "default";
-  if (!sessions[sessionKey]) {
-    sessions[sessionKey] = [];
+  // The Python wrapper passes metadata.chat_id and metadata.turn_id.
+  const md = body.metadata ?? {};
+  const chatId: string = md.chat_id ?? body.session_id ?? "default";
+  const turnId: number | undefined =
+    typeof md.turn_id === "number" ? md.turn_id : undefined;
+
+  if (!sessions[chatId]) {
+    sessions[chatId] = [];
   }
-  sessions[sessionKey].push(...messages);
+  sessions[chatId].push(...messages);
 
-  const assistant = mastra.getAgent("assistant");
-  // Use generateLegacy for AI SDK v4 model providers
-  const result = await assistant.generateLegacy(sessions[sessionKey]);
+  // Run the whole turn under the routing store so every emitted span
+  // (model, tool, etc.) carries arksim.conversation_id and arksim.turn_id.
+  return routingStore.run({ chatId, turnId }, async () => {
+    const assistant = mastra.getAgent("assistant");
+    // Use generateLegacy for AI SDK v4 model providers.
+    const result = await assistant.generateLegacy(sessions[chatId]);
 
-  const content =
-    typeof result.text === "string" ? result.text : JSON.stringify(result.text);
+    const content =
+      typeof result.text === "string"
+        ? result.text
+        : JSON.stringify(result.text);
 
-  sessions[sessionKey].push({ role: "assistant", content });
+    sessions[chatId].push({ role: "assistant", content });
 
-  return c.json({
-    id: `chatcmpl-${Date.now()}`,
-    object: "chat.completion",
-    choices: [
-      {
-        index: 0,
-        message: { role: "assistant", content },
-        finish_reason: "stop",
-      },
-    ],
+    return c.json({
+      id: `chatcmpl-${Date.now()}`,
+      object: "chat.completion",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content },
+          finish_reason: "stop",
+        },
+      ],
+    });
   });
 });
 
@@ -62,3 +191,10 @@ app.get("/health", (c) => c.json({ status: "ok" }));
 const port = parseInt(process.env.PORT ?? "8888", 10);
 console.log(`Mastra agent server listening on port ${port}`);
 serve({ fetch: app.fetch, port });
+
+const shutdown = async () => {
+  await otelSdk.shutdown();
+  process.exit(0);
+};
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/examples/integrations/mastra/agent_server.ts
+++ b/examples/integrations/mastra/agent_server.ts
@@ -131,7 +131,7 @@ const agent = new Agent({
     "You are a helpful assistant with access to two tools: " +
     "lookup_order(order_id) and book_table(party_size, time). " +
     "Call them when relevant to answer the user.",
-  model: openai(process.env.OPENAI_MODEL ?? "gpt-4o"),
+  model: openai(process.env.OPENAI_MODEL ?? "gpt-5.1"),
   tools: { lookup_order, book_table },
 });
 

--- a/examples/integrations/mastra/agent_server.ts
+++ b/examples/integrations/mastra/agent_server.ts
@@ -131,7 +131,7 @@ const agent = new Agent({
     "You are a helpful assistant with access to two tools: " +
     "lookup_order(order_id) and book_table(party_size, time). " +
     "Call them when relevant to answer the user.",
-  model: openai("gpt-4o"),
+  model: openai(process.env.OPENAI_MODEL ?? "gpt-4o"),
   tools: { lookup_order, book_table },
 });
 

--- a/examples/integrations/mastra/config.yaml
+++ b/examples/integrations/mastra/config.yaml
@@ -16,6 +16,9 @@ agent_config:
     body:
       model: gpt-4o
       messages: []
+      # Forward chat_id and turn_id to the Mastra server so it can stamp
+      # arksim.conversation_id and arksim.turn_id on emitted OTel spans.
+      enable_metadata: true
 
 # ── SIMULATION SETTINGS ──────────────────────────────────────────────────────
 
@@ -44,3 +47,9 @@ provider: openai
 
 # Workers for parallel processing
 num_workers: 50
+
+# ── TRACE RECEIVER ───────────────────────────────────────────────────────────
+# Receives OTel spans emitted by the Mastra server's tool wrappers.
+trace_receiver:
+  enabled: true
+  wait_timeout: 5

--- a/examples/integrations/mastra/package.json
+++ b/examples/integrations/mastra/package.json
@@ -8,8 +8,14 @@
   "dependencies": {
     "@mastra/core": "^1.0",
     "@ai-sdk/openai": "^1.0",
+    "@opentelemetry/api": "^1.9",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.55",
+    "@opentelemetry/resources": "^1.30",
+    "@opentelemetry/sdk-node": "^0.55",
+    "@opentelemetry/sdk-trace-base": "^1.30",
     "hono": "^4.0",
     "@hono/node-server": "^1.0",
-    "tsx": "^4.0"
+    "tsx": "^4.0",
+    "zod": "^3.23"
   }
 }

--- a/examples/integrations/mastra/scenarios.json
+++ b/examples/integrations/mastra/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/openai-agents-sdk/README.md
+++ b/examples/integrations/openai-agents-sdk/README.md
@@ -22,6 +22,8 @@ An [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) `Agent` w
    export OPENAI_API_KEY="<your-key>"
    ```
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 From this example directory:

--- a/examples/integrations/openai-agents-sdk/README.md
+++ b/examples/integrations/openai-agents-sdk/README.md
@@ -1,33 +1,65 @@
 # OpenAI Agents SDK Integration
 
-This example demonstrates how to connect an [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) agent to ArkSim using the custom agent connector.
+An [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) `Agent` with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimTracingProcessor` so every tool call is captured in `simulation.json`.
 
-## Prerequisites
+## Setup
 
-1. Install the OpenAI Agents SDK:
+1. Install arksim with the OTel extra (required for the trace receiver this example uses):
+
+   ```bash
+   pip install 'arksim[otel]'
+   ```
+
+2. Install the OpenAI Agents SDK:
 
    ```bash
    pip install openai-agents
    ```
 
-2. Set your API key:
+3. Set your API key:
 
    ```bash
    export OPENAI_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-From this example directory, run:
+From this example directory:
 
 ```bash
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+`ArksimTracingProcessor` implements the OpenAI Agents SDK's `TracingProcessor` interface. The agent registers one instance at module load via `add_trace_processor(ArksimTracingProcessor())`; the simulator caches modules by file path so the registration runs exactly once. Each tool is wrapped with `@function_tool` so the SDK emits a `FunctionSpanData` entry when it fires. Before each agent turn the simulator binds `conversation_id`, `turn_id`, and the trace receiver into contextvars, so when the SDK calls `on_span_end` the processor reads that context, converts the span into a `ToolCall`, and injects it into the receiver's buffer. The captured calls land in the `tool_calls` field of every turn in `results/simulation/simulation.json`.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "openai_agents"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "openai_agents"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                         |
-| ------------------ | ----------------------------------- |
-| `custom_agent.py`  | OpenAI Agents SDK integration       |
-| `config.yaml`      | Simulator configuration             |
-| `scenarios.json`   | Simulation scenarios                |
+| File              | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `custom_agent.py` | OpenAI Agents SDK `Agent` + `ArksimTracingProcessor`     |
+| `tools.py`        | `lookup_order` and `book_table` mock tools               |
+| `config.yaml`     | Simulator configuration with `trace_receiver` enabled    |
+| `scenarios.json`  | Two scenarios, one per tool                              |

--- a/examples/integrations/openai-agents-sdk/config.yaml
+++ b/examples/integrations/openai-agents-sdk/config.yaml
@@ -36,3 +36,10 @@ provider: openai
 
 # Workers for parallel processing
 num_workers: 50
+
+# ── TRACE RECEIVER ───────────────────────────────────────────────────────────
+# Activates the in-process trace receiver so ArksimTracingProcessor can land
+# OpenAI Agents SDK function spans on the active turn.
+trace_receiver:
+  enabled: true
+  wait_timeout: 5

--- a/examples/integrations/openai-agents-sdk/custom_agent.py
+++ b/examples/integrations/openai-agents-sdk/custom_agent.py
@@ -1,8 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-"""OpenAI Agents SDK integration for ArkSim.
+"""OpenAI Agents SDK integration for arksim.
 
-Install: pip install openai-agents
-Auth:    export OPENAI_API_KEY="<your-key>"
+Install:
+    pip install 'arksim[otel]'
+    pip install openai-agents
+Auth:
+    export OPENAI_API_KEY="<your-key>"
+
+Wires two mock tools (``lookup_order``, ``book_table``) into an OpenAI
+Agents SDK ``Agent`` and registers ``ArksimTracingProcessor`` so every
+``FunctionSpanData`` the SDK emits lands as a ``ToolCall`` on the right
+turn in ``results/simulation/simulation.json``.
 """
 
 from __future__ import annotations
@@ -10,9 +18,16 @@ from __future__ import annotations
 import uuid
 
 from agents import Agent, Runner, RunResult
+from agents.tracing import add_trace_processor
+from tools import book_table, lookup_order
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.openai import ArksimTracingProcessor
+
+# Register once at module load; the simulator caches modules by file path
+# so this runs exactly once regardless of how many conversations start.
+add_trace_processor(ArksimTracingProcessor())
 
 
 class OpenAIAgentsSDKAgent(BaseAgent):
@@ -21,7 +36,12 @@ class OpenAIAgentsSDKAgent(BaseAgent):
         self._chat_id = str(uuid.uuid4())
         self._agent = Agent(
             name="assistant",
-            instructions="You are a helpful assistant.",
+            instructions=(
+                "You are a helpful assistant with access to two tools: "
+                "lookup_order(order_id) and book_table(party_size, time). "
+                "Call them when relevant to answer the user."
+            ),
+            tools=[lookup_order, book_table],
         )
         self._last_result: RunResult | None = None
 

--- a/examples/integrations/openai-agents-sdk/custom_agent.py
+++ b/examples/integrations/openai-agents-sdk/custom_agent.py
@@ -15,6 +15,7 @@ turn in ``results/simulation/simulation.json``.
 
 from __future__ import annotations
 
+import os
 import uuid
 
 from agents import Agent, Runner, RunResult
@@ -41,6 +42,7 @@ class OpenAIAgentsSDKAgent(BaseAgent):
                 "lookup_order(order_id) and book_table(party_size, time). "
                 "Call them when relevant to answer the user."
             ),
+            model=os.environ.get("OPENAI_MODEL", "gpt-5.1"),
             tools=[lookup_order, book_table],
         )
         self._last_result: RunResult | None = None

--- a/examples/integrations/openai-agents-sdk/scenarios.json
+++ b/examples/integrations/openai-agents-sdk/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/openai-agents-sdk/tools.py
+++ b/examples/integrations/openai-agents-sdk/tools.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the OpenAI Agents SDK integration example.
+
+Both tools are wrapped with ``@function_tool`` so the SDK emits
+``FunctionSpanData`` entries via its tracing pipeline; ``ArksimTracingProcessor``
+turns each completed span into a ``ToolCall`` on the active turn. Outputs are
+deterministic so the example runs offline (apart from the LLM call) and
+produces predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+from agents import function_tool
+
+
+@function_tool
+def lookup_order(order_id: str) -> str:
+    """Look up an order by ID and return its status."""
+    return f"Order {order_id}: shipped, arrives Tuesday."
+
+
+@function_tool
+def book_table(party_size: int, time: str) -> str:
+    """Book a restaurant table for the given party size and time."""
+    return f"Booked table for {party_size} at {time}."

--- a/examples/integrations/pydantic-ai/README.md
+++ b/examples/integrations/pydantic-ai/README.md
@@ -4,14 +4,20 @@ A [Pydantic AI](https://github.com/pydantic/pydantic-ai) `Agent` with two mock t
 
 ## Setup
 
-1. Install Pydantic AI and the OTel exporter:
+1. Install arksim with the OTel extra (required for the trace receiver this example uses):
+
+   ```bash
+   pip install 'arksim[otel]'
+   ```
+
+2. Install Pydantic AI and the OTel exporter:
 
    ```bash
    pip install pydantic-ai
    pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
    ```
 
-2. Set your API key:
+3. Set your API key:
 
    ```bash
    export OPENAI_API_KEY="<your-key>"

--- a/examples/integrations/pydantic-ai/README.md
+++ b/examples/integrations/pydantic-ai/README.md
@@ -23,6 +23,8 @@ A [Pydantic AI](https://github.com/pydantic/pydantic-ai) `Agent` with two mock t
    export OPENAI_API_KEY="<your-key>"
    ```
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 From this example directory:

--- a/examples/integrations/pydantic-ai/README.md
+++ b/examples/integrations/pydantic-ai/README.md
@@ -1,13 +1,14 @@
 # Pydantic AI Integration
 
-This example demonstrates how to connect a [Pydantic AI](https://github.com/pydantic/pydantic-ai) agent to ArkSim using the custom agent connector.
+A [Pydantic AI](https://github.com/pydantic/pydantic-ai) `Agent` with two mock tools (`lookup_order`, `book_table`) whose calls are exported as OpenTelemetry spans and captured by arksim's built-in OTLP receiver, landing in `simulation.json`.
 
-## Prerequisites
+## Setup
 
-1. Install Pydantic AI:
+1. Install Pydantic AI and the OTel exporter:
 
    ```bash
    pip install pydantic-ai
+   pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
    ```
 
 2. Set your API key:
@@ -16,18 +17,44 @@ This example demonstrates how to connect a [Pydantic AI](https://github.com/pyda
    export OPENAI_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-From this example directory, run:
+From this example directory:
 
 ```bash
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+Pydantic AI emits `gen_ai.tool.*` spans natively for every tool invocation when the `Agent` is constructed with `instrument=True`. The agent builds a `TracerProvider` that exports through `OTLPSpanExporter` to `127.0.0.1:4318/v1/traces` and passes it to `InstrumentationSettings(tracer_provider=...)` so Pydantic AI routes all its tool and model spans through that provider. A small `_ArksimRoutingProcessor` reads `arksim.turn_id` from arksim's contextvar and stamps it on every span; `arksim.conversation_id` is pinned to the agent's `chat_id` via a `Resource` attribute. Arksim's OTLP receiver listens on `127.0.0.1:4318` whenever `trace_receiver.enabled: true` is set in `config.yaml`, decodes the spans, picks the routing attributes, and lands each tool span as a `ToolCall` on the correct turn in `results/simulation/simulation.json`. The same path works for any OTel exporter you wire up (Logfire, stdlib OTLP, etc.); the example uses the stdlib exporter to avoid an extra dependency.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "otel_trace"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "otel_trace"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                         |
-| ------------------ | ----------------------------------- |
-| `custom_agent.py`  | Pydantic AI integration             |
-| `config.yaml`      | Simulator configuration             |
-| `scenarios.json`   | Simulation scenarios                |
+| File              | Description                                                  |
+| ----------------- | ------------------------------------------------------------ |
+| `custom_agent.py` | Pydantic AI `Agent` + OTLP tracer provider                   |
+| `tools.py`        | `lookup_order` and `book_table` plain Python callables       |
+| `config.yaml`     | Simulator configuration with `trace_receiver` enabled        |
+| `scenarios.json`  | Two scenarios, one per tool                                  |

--- a/examples/integrations/pydantic-ai/config.yaml
+++ b/examples/integrations/pydantic-ai/config.yaml
@@ -36,3 +36,9 @@ provider: openai
 
 # Workers for parallel processing
 num_workers: 50
+
+# ── TRACE RECEIVER ───────────────────────────────────────────────────────────
+# Receives OTel spans emitted by Pydantic AI's built-in instrumentation.
+trace_receiver:
+  enabled: true
+  wait_timeout: 5

--- a/examples/integrations/pydantic-ai/custom_agent.py
+++ b/examples/integrations/pydantic-ai/custom_agent.py
@@ -17,6 +17,7 @@ receiver can route tool calls to the right turn.
 
 from __future__ import annotations
 
+import os
 import uuid
 
 from opentelemetry.context import Context
@@ -33,6 +34,7 @@ from arksim.simulation_engine.agent.base import BaseAgent
 from arksim.tracing.context import trace_turn_id
 
 _OTLP_ENDPOINT = "http://127.0.0.1:4318/v1/traces"
+_MODEL = os.environ.get("OPENAI_MODEL", "gpt-5.1")
 
 
 class _ArksimRoutingProcessor(SpanProcessor):
@@ -77,7 +79,7 @@ class PydanticAIAgent(BaseAgent):
         )
 
         self._agent = Agent(
-            "openai:gpt-4o",
+            f"openai:{_MODEL}",
             system_prompt=(
                 "You are a helpful assistant with access to two tools: "
                 "lookup_order(order_id) and book_table(party_size, time). "

--- a/examples/integrations/pydantic-ai/custom_agent.py
+++ b/examples/integrations/pydantic-ai/custom_agent.py
@@ -1,34 +1,90 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Pydantic AI integration for ArkSim.
+"""Pydantic AI integration for arksim.
 
-Install: pip install pydantic-ai
-Auth:    export OPENAI_API_KEY="<your-key>"
+Install:
+    pip install pydantic-ai
+    pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+Auth:
+    export OPENAI_API_KEY="<your-key>"
+
+Wires two mock tools (``lookup_order``, ``book_table``) into a Pydantic AI
+``Agent`` and exports OTel spans to arksim's OTLP/HTTP trace receiver.
+Pydantic AI emits ``gen_ai.tool.*`` spans natively for every tool call
+when ``instrument=True``; a custom span processor stamps
+``arksim.conversation_id`` and ``arksim.turn_id`` on every span so the
+receiver can route tool calls to the right turn.
 """
 
 from __future__ import annotations
 
 import uuid
 
-from pydantic_ai import Agent
+from opentelemetry.context import Context
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import Span, SpanProcessor, TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from pydantic_ai import Agent, InstrumentationSettings
 from pydantic_ai.messages import ModelMessage
+from tools import book_table, lookup_order
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.context import trace_turn_id
+
+_OTLP_ENDPOINT = "http://127.0.0.1:4318/v1/traces"
+
+
+class _ArksimRoutingProcessor(SpanProcessor):
+    """Stamp ``arksim.turn_id`` on every span from the current contextvar."""
+
+    def on_start(self, span: Span, parent_context: Context | None = None) -> None:
+        turn_id = trace_turn_id.get()
+        if turn_id is not None:
+            span.set_attribute("arksim.turn_id", turn_id)
+
+    def on_end(self, span: Span) -> None:
+        return
+
+    def shutdown(self) -> None:
+        return
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
 
 
 class PydanticAIAgent(BaseAgent):
-    """Pydantic AI agent wrapper.
+    """Pydantic AI agent wrapper with tool calls captured via OTel.
 
-    Maintains conversation history via message_history parameter
-    and all_messages() to accumulate context across turns.
+    Maintains conversation history via the ``message_history`` parameter
+    and ``all_messages()`` to accumulate context across turns.
     """
 
     def __init__(self, agent_config: AgentConfig) -> None:
         super().__init__(agent_config)
         self._chat_id = str(uuid.uuid4())
+
+        resource = Resource.create(
+            {
+                "service.name": "arksim-pydantic-ai-example",
+                "arksim.conversation_id": self._chat_id,
+            }
+        )
+        self._provider = TracerProvider(resource=resource)
+        self._provider.add_span_processor(_ArksimRoutingProcessor())
+        self._provider.add_span_processor(
+            BatchSpanProcessor(OTLPSpanExporter(endpoint=_OTLP_ENDPOINT))
+        )
+
         self._agent = Agent(
             "openai:gpt-4o",
-            system_prompt="You are a helpful assistant.",
+            system_prompt=(
+                "You are a helpful assistant with access to two tools: "
+                "lookup_order(order_id) and book_table(party_size, time). "
+                "Call them when relevant to answer the user."
+            ),
+            tools=[lookup_order, book_table],
+            instrument=InstrumentationSettings(tracer_provider=self._provider),
         )
         self._history: list[ModelMessage] = []
 
@@ -41,4 +97,8 @@ class PydanticAIAgent(BaseAgent):
             message_history=self._history,
         )
         self._history = result.all_messages()
+        self._provider.force_flush()
         return result.output
+
+    async def close(self) -> None:
+        self._provider.shutdown()

--- a/examples/integrations/pydantic-ai/scenarios.json
+++ b/examples/integrations/pydantic-ai/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/pydantic-ai/tools.py
+++ b/examples/integrations/pydantic-ai/tools.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the Pydantic AI integration example.
+
+Pydantic AI emits ``gen_ai.tool.*`` spans for every tool invocation when
+the ``Agent`` is constructed with ``instrument=True``. Outputs are
+deterministic so the example runs offline (apart from the LLM call) and
+produces predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+
+def lookup_order(order_id: str) -> str:
+    """Look up an order by ID and return its status."""
+    return f"Order {order_id}: shipped, arrives Tuesday."
+
+
+def book_table(party_size: int, time: str) -> str:
+    """Book a restaurant table for the given party size and time."""
+    return f"Booked table for {party_size} at {time}."

--- a/examples/integrations/rasa/README.md
+++ b/examples/integrations/rasa/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to simulate and evaluate a [Rasa Pro](https://rasa.com/) assistant built with [CALM](https://rasa.com/docs/pro/), Rasa's LLM-powered dialogue engine. CALM replaces traditional NLU pipelines with flow-based conversation management, where an LLM routes user messages to the right flow based on natural language descriptions.
 
-The integration connects to Rasa via its REST webhook channel. Point ArkSim at a running Rasa server, define your scenarios, and get a full evaluation report.
+The integration connects to Rasa via its REST webhook channel. Point arksim at a running Rasa server, define your scenarios, and get a full evaluation report. Each turn also pulls the Rasa conversation tracker so that custom action invocations surface in `simulation.json` as `ToolCall` instances.
 
 ## What This Example Covers
 
@@ -68,6 +68,25 @@ arksim simulate-evaluate config.yaml
 ```
 
 By default the agent connects to `http://localhost:5005/webhooks/rest/webhook`. Override with the `RASA_ENDPOINT` environment variable if your server runs elsewhere.
+
+## How it works
+
+Rasa's REST channel returns only bot replies, not the actions that ran behind the scenes. To capture custom actions as `ToolCall` instances, the wrapper in `custom_agent.py` does two HTTP calls per turn: first it POSTs the user message to `/webhooks/rest/webhook` and collects the bot replies, then it GETs `/conversations/{sender_id}/tracker` and walks the events list. Each `action` event whose name is not in the built-in set (`action_listen`, `action_session_start`, and friends) becomes a `ToolCall` tagged `source="rasa"`. The wrapper pairs each action with the slot events that fire before the next action; those slot sets are how Rasa custom actions surface their results, so we capture them as the tool's `arguments` (and `result`, if a slot name contains "status" or "result"). A monotonic cutoff timestamp ensures each turn only emits events freshly produced during that turn.
+
+## Expected output
+
+For the order status flow, a turn that runs `action_check_order_status` lands in `simulation.json` as:
+
+```json
+"tool_calls": [
+  {
+    "name": "action_check_order_status",
+    "arguments": {"order_id": "ORD-001", "order_status": "Shipped - in transit, arriving in 2-3 business days"},
+    "result": "Shipped - in transit, arriving in 2-3 business days",
+    "source": "rasa"
+  }
+]
+```
 
 ## Files
 

--- a/examples/integrations/rasa/custom_agent.py
+++ b/examples/integrations/rasa/custom_agent.py
@@ -1,7 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Rasa integration for ArkSim.
+"""Rasa integration for arksim.
 
-Requires a running Rasa server with the REST channel enabled.
+Drives a running Rasa server through the REST channel and surfaces any
+custom actions Rasa executed as ``ToolCall`` instances on the returned
+``AgentResponse``.
+
+The REST webhook only returns bot replies (text/buttons/etc.), not the
+underlying action invocations. To capture those we hit
+``/conversations/{sender_id}/tracker`` after each message and extract
+the ``action`` events Rasa logged during that turn, filtering out the
+built-in housekeeping actions (``action_listen``, ``action_session_*``,
+etc.) so only meaningful custom actions reach ``simulation.json``.
+
 Start Rasa:  rasa run --enable-api --cors "*"
 Endpoint:    RASA_ENDPOINT env var or http://localhost:5005/webhooks/rest/webhook
 """
@@ -11,35 +21,151 @@ from __future__ import annotations
 import logging
 import os
 import uuid
+from typing import Any
 
 import httpx
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.simulation_engine.tool_types import (
+    AgentResponse,
+    ToolCall,
+    ToolCallSource,
+)
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_ENDPOINT = "http://localhost:5005/webhooks/rest/webhook"
 
+# Built-in Rasa actions that fire on every turn or session boundary.
+# Filtering these out keeps ``tool_calls`` focused on meaningful custom
+# actions the assistant invoked.
+_BUILTIN_ACTIONS: frozenset[str] = frozenset(
+    {
+        "action_listen",
+        "action_session_start",
+        "action_restart",
+        "action_default_fallback",
+        "action_deactivate_loop",
+        "action_revert_fallback_events",
+        "action_default_ask_affirmation",
+        "action_default_ask_rephrase",
+        "action_back",
+        "action_two_stage_fallback",
+        "action_extract_slots",
+    }
+)
+
+
+def _server_root(webhook_endpoint: str) -> str:
+    """Derive the Rasa server root from the REST webhook URL.
+
+    The tracker endpoint lives at the server root, not under
+    ``/webhooks/rest/webhook``.
+    """
+    marker = "/webhooks/"
+    idx = webhook_endpoint.find(marker)
+    if idx >= 0:
+        return webhook_endpoint[:idx]
+    return webhook_endpoint.rstrip("/")
+
+
+def _extract_tool_calls(
+    tracker: dict[str, Any], cutoff_timestamp: float
+) -> list[ToolCall]:
+    """Build ``ToolCall`` instances from Rasa tracker events after ``cutoff``.
+
+    Pairs each ``action`` event with the slot events that fire before the
+    next action; those slot sets are how Rasa custom actions surface
+    their results, so we capture them as the tool's arguments/result.
+    """
+    events = tracker.get("events") or []
+    if not isinstance(events, list):
+        return []
+
+    # Drop events that predate this turn; the tracker accumulates across
+    # the whole conversation but we only want the slice this turn
+    # produced.
+    fresh = [
+        e
+        for e in events
+        if isinstance(e, dict) and (e.get("timestamp") or 0) > cutoff_timestamp
+    ]
+
+    tool_calls: list[ToolCall] = []
+    current_action: dict[str, Any] | None = None
+    pending_slots: dict[str, Any] = {}
+
+    def _flush() -> None:
+        if current_action is None:
+            return
+        name = current_action.get("name") or ""
+        if not name or name in _BUILTIN_ACTIONS:
+            return
+        result = pending_slots.pop("__result__", None)
+        tool_calls.append(
+            ToolCall(
+                id=str(current_action.get("action_id") or uuid.uuid4()),
+                name=str(name),
+                arguments=dict(pending_slots),
+                result=str(result) if result is not None else None,
+                source=ToolCallSource.RASA,
+            )
+        )
+
+    for event in fresh:
+        kind = event.get("event")
+        if kind == "action":
+            _flush()
+            current_action = event
+            pending_slots = {}
+        elif kind == "slot" and current_action is not None:
+            slot_name = event.get("name")
+            slot_value = event.get("value")
+            if slot_name:
+                pending_slots[str(slot_name)] = slot_value
+                # Heuristic: a slot whose name contains "status" or
+                # "result" is the action's payload; everything else is
+                # input the action consumed.
+                lowered = str(slot_name).lower()
+                if "status" in lowered or "result" in lowered:
+                    pending_slots["__result__"] = slot_value
+    _flush()
+    return tool_calls
+
 
 class RasaAgent(BaseAgent):
-    """Rasa agent wrapper using the REST webhook channel.
-
-    Sends messages to a running Rasa server over HTTP. Rasa tracks
-    conversation state per sender ID server-side, so no local history
-    is needed. Multiple response messages are joined into a single string.
-    """
+    """Rasa wrapper that captures custom actions via the tracker endpoint."""
 
     def __init__(self, agent_config: AgentConfig) -> None:
         super().__init__(agent_config)
         self._chat_id = str(uuid.uuid4())
         self._endpoint = os.environ.get("RASA_ENDPOINT", _DEFAULT_ENDPOINT)
+        self._tracker_url = (
+            f"{_server_root(self._endpoint)}/conversations/{self._chat_id}/tracker"
+        )
         self._client = httpx.AsyncClient(timeout=60)
+        # Track the latest event timestamp we have already consumed so a
+        # subsequent turn only surfaces newly emitted actions.
+        self._cutoff_timestamp: float = 0.0
 
     async def get_chat_id(self) -> str:
         return self._chat_id
 
-    async def execute(self, user_query: str, **kwargs: object) -> str:
+    async def _fetch_tracker(self) -> dict[str, Any] | None:
+        try:
+            resp = await self._client.get(self._tracker_url)
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            # Tracker fetch is best-effort: warn but keep the
+            # conversation alive so the example still produces a
+            # transcript.
+            logger.warning("Failed to fetch Rasa tracker: %s", exc)
+            return None
+        data = resp.json()
+        return data if isinstance(data, dict) else None
+
+    async def execute(self, user_query: str, **kwargs: object) -> AgentResponse:
         try:
             response = await self._client.post(
                 self._endpoint,
@@ -53,11 +179,24 @@ class RasaAgent(BaseAgent):
             raise RuntimeError(msg) from exc
 
         messages = response.json()
-        texts = [m["text"] for m in messages if "text" in m]
+        texts = [m["text"] for m in messages if isinstance(m, dict) and "text" in m]
+        content = "\n".join(texts) if texts else ""
         if not texts:
             logger.warning("Rasa returned no text messages for query: %s", user_query)
-            return ""
-        return "\n".join(texts)
+
+        tracker = await self._fetch_tracker()
+        if tracker is None:
+            return AgentResponse(content=content, tool_calls=[])
+
+        tool_calls = _extract_tool_calls(tracker, self._cutoff_timestamp)
+        # Advance the cutoff so the next turn only sees newly emitted
+        # events. ``latest_event_time`` is the timestamp of the most
+        # recent tracker event; Rasa updates it monotonically.
+        latest = tracker.get("latest_event_time")
+        if isinstance(latest, int | float):
+            self._cutoff_timestamp = float(latest)
+
+        return AgentResponse(content=content, tool_calls=tool_calls)
 
     async def close(self) -> None:
         await self._client.aclose()

--- a/examples/integrations/smolagents/README.md
+++ b/examples/integrations/smolagents/README.md
@@ -16,6 +16,8 @@ A [Smolagents](https://github.com/huggingface/smolagents) (Hugging Face) `CodeAg
    export OPENAI_API_KEY="<your-key>"
    ```
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 From this example directory:

--- a/examples/integrations/smolagents/README.md
+++ b/examples/integrations/smolagents/README.md
@@ -1,13 +1,13 @@
 # Smolagents Integration
 
-This example demonstrates how to connect a [Smolagents](https://github.com/huggingface/smolagents) (Hugging Face) agent to ArkSim using the custom agent connector.
+A [Smolagents](https://github.com/huggingface/smolagents) (Hugging Face) `CodeAgent` with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimSmolagentsCallback` so every tool call is captured in `simulation.json`.
 
-## Prerequisites
+## Setup
 
-1. Install Smolagents:
+1. Install arksim with the Smolagents extra:
 
    ```bash
-   pip install smolagents
+   pip install 'arksim[smolagents]'
    ```
 
 2. Set your API key:
@@ -16,18 +16,44 @@ This example demonstrates how to connect a [Smolagents](https://github.com/huggi
    export OPENAI_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-From this example directory, run:
+From this example directory:
 
 ```bash
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+`ArksimSmolagentsCallback` is a smolagents step callback. The agent registers one instance via `CodeAgent(step_callbacks=[self._callback])`, and smolagents invokes the callback after each `ActionStep`, where the tool calls live. Before each agent turn the simulator binds `conversation_id`, `turn_id`, and the trace receiver into contextvars, so when smolagents fires the callback the recorded tool calls land in the `tool_calls` field of every turn in `results/simulation/simulation.json`. Other step types (`PlanningStep`, `TaskStep`, `FinalAnswerStep`, `SystemPromptStep`) are ignored.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "smolagents"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "smolagents"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                         |
-| ------------------ | ----------------------------------- |
-| `custom_agent.py`  | Smolagents integration              |
-| `config.yaml`      | Simulator configuration             |
-| `scenarios.json`   | Simulation scenarios                |
+| File              | Description                                         |
+| ----------------- | --------------------------------------------------- |
+| `custom_agent.py` | Smolagents `CodeAgent` + `ArksimSmolagentsCallback` |
+| `tools.py`        | `lookup_order` and `book_table` mock tools          |
+| `config.yaml`     | Simulator configuration                             |
+| `scenarios.json`  | Two scenarios, one per tool                         |

--- a/examples/integrations/smolagents/custom_agent.py
+++ b/examples/integrations/smolagents/custom_agent.py
@@ -1,8 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Smolagents (Hugging Face) integration for ArkSim.
+"""Smolagents (Hugging Face) integration for arksim.
 
-Install: pip install smolagents
-Auth:    export OPENAI_API_KEY="<your-key>"
+Install:
+    pip install 'arksim[smolagents]'
+Auth:
+    export OPENAI_API_KEY="<your-key>"
+
+Wires arksim's Smolagents tracing adapter into a ``CodeAgent`` with two
+mock tools (lookup_order, book_table). ``ArksimSmolagentsCallback`` is
+registered via ``step_callbacks=[...]`` and emits one ``ToolCall`` per
+``ActionStep``. Running ``arksim simulate-evaluate`` produces a
+simulation.json whose ``tool_calls`` field is populated by the captured
+invocations.
 """
 
 from __future__ import annotations
@@ -12,27 +21,34 @@ import os
 import uuid
 
 from smolagents import CodeAgent, OpenAIServerModel
+from tools import book_table, lookup_order
 
 from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.integrations.smolagents import ArksimSmolagentsCallback
 
 
 class SmolagentsAgent(BaseAgent):
     """Smolagents agent wrapper.
 
-    Uses reset=False on run() to maintain conversation history
-    across turns internally.
+    Uses ``reset=False`` on ``run()`` after the first turn to maintain
+    conversation history across turns internally.
     """
 
     def __init__(self, agent_config: AgentConfig) -> None:
         super().__init__(agent_config)
         self._chat_id = str(uuid.uuid4())
+        self._callback = ArksimSmolagentsCallback()
         model = OpenAIServerModel(
             model_id="gpt-4o",
             api_base="https://api.openai.com/v1",
             api_key=os.environ["OPENAI_API_KEY"],
         )
-        self._agent = CodeAgent(tools=[], model=model)
+        self._agent = CodeAgent(
+            tools=[lookup_order, book_table],
+            model=model,
+            step_callbacks=[self._callback],
+        )
         self._first_turn = True
 
     async def get_chat_id(self) -> str:

--- a/examples/integrations/smolagents/custom_agent.py
+++ b/examples/integrations/smolagents/custom_agent.py
@@ -27,6 +27,8 @@ from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
 from arksim.tracing.integrations.smolagents import ArksimSmolagentsCallback
 
+_MODEL = os.environ.get("OPENAI_MODEL", "gpt-5.1")
+
 
 class SmolagentsAgent(BaseAgent):
     """Smolagents agent wrapper.
@@ -40,7 +42,7 @@ class SmolagentsAgent(BaseAgent):
         self._chat_id = str(uuid.uuid4())
         self._callback = ArksimSmolagentsCallback()
         model = OpenAIServerModel(
-            model_id="gpt-4o",
+            model_id=_MODEL,
             api_base="https://api.openai.com/v1",
             api_key=os.environ["OPENAI_API_KEY"],
         )

--- a/examples/integrations/smolagents/scenarios.json
+++ b/examples/integrations/smolagents/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/examples/integrations/smolagents/tools.py
+++ b/examples/integrations/smolagents/tools.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the Smolagents integration example.
+
+Both tools showcase tool-call capture by ``ArksimSmolagentsCallback``.
+They return deterministic strings so the example runs offline (apart
+from the LLM call) and produces predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+from smolagents import tool
+
+
+@tool
+def lookup_order(order_id: str) -> str:
+    """Look up an order by ID and return its status.
+
+    Args:
+        order_id: The order identifier to look up.
+    """
+    return f"Order {order_id}: shipped, arrives Tuesday."
+
+
+@tool
+def book_table(party_size: int, time: str) -> str:
+    """Book a restaurant table for the given party size and time.
+
+    Args:
+        party_size: Number of people to seat.
+        time: The time to book for, for example "7pm".
+    """
+    return f"Booked table for {party_size} at {time}."

--- a/examples/integrations/strands/README.md
+++ b/examples/integrations/strands/README.md
@@ -11,7 +11,7 @@ A Strands `Agent` with two mock tools (`lookup_order`, `book_table`), wired to a
    pip install 'strands-agents[openai]'
    ```
 
-   Strands defaults to AWS Bedrock. This example uses `OpenAIModel` so the wiring matches the rest of the integration examples (single `OPENAI_API_KEY` env var).
+   Strands defaults to AWS Bedrock. This example uses `OpenAIModel` so the wiring matches the rest of the integration examples (single `OPENAI_API_KEY` env var). Note: the quotes around `'strands-agents[openai]'` are required on zsh; the brackets are shell glob characters.
 
 2. Set your API key:
 

--- a/examples/integrations/strands/README.md
+++ b/examples/integrations/strands/README.md
@@ -1,0 +1,62 @@
+# Strands Agents Integration
+
+A Strands `Agent` with two mock tools (`lookup_order`, `book_table`), wired to arksim through `ArksimStrandsHookProvider` so every tool call is captured in `simulation.json`.
+
+## Setup
+
+1. Install arksim with the Strands extra plus the Strands OpenAI provider:
+
+   ```bash
+   pip install 'arksim[strands]'
+   pip install 'strands-agents[openai]'
+   ```
+
+   Strands defaults to AWS Bedrock. This example uses `OpenAIModel` so the wiring matches the rest of the integration examples (single `OPENAI_API_KEY` env var).
+
+2. Set your API key:
+
+   ```bash
+   export OPENAI_API_KEY="<your-key>"
+   ```
+
+## Run
+
+From this example directory:
+
+```bash
+arksim simulate-evaluate config.yaml
+```
+
+## How it works
+
+`ArksimStrandsHookProvider` implements the Strands `HookProvider` protocol and registers a callback on `AfterToolCallEvent`. The agent passes one provider instance via `hooks=[ArksimStrandsHookProvider()]` at construction. Before each agent turn the simulator binds `conversation_id`, `turn_id`, and the trace receiver into contextvars, so when Strands fires `AfterToolCallEvent` (with `tool_use["name"]`, `tool_use["toolUseId"]`, `tool_use["input"]`, and either `result` or `exception`) the provider emits a `ToolCall` record on the active turn. Successes carry the `result`, failures forward the exception type and message into `error`.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "strands"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "strands"
+  }
+]
+```
+
+## Files
+
+| File              | Description                                          |
+| ----------------- | ---------------------------------------------------- |
+| `custom_agent.py` | Strands `Agent` + `ArksimStrandsHookProvider`        |
+| `tools.py`        | `lookup_order` and `book_table` mock tools           |
+| `config.yaml`     | Simulator configuration                              |
+| `scenarios.json`  | Two scenarios, one per tool                          |

--- a/examples/integrations/strands/README.md
+++ b/examples/integrations/strands/README.md
@@ -19,6 +19,8 @@ A Strands `Agent` with two mock tools (`lookup_order`, `book_table`), wired to a
    export OPENAI_API_KEY="<your-key>"
    ```
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 From this example directory:

--- a/examples/integrations/strands/config.yaml
+++ b/examples/integrations/strands/config.yaml
@@ -1,0 +1,38 @@
+# Simulate + Evaluate Configuration File
+# Configuration for 'arksim simulate-evaluate' command
+
+# ── AGENT CONFIGURATION ────────────────────────────────────────────────────
+
+agent_config:
+  agent_type: custom
+  agent_name: strands
+  custom_config:
+    module_path: ./custom_agent.py
+
+# ── SIMULATION SETTINGS ──────────────────────────────────────────────────────
+
+# Path to the scenarios file
+scenario_file_path: ./scenarios.json
+
+# Number of conversations per scenario to generate
+num_conversations_per_scenario: 1
+
+# Maximum turns per conversation
+max_turns: 5
+
+# Output file path for simulation results
+output_file_path: ./results/simulation/simulation.json
+
+# Jinja template for the simulated user's system prompt
+simulated_user_prompt_template: null
+
+# ── SHARED SETTINGS ──────────────────────────────────────────────────────────
+
+# LLM model
+model: gpt-5.1
+
+# LLM provider
+provider: openai
+
+# Workers for parallel processing
+num_workers: 50

--- a/examples/integrations/strands/custom_agent.py
+++ b/examples/integrations/strands/custom_agent.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Strands Agents integration for arksim.
+
+Install:
+    pip install 'arksim[strands]'
+    pip install strands-agents[openai]
+Auth:
+    export OPENAI_API_KEY="<your-key>"
+
+Wires arksim's Strands tracing adapter into a Strands ``Agent`` with
+two mock tools (lookup_order, book_table). Running
+``arksim simulate-evaluate`` produces a simulation.json whose
+``tool_calls`` field is populated by the captured invocations.
+
+By default Strands routes through AWS Bedrock. This example uses the
+``OpenAIModel`` provider so the wiring matches the rest of the
+integration examples (single ``OPENAI_API_KEY`` env var).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from strands import Agent
+from strands.models.openai import OpenAIModel
+from tools import book_table, lookup_order
+
+from arksim.config import AgentConfig
+from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.tracing.integrations.strands import ArksimStrandsHookProvider
+
+
+class StrandsAgent(BaseAgent):
+    def __init__(self, agent_config: AgentConfig) -> None:
+        super().__init__(agent_config)
+        self._chat_id = str(uuid.uuid4())
+        self._agent = Agent(
+            model=OpenAIModel(model_id="gpt-5.1"),
+            tools=[lookup_order, book_table],
+            system_prompt="You are a helpful assistant.",
+            hooks=[ArksimStrandsHookProvider()],
+        )
+
+    async def get_chat_id(self) -> str:
+        return self._chat_id
+
+    async def execute(self, user_query: str, **kwargs: object) -> str:
+        result = await self._agent.invoke_async(user_query)
+        return str(result)

--- a/examples/integrations/strands/custom_agent.py
+++ b/examples/integrations/strands/custom_agent.py
@@ -19,6 +19,7 @@ integration examples (single ``OPENAI_API_KEY`` env var).
 
 from __future__ import annotations
 
+import os
 import uuid
 
 from strands import Agent
@@ -29,13 +30,15 @@ from arksim.config import AgentConfig
 from arksim.simulation_engine.agent.base import BaseAgent
 from arksim.tracing.integrations.strands import ArksimStrandsHookProvider
 
+_MODEL = os.environ.get("OPENAI_MODEL", "gpt-5.1")
+
 
 class StrandsAgent(BaseAgent):
     def __init__(self, agent_config: AgentConfig) -> None:
         super().__init__(agent_config)
         self._chat_id = str(uuid.uuid4())
         self._agent = Agent(
-            model=OpenAIModel(model_id="gpt-5.1"),
+            model=OpenAIModel(model_id=_MODEL),
             tools=[lookup_order, book_table],
             system_prompt="You are a helpful assistant.",
             hooks=[ArksimStrandsHookProvider()],

--- a/examples/integrations/strands/scenarios.json
+++ b/examples/integrations/strands/scenarios.json
@@ -1,0 +1,19 @@
+{
+    "schema_version": "v1",
+    "scenarios": [
+        {
+            "scenario_id": "order_status_lookup",
+            "user_id": "user_0001",
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
+        },
+        {
+            "scenario_id": "dinner_reservation",
+            "user_id": "user_0002",
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
+        }
+    ]
+}

--- a/examples/integrations/strands/tools.py
+++ b/examples/integrations/strands/tools.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standard mock tools for the Strands Agents integration example.
+
+Both tools showcase tool-call capture by ``ArksimStrandsHookProvider``.
+They return deterministic strings so the example runs offline (apart
+from the LLM call) and produces predictable evaluation results.
+"""
+
+from __future__ import annotations
+
+from strands.tools import tool
+
+
+@tool
+def lookup_order(order_id: str) -> str:
+    """Look up an order by ID and return its status."""
+    return f"Order {order_id}: shipped, arrives Tuesday."
+
+
+@tool
+def book_table(party_size: int, time: str) -> str:
+    """Book a restaurant table for the given party size and time."""
+    return f"Booked table for {party_size} at {time}."

--- a/examples/integrations/vercel-ai-sdk/README.md
+++ b/examples/integrations/vercel-ai-sdk/README.md
@@ -24,7 +24,7 @@ A [Vercel AI SDK](https://github.com/vercel/ai) agent running as a Node.js servi
    export OPENAI_API_KEY="<your-key>"
    ```
 
-If `gpt-4o` isn't available in your account, set `OPENAI_MODEL=<your-model>` before starting the server to override the agent's model. The simulator's own model (used for the simulated user and evaluation) is set separately by the top-level `model:` field in `config.yaml`.
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` before starting the server to override the agent's model. The simulator's own model (used for the simulated user and evaluation) is set separately by the top-level `model:` field in `config.yaml`.
 
 ## Run
 

--- a/examples/integrations/vercel-ai-sdk/README.md
+++ b/examples/integrations/vercel-ai-sdk/README.md
@@ -1,14 +1,16 @@
 # Vercel AI SDK Integration
 
-This example demonstrates how to connect a [Vercel AI SDK](https://github.com/vercel/ai) agent to ArkSim via an HTTP server exposing an OpenAI-compatible chat completions endpoint.
+A [Vercel AI SDK](https://github.com/vercel/ai) agent running as a Node.js service with two mock tools (`lookup_order`, `book_table`) whose calls are exported as OpenTelemetry spans and captured by arksim's built-in OTLP receiver, landing in `simulation.json`. arksim drives the agent via an OpenAI-compatible chat completions endpoint.
 
-## Prerequisites
+## Setup
 
-1. Install dependencies:
+1. Install Node dependencies:
 
    ```bash
    npm install
    ```
+
+   This installs `ai`, `@ai-sdk/openai`, `hono`, the OpenTelemetry SDK and OTLP exporter, and `zod`.
 
 2. Set your API key:
 
@@ -16,9 +18,9 @@ This example demonstrates how to connect a [Vercel AI SDK](https://github.com/ve
    export OPENAI_API_KEY="<your-key>"
    ```
 
-## Usage
+## Run
 
-Start the agent server:
+Start the Vercel AI SDK agent server in one terminal:
 
 ```bash
 npm start
@@ -30,11 +32,36 @@ In a separate terminal, run the simulation and evaluation:
 arksim simulate-evaluate config.yaml
 ```
 
+## How it works
+
+The Vercel AI SDK is TypeScript-only, so arksim drives it through its `chat_completions` agent connector: each turn becomes an HTTP POST to `http://localhost:8888/v1/chat/completions` carrying the conversation history plus a `metadata` block with `chat_id` and `turn_id` (`enable_metadata: true` in `config.yaml` switches on that forward). arksim's chat-completions response parser only reads the assistant text from `choices[0].message.content` and ignores any `tool_calls` in the body, so the server cannot surface tool calls that way. Instead, the server starts an OpenTelemetry SDK pointed at arksim's OTLP receiver (`127.0.0.1:4318/v1/traces`) and threads `chat_id` and `turn_id` through an `AsyncLocalStorage`. A custom `ArksimRoutingProcessor` reads that store and stamps `arksim.conversation_id` and `arksim.turn_id` on every span. Both tools are registered with `tool({ ... })` from the `ai` package and passed to `generateText` with `stopWhen: stepCountIs(5)` to allow multi-step tool use; their bodies are wrapped in `tracer.startActiveSpan("execute_tool ...")` with the OTel GenAI semantic conventions (`gen_ai.tool.name`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`). The receiver decodes the OTLP payload, routes by the two arksim attributes, and lands each tool span as a `ToolCall` on the correct turn in `results/simulation/simulation.json`.
+
+## Expected output
+
+After running the example, each turn that invoked a tool contains entries like this in `results/simulation/simulation.json`:
+
+```json
+"tool_calls": [
+  {
+    "name": "lookup_order",
+    "arguments": {"order_id": "ORD-1001"},
+    "result": "Order ORD-1001: shipped, arrives Tuesday.",
+    "source": "otel_trace"
+  },
+  {
+    "name": "book_table",
+    "arguments": {"party_size": 4, "time": "7pm"},
+    "result": "Booked table for 4 at 7pm.",
+    "source": "otel_trace"
+  }
+]
+```
+
 ## Files
 
-| File               | Description                                |
-| ------------------ | ------------------------------------------ |
-| `agent_server.ts`  | Vercel AI SDK agent as an HTTP server      |
-| `config.yaml`      | Simulator configuration (chat_completions) |
-| `scenarios.json`   | Simulation scenarios                       |
-| `package.json`     | Node.js dependencies                       |
+| File              | Description                                                       |
+| ----------------- | ----------------------------------------------------------------- |
+| `agent_server.ts` | Vercel AI SDK agent + OTLP exporter + tool wrappers               |
+| `config.yaml`     | Simulator config (`chat_completions` + `trace_receiver` enabled)  |
+| `scenarios.json`  | Two scenarios, one per tool                                       |
+| `package.json`    | Node.js dependencies (ai, OTel SDK, Zod)                          |

--- a/examples/integrations/vercel-ai-sdk/README.md
+++ b/examples/integrations/vercel-ai-sdk/README.md
@@ -24,7 +24,7 @@ A [Vercel AI SDK](https://github.com/vercel/ai) agent running as a Node.js servi
    export OPENAI_API_KEY="<your-key>"
    ```
 
-If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+If `gpt-4o` isn't available in your account, set `OPENAI_MODEL=<your-model>` before starting the server to override the agent's model. The simulator's own model (used for the simulated user and evaluation) is set separately by the top-level `model:` field in `config.yaml`.
 
 ## Run
 

--- a/examples/integrations/vercel-ai-sdk/README.md
+++ b/examples/integrations/vercel-ai-sdk/README.md
@@ -4,7 +4,13 @@ A [Vercel AI SDK](https://github.com/vercel/ai) agent running as a Node.js servi
 
 ## Setup
 
-1. Install Node dependencies:
+1. Install arksim with the OTel extra (required for the trace receiver this example uses):
+
+   ```bash
+   pip install 'arksim[otel]'
+   ```
+
+2. Install Node dependencies:
 
    ```bash
    npm install
@@ -12,7 +18,7 @@ A [Vercel AI SDK](https://github.com/vercel/ai) agent running as a Node.js servi
 
    This installs `ai`, `@ai-sdk/openai`, `hono`, the OpenTelemetry SDK and OTLP exporter, and `zod`.
 
-2. Set your API key:
+3. Set your API key:
 
    ```bash
    export OPENAI_API_KEY="<your-key>"

--- a/examples/integrations/vercel-ai-sdk/README.md
+++ b/examples/integrations/vercel-ai-sdk/README.md
@@ -24,6 +24,8 @@ A [Vercel AI SDK](https://github.com/vercel/ai) agent running as a Node.js servi
    export OPENAI_API_KEY="<your-key>"
    ```
 
+If `gpt-5.1` isn't available in your account, set `OPENAI_MODEL=<your-model>` and re-run, or edit `config.yaml` directly.
+
 ## Run
 
 Start the Vercel AI SDK agent server in one terminal:

--- a/examples/integrations/vercel-ai-sdk/agent_server.ts
+++ b/examples/integrations/vercel-ai-sdk/agent_server.ts
@@ -148,7 +148,7 @@ app.post("/v1/chat/completions", async (c) => {
 
   return routingStore.run({ chatId, turnId }, async () => {
     const result = await generateText({
-      model: openai("gpt-4o"),
+      model: openai(process.env.OPENAI_MODEL ?? "gpt-4o"),
       messages: sessions[chatId],
       tools: { lookup_order, book_table },
       stopWhen: stepCountIs(5),

--- a/examples/integrations/vercel-ai-sdk/agent_server.ts
+++ b/examples/integrations/vercel-ai-sdk/agent_server.ts
@@ -148,7 +148,7 @@ app.post("/v1/chat/completions", async (c) => {
 
   return routingStore.run({ chatId, turnId }, async () => {
     const result = await generateText({
-      model: openai(process.env.OPENAI_MODEL ?? "gpt-4o"),
+      model: openai(process.env.OPENAI_MODEL ?? "gpt-5.1"),
       messages: sessions[chatId],
       tools: { lookup_order, book_table },
       stopWhen: stepCountIs(5),

--- a/examples/integrations/vercel-ai-sdk/agent_server.ts
+++ b/examples/integrations/vercel-ai-sdk/agent_server.ts
@@ -1,57 +1,173 @@
 // SPDX-License-Identifier: Apache-2.0
-// Vercel AI SDK integration for ArkSim.
+// Vercel AI SDK integration for arksim.
 //
-// Install: npm install ai @ai-sdk/openai hono @hono/node-server
+// Install: npm install
 // Auth:    export OPENAI_API_KEY="<your-key>"
+//
+// Exposes a Vercel AI SDK agent with two mock tools (lookup_order,
+// book_table) over an OpenAI-compatible chat completions endpoint.
+// arksim's `chat_completions` connector drops any tool_calls in the
+// response body, so this server takes the same path the Mastra example
+// uses: it wraps each tool body in an OpenTelemetry span following the
+// OTel GenAI semantic conventions and exports spans via OTLP/HTTP to
+// arksim's built-in trace receiver (127.0.0.1:4318). The Python wrapper
+// passes metadata.chat_id and metadata.turn_id in every request; this
+// process threads them through an AsyncLocalStorage and a custom span
+// processor stamps them on every span as arksim.conversation_id and
+// arksim.turn_id so the receiver routes tool calls to the right turn.
 
-import { generateText } from "ai";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import {
+  BatchSpanProcessor,
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { Context } from "@opentelemetry/api";
+import { Resource } from "@opentelemetry/resources";
+import { trace } from "@opentelemetry/api";
+import { generateText, tool, stepCountIs } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
+import { z } from "zod";
+
+type Routing = { chatId: string; turnId?: number };
+const routingStore = new AsyncLocalStorage<Routing>();
+
+// Stamp arksim.conversation_id and arksim.turn_id on every span from
+// the routing AsyncLocalStorage.
+class ArksimRoutingProcessor implements SpanProcessor {
+  onStart(span: Span, _parentContext: Context): void {
+    const routing = routingStore.getStore();
+    if (!routing) return;
+    span.setAttribute("arksim.conversation_id", routing.chatId);
+    if (routing.turnId !== undefined) {
+      span.setAttribute("arksim.turn_id", routing.turnId);
+    }
+  }
+  onEnd(_span: ReadableSpan): void {}
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}
+
+const otelSdk = new NodeSDK({
+  resource: new Resource({
+    "service.name": "arksim-vercel-ai-sdk-example",
+  }),
+  spanProcessors: [
+    new ArksimRoutingProcessor(),
+    new BatchSpanProcessor(
+      new OTLPTraceExporter({
+        url: "http://127.0.0.1:4318/v1/traces",
+      }),
+    ),
+  ],
+});
+otelSdk.start();
+
+const tracer = trace.getTracer("arksim.examples.vercel-ai-sdk");
+
+const lookup_order = tool({
+  description: "Look up an order by ID and return its status.",
+  inputSchema: z.object({
+    order_id: z.string().describe("The order identifier to look up."),
+  }),
+  execute: async ({ order_id }) => {
+    const args = { order_id };
+    return tracer.startActiveSpan("execute_tool lookup_order", (span) => {
+      try {
+        span.setAttribute("gen_ai.tool.name", "lookup_order");
+        span.setAttribute("gen_ai.tool.call.arguments", JSON.stringify(args));
+        const result = `Order ${order_id}: shipped, arrives Tuesday.`;
+        span.setAttribute("gen_ai.tool.call.result", result);
+        return result;
+      } finally {
+        span.end();
+      }
+    });
+  },
+});
+
+const book_table = tool({
+  description: "Book a restaurant table for the given party size and time.",
+  inputSchema: z.object({
+    party_size: z.number().int().describe("Number of people to seat."),
+    time: z.string().describe("Time to book for, for example '7pm'."),
+  }),
+  execute: async ({ party_size, time }) => {
+    const args = { party_size, time };
+    return tracer.startActiveSpan("execute_tool book_table", (span) => {
+      try {
+        span.setAttribute("gen_ai.tool.name", "book_table");
+        span.setAttribute("gen_ai.tool.call.arguments", JSON.stringify(args));
+        const result = `Booked table for ${party_size} at ${time}.`;
+        span.setAttribute("gen_ai.tool.call.result", result);
+        return result;
+      } finally {
+        span.end();
+      }
+    });
+  },
+});
 
 type ChatMessage = { role: "system" | "user" | "assistant"; content: string };
 
-// In-memory session storage for multi-turn conversations
+// In-memory session storage for multi-turn conversations.
 const sessions: Record<string, ChatMessage[]> = {};
 
 const app = new Hono();
 
-// OpenAI-compatible chat completions endpoint
 app.post("/v1/chat/completions", async (c) => {
   const body = await c.req.json();
   const messages: ChatMessage[] = body.messages ?? [];
 
-  const sessionKey = body.session_id ?? "default";
-  if (!sessions[sessionKey]) {
-    sessions[sessionKey] = [
-      { role: "system", content: "You are a helpful assistant." },
+  const md = body.metadata ?? {};
+  const chatId: string = md.chat_id ?? body.session_id ?? "default";
+  const turnId: number | undefined =
+    typeof md.turn_id === "number" ? md.turn_id : undefined;
+
+  if (!sessions[chatId]) {
+    sessions[chatId] = [
+      {
+        role: "system",
+        content:
+          "You are a helpful assistant with access to two tools: " +
+          "lookup_order(order_id) and book_table(party_size, time). " +
+          "Call them when relevant to answer the user.",
+      },
     ];
   }
-
   for (const msg of messages) {
     if (msg.role !== "system") {
-      sessions[sessionKey].push(msg);
+      sessions[chatId].push(msg);
     }
   }
 
-  const result = await generateText({
-    model: openai("gpt-4o"),
-    messages: sessions[sessionKey],
-  });
+  return routingStore.run({ chatId, turnId }, async () => {
+    const result = await generateText({
+      model: openai("gpt-4o"),
+      messages: sessions[chatId],
+      tools: { lookup_order, book_table },
+      stopWhen: stepCountIs(5),
+    });
 
-  const content = result.text;
-  sessions[sessionKey].push({ role: "assistant", content });
+    const content = result.text;
+    sessions[chatId].push({ role: "assistant", content });
 
-  return c.json({
-    id: `chatcmpl-${Date.now()}`,
-    object: "chat.completion",
-    choices: [
-      {
-        index: 0,
-        message: { role: "assistant", content },
-        finish_reason: "stop",
-      },
-    ],
+    return c.json({
+      id: `chatcmpl-${Date.now()}`,
+      object: "chat.completion",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content },
+          finish_reason: "stop",
+        },
+      ],
+    });
   });
 });
 
@@ -60,3 +176,10 @@ app.get("/health", (c) => c.json({ status: "ok" }));
 const port = parseInt(process.env.PORT ?? "8888", 10);
 console.log(`Vercel AI SDK agent server listening on port ${port}`);
 serve({ fetch: app.fetch, port });
+
+const shutdown = async () => {
+  await otelSdk.shutdown();
+  process.exit(0);
+};
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/examples/integrations/vercel-ai-sdk/config.yaml
+++ b/examples/integrations/vercel-ai-sdk/config.yaml
@@ -16,6 +16,9 @@ agent_config:
     body:
       model: gpt-4o
       messages: []
+      # Forward chat_id and turn_id to the agent server so it can stamp
+      # arksim.conversation_id and arksim.turn_id on emitted OTel spans.
+      enable_metadata: true
 
 # ── SIMULATION SETTINGS ──────────────────────────────────────────────────────
 
@@ -44,3 +47,9 @@ provider: openai
 
 # Workers for parallel processing
 num_workers: 50
+
+# ── TRACE RECEIVER ───────────────────────────────────────────────────────────
+# Receives OTel spans emitted by the Vercel AI SDK server's tool wrappers.
+trace_receiver:
+  enabled: true
+  wait_timeout: 5

--- a/examples/integrations/vercel-ai-sdk/package.json
+++ b/examples/integrations/vercel-ai-sdk/package.json
@@ -8,8 +8,14 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.41",
     "@hono/node-server": "^1.0",
+    "@opentelemetry/api": "^1.9",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.55",
+    "@opentelemetry/resources": "^1.30",
+    "@opentelemetry/sdk-node": "^0.55",
+    "@opentelemetry/sdk-trace-base": "^1.30",
     "ai": "^6.0.116",
     "hono": "^4.0",
-    "tsx": "^4.0"
+    "tsx": "^4.0",
+    "zod": "^3.23"
   }
 }

--- a/examples/integrations/vercel-ai-sdk/scenarios.json
+++ b/examples/integrations/vercel-ai-sdk/scenarios.json
@@ -2,18 +2,18 @@
     "schema_version": "v1",
     "scenarios": [
         {
-            "scenario_id": "general_knowledge_qa",
+            "scenario_id": "order_status_lookup",
             "user_id": "user_0001",
-            "goal": "You want to learn about the history and science behind renewable energy sources. Ask about solar, wind, and hydroelectric power, including how they work, their advantages and disadvantages, and their adoption worldwide.",
-            "agent_context": "You are a helpful assistant that answers user questions clearly and accurately.",
-            "user_profile": "You are Jordan, a curious and detail-oriented 28-year-old graduate student studying environmental policy. You enjoy learning about technical topics and ask follow-up questions to deepen your understanding. You prefer clear, structured explanations and appreciate when answers include real-world examples."
+            "goal": "Find out when order ORD-1001 will arrive. Ask the agent to look up the order and report its status.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Alex, a 32-year-old who recently ordered headphones online. You are patient and casual and want a clear update on your delivery."
         },
         {
-            "scenario_id": "task_assistance",
+            "scenario_id": "dinner_reservation",
             "user_id": "user_0002",
-            "goal": "You need help drafting a professional email to your manager requesting time off next month for a family event. Ask the assistant to help you write the email, suggest improvements, and make it concise yet polite.",
-            "agent_context": "You are a helpful assistant that assists users with writing, planning, and everyday tasks.",
-            "user_profile": "You are Sam, a 34-year-old marketing coordinator at a mid-sized company. You are friendly and collaborative but sometimes unsure about formal communication. You value politeness and professionalism in workplace writing and want your emails to strike the right tone without being overly stiff."
+            "goal": "Book a dinner table for 4 people at 7pm tonight. Ask the agent to make the reservation.",
+            "agent_context": "You are a helpful assistant with access to two tools: lookup_order(order_id) and book_table(party_size, time). Use them when relevant to answer the user.",
+            "user_profile": "You are Jamie, a 29-year-old planning a small dinner with friends. You are direct and polite and expect the agent to confirm the booking details."
         }
     ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,25 +51,25 @@ otel = [
     "opentelemetry-proto>=1.20.0",
 ]
 langchain = [
-    "langchain-core>=0.3.0",
+    "langchain-core>=1.0.0",
 ]
 crewai = [
     "crewai>=0.80.0",
 ]
 claude-agent = [
-    "claude-agent-sdk>=0.1.0",
+    "claude-agent-sdk>=0.1.0,<0.3.0",
 ]
 google-adk = [
-    "google-adk>=0.5.0",
+    "google-adk>=1.0.0",
 ]
 livekit = [
     "livekit-agents>=1.0.0",
 ]
 strands = [
-    "strands-agents>=0.1.0",
+    "strands-agents>=1.0.0",
 ]
 llamaindex = [
-    "llama-index-core>=0.10.0",
+    "llama-index-core>=0.14.0",
 ]
 smolagents = [
     "smolagents>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ claude-agent = [
 google-adk = [
     "google-adk>=1.0.0",
 ]
-livekit = [
+livekit-agents = [
     "livekit-agents>=1.0.0",
 ]
 strands = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ google = [
 otel = [
     "opentelemetry-proto>=1.20.0",
 ]
+# Lower bounds for SDK tracing-adapter extras correspond to the SDK
+# versions documented in arksim/tracing/integrations/<sdk>.py module
+# docstrings (e.g. "Verified against langchain-core 1.3.0"). Lowering
+# these floors requires re-verifying the adapter against the older
+# version's callback/hook surface.
 langchain = [
     "langchain-core>=1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,30 @@ google = [
 otel = [
     "opentelemetry-proto>=1.20.0",
 ]
+langchain = [
+    "langchain-core>=0.3.0",
+]
+crewai = [
+    "crewai>=0.80.0",
+]
+claude-agent = [
+    "claude-agent-sdk>=0.1.0",
+]
+google-adk = [
+    "google-adk>=0.5.0",
+]
+livekit = [
+    "livekit-agents>=1.0.0",
+]
+strands = [
+    "strands-agents>=0.1.0",
+]
+llamaindex = [
+    "llama-index-core>=0.10.0",
+]
+smolagents = [
+    "smolagents>=1.0.0",
+]
 all = [
     "arksim[azure,anthropic,google,otel]",
 ]

--- a/tests/unit/integrations/__init__.py
+++ b/tests/unit/integrations/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations

--- a/tests/unit/integrations/conftest.py
+++ b/tests/unit/integrations/conftest.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for SDK tracing-adapter unit tests.
+
+Every adapter test exercises the same trace-context plumbing and asserts
+the same shape of receiver call. Centralizing the fixtures here keeps
+that plumbing in one place: the autouse ``_clean_context`` fixture
+resets ``trace_conversation_id`` / ``trace_turn_id`` / ``trace_receiver_ref``
+between tests, and ``only_call`` returns the single ``ToolCall`` that
+the adapter submitted (or fails the test if zero or many were submitted).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from arksim.simulation_engine.tool_types import ToolCall
+from arksim.tracing.context import _clear_trace_context
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> Iterator[None]:
+    """Reset the trace-context contextvars before and after each test."""
+    _clear_trace_context()
+    yield
+    _clear_trace_context()
+
+
+@pytest.fixture
+def only_call() -> Callable[[MagicMock], ToolCall]:
+    """Return a helper that asserts the receiver got exactly one submission.
+
+    Use as ``tc = only_call(receiver)`` in tests where the adapter is
+    expected to emit a single ``ToolCall``. Validates routing context
+    matched ``conv-1`` / turn ``0`` along the way.
+    """
+
+    def _only_call(receiver: MagicMock) -> ToolCall:
+        assert receiver.submit_tool_calls.call_count == 1
+        args, _ = receiver.submit_tool_calls.call_args
+        conv, turn, tool_calls = args
+        assert conv == "conv-1"
+        assert turn == 0
+        assert len(tool_calls) == 1
+        return tool_calls[0]
+
+    return _only_call

--- a/tests/unit/integrations/test_args.py
+++ b/tests/unit/integrations/test_args.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for parse_tool_arguments normalization."""
+
+from __future__ import annotations
+
+from arksim.tracing.integrations._args import parse_tool_arguments
+
+
+def test_dict_passthrough() -> None:
+    raw = {"city": "NYC", "units": "F"}
+    assert parse_tool_arguments(raw) == {"city": "NYC", "units": "F"}
+
+
+def test_none_yields_empty() -> None:
+    assert parse_tool_arguments(None) == {}
+
+
+def test_empty_string_yields_empty() -> None:
+    assert parse_tool_arguments("") == {}
+
+
+def test_json_dict_string_parses() -> None:
+    assert parse_tool_arguments('{"city": "NYC"}') == {"city": "NYC"}
+
+
+def test_json_scalar_wrapped_in_value() -> None:
+    assert parse_tool_arguments("42") == {"_value": 42}
+
+
+def test_json_list_wrapped_in_value() -> None:
+    assert parse_tool_arguments("[1, 2, 3]") == {"_value": [1, 2, 3]}
+
+
+def test_json_null_wrapped_in_value() -> None:
+    assert parse_tool_arguments("null") == {"_value": None}
+
+
+def test_json_string_literal_wrapped_in_value() -> None:
+    assert parse_tool_arguments('"hello"') == {"_value": "hello"}
+
+
+def test_non_json_string_wrapped_in_value() -> None:
+    assert parse_tool_arguments("not-json") == {"_value": "not-json"}
+
+
+def test_malformed_json_falls_back_to_raw_value() -> None:
+    assert parse_tool_arguments("{incomplete") == {"_value": "{incomplete"}

--- a/tests/unit/integrations/test_base_adapter.py
+++ b/tests/unit/integrations/test_base_adapter.py
@@ -24,11 +24,43 @@ def _tool_call(name: str = "f") -> ToolCall:
     return ToolCall(id="t1", name=name, arguments={}, source=ToolCallSource.LANGCHAIN)
 
 
-def test_submit_no_op_when_no_routing_context() -> None:
+def test_submit_no_op_when_no_routing_context(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     receiver = MagicMock()
     adapter = BaseTracingAdapter()
-    adapter._submit(_tool_call())
+    with caplog.at_level("DEBUG", logger="arksim.tracing.integrations._base"):
+        adapter._submit(_tool_call(name="missing"))
     receiver.submit_tool_calls.assert_not_called()
+    assert any(
+        "no routing context" in r.getMessage() and "missing" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_submit_swallows_receiver_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Observability must never break the observed.
+
+    If the receiver raises, ``_submit`` logs and absorbs the error rather
+    than propagating it back into the SDK callback that invoked the adapter.
+    """
+    receiver = MagicMock()
+    receiver.submit_tool_calls.side_effect = RuntimeError("boom")
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    adapter = BaseTracingAdapter()
+
+    with caplog.at_level("ERROR", logger="arksim.tracing.integrations._base"):
+        adapter._submit(_tool_call(name="oops"))  # must not raise
+
+    receiver.submit_tool_calls.assert_called_once()
+    assert any(
+        "receiver raised" in r.getMessage()
+        and "oops" in r.getMessage()
+        and "conv-1" in r.getMessage()
+        for r in caplog.records
+    )
 
 
 def test_submit_debug_logs_when_ids_set_but_no_receiver(

--- a/tests/unit/integrations/test_base_adapter.py
+++ b/tests/unit/integrations/test_base_adapter.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for BaseTracingAdapter._submit behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.integrations._base import BaseTracingAdapter
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> Iterator[None]:
+    _clear_trace_context()
+    yield
+    _clear_trace_context()
+
+
+def _tool_call(name: str = "f") -> ToolCall:
+    return ToolCall(id="t1", name=name, arguments={}, source=ToolCallSource.LANGCHAIN)
+
+
+def test_submit_no_op_when_no_routing_context() -> None:
+    receiver = MagicMock()
+    adapter = BaseTracingAdapter()
+    adapter._submit(_tool_call())
+    receiver.submit_tool_calls.assert_not_called()
+
+
+def test_submit_debug_logs_when_ids_set_but_no_receiver(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _set_trace_context("conv-1", 0, receiver=None)
+    adapter = BaseTracingAdapter()
+    with caplog.at_level("DEBUG", logger="arksim.tracing.integrations._base"):
+        adapter._submit(_tool_call(name="foo"))
+    assert any(
+        "no receiver" in r.getMessage() and "foo" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_submit_calls_submit_tool_calls_plural_with_list() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    adapter = BaseTracingAdapter()
+    tc = _tool_call(name="bar")
+    adapter._submit(tc)
+    receiver.submit_tool_calls.assert_called_once_with("conv-1", 0, [tc])

--- a/tests/unit/integrations/test_base_adapter.py
+++ b/tests/unit/integrations/test_base_adapter.py
@@ -3,21 +3,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from unittest.mock import MagicMock
 
 import pytest
 
 from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
-from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.context import _set_trace_context
 from arksim.tracing.integrations._base import BaseTracingAdapter
-
-
-@pytest.fixture(autouse=True)
-def _clean_context() -> Iterator[None]:
-    _clear_trace_context()
-    yield
-    _clear_trace_context()
 
 
 def _tool_call(name: str = "f") -> ToolCall:

--- a/tests/unit/integrations/test_claude_agent_sdk_adapter.py
+++ b/tests/unit/integrations/test_claude_agent_sdk_adapter.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ArksimClaudeHooks."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from claude_agent_sdk import HookMatcher
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.integrations.claude_agent_sdk import ArksimClaudeHooks
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> Iterator[None]:
+    _clear_trace_context()
+    yield
+    _clear_trace_context()
+
+
+def _only_call(receiver: MagicMock) -> ToolCall:
+    assert receiver.submit_tool_calls.call_count == 1
+    args, _ = receiver.submit_tool_calls.call_args
+    conv, turn, tool_calls = args
+    assert conv == "conv-1"
+    assert turn == 0
+    assert len(tool_calls) == 1
+    return tool_calls[0]
+
+
+def _input(
+    *,
+    tool_name: str = "lookup_order",
+    tool_input: Any = None,  # noqa: ANN401  (PostToolUseHookInput.tool_input is Any-ish)
+    tool_response: Any = "shipped",  # noqa: ANN401  (PostToolUseHookInput.tool_response is Any)
+) -> dict[str, Any]:
+    """Build a synthetic PostToolUseHookInput dict for direct hook invocation."""
+    payload: dict[str, Any] = {
+        "tool_name": tool_name,
+        "tool_response": tool_response,
+    }
+    if tool_input is not None:
+        payload["tool_input"] = tool_input
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_happy_path_post_tool_use_submits_tool_call() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    hooks = ArksimClaudeHooks()
+
+    result = await hooks.post_tool_use(
+        _input(
+            tool_name="lookup_order",
+            tool_input={"order_id": "12345"},
+            tool_response="shipped",
+        ),
+        "t1",
+        cast("Any", {}),
+    )
+
+    assert result == {}
+    tc = _only_call(receiver)
+    assert tc.id == "t1"
+    assert tc.name == "lookup_order"
+    assert tc.arguments == {"order_id": "12345"}
+    assert tc.result == "shipped"
+    assert tc.error is None
+    assert tc.source == ToolCallSource.CLAUDE_AGENT_SDK
+
+
+@pytest.mark.asyncio
+async def test_source_field_set_on_every_emission() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    hooks = ArksimClaudeHooks()
+
+    await hooks.post_tool_use(_input(), "t1", cast("Any", {}))
+    await hooks.post_tool_use(_input(tool_name="other"), "t2", cast("Any", {}))
+
+    assert receiver.submit_tool_calls.call_count == 2
+    for call in receiver.submit_tool_calls.call_args_list:
+        tool_call = call.args[2][0]
+        assert tool_call.source == ToolCallSource.CLAUDE_AGENT_SDK
+
+
+@pytest.mark.asyncio
+async def test_no_trace_context_silently_drops() -> None:
+    receiver = MagicMock()
+    # Deliberately do NOT call _set_trace_context.
+    hooks = ArksimClaudeHooks()
+
+    await hooks.post_tool_use(_input(), "t1", cast("Any", {}))
+
+    receiver.submit_tool_calls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_tool_input_yields_empty_arguments() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    hooks = ArksimClaudeHooks()
+
+    # tool_input key absent from the input dict entirely.
+    await hooks.post_tool_use(
+        {"tool_name": "lookup_order", "tool_response": "ok"},
+        "t1",
+        cast("Any", {}),
+    )
+
+    tc = _only_call(receiver)
+    assert tc.arguments == {}
+
+
+@pytest.mark.asyncio
+async def test_non_dict_tool_input_wrapped_in_value() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    hooks = ArksimClaudeHooks()
+
+    await hooks.post_tool_use(
+        _input(tool_input="raw"),
+        "t1",
+        cast("Any", {}),
+    )
+
+    tc = _only_call(receiver)
+    assert tc.arguments == {"_value": "raw"}
+
+
+@pytest.mark.asyncio
+async def test_dict_tool_response_serialized_to_string() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    hooks = ArksimClaudeHooks()
+
+    # PostToolUseHookInput.tool_response is typed Any. When a tool returns
+    # a structured payload, we serialize with str() to keep ToolCall.result a
+    # printable string consistent with the cross-adapter contract.
+    await hooks.post_tool_use(
+        _input(tool_response={"status": "ok"}),
+        "t1",
+        cast("Any", {}),
+    )
+
+    tc = _only_call(receiver)
+    assert tc.result == str({"status": "ok"})
+
+
+@pytest.mark.asyncio
+async def test_hooks_dict_returns_post_tool_use_matcher() -> None:
+    """The shape users pass to ClaudeAgentOptions(hooks=...)."""
+    hooks = ArksimClaudeHooks()
+
+    out = hooks.hooks_dict()
+
+    assert set(out) == {"PostToolUse"}
+    matchers = out["PostToolUse"]
+    assert len(matchers) == 1
+    matcher = matchers[0]
+    assert isinstance(matcher, HookMatcher)
+    assert matcher.hooks == [hooks.post_tool_use]

--- a/tests/unit/integrations/test_claude_agent_sdk_adapter.py
+++ b/tests/unit/integrations/test_claude_agent_sdk_adapter.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable
 from typing import Any, cast
 from unittest.mock import MagicMock
 
@@ -11,25 +11,10 @@ import pytest
 from claude_agent_sdk import HookMatcher
 
 from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
-from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.context import _set_trace_context
 from arksim.tracing.integrations.claude_agent_sdk import ArksimClaudeHooks
 
-
-@pytest.fixture(autouse=True)
-def _clean_context() -> Iterator[None]:
-    _clear_trace_context()
-    yield
-    _clear_trace_context()
-
-
-def _only_call(receiver: MagicMock) -> ToolCall:
-    assert receiver.submit_tool_calls.call_count == 1
-    args, _ = receiver.submit_tool_calls.call_args
-    conv, turn, tool_calls = args
-    assert conv == "conv-1"
-    assert turn == 0
-    assert len(tool_calls) == 1
-    return tool_calls[0]
+OnlyCall = Callable[[MagicMock], ToolCall]
 
 
 def _input(
@@ -49,7 +34,9 @@ def _input(
 
 
 @pytest.mark.asyncio
-async def test_happy_path_post_tool_use_submits_tool_call() -> None:
+async def test_happy_path_post_tool_use_submits_tool_call(
+    only_call: OnlyCall,
+) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     hooks = ArksimClaudeHooks()
@@ -65,7 +52,7 @@ async def test_happy_path_post_tool_use_submits_tool_call() -> None:
     )
 
     assert result == {}
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.id == "t1"
     assert tc.name == "lookup_order"
     assert tc.arguments == {"order_id": "12345"}
@@ -101,7 +88,9 @@ async def test_no_trace_context_silently_drops() -> None:
 
 
 @pytest.mark.asyncio
-async def test_missing_tool_input_yields_empty_arguments() -> None:
+async def test_missing_tool_input_yields_empty_arguments(
+    only_call: OnlyCall,
+) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     hooks = ArksimClaudeHooks()
@@ -113,12 +102,12 @@ async def test_missing_tool_input_yields_empty_arguments() -> None:
         cast("Any", {}),
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.arguments == {}
 
 
 @pytest.mark.asyncio
-async def test_non_dict_tool_input_wrapped_in_value() -> None:
+async def test_non_dict_tool_input_wrapped_in_value(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     hooks = ArksimClaudeHooks()
@@ -129,12 +118,14 @@ async def test_non_dict_tool_input_wrapped_in_value() -> None:
         cast("Any", {}),
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.arguments == {"_value": "raw"}
 
 
 @pytest.mark.asyncio
-async def test_dict_tool_response_serialized_to_string() -> None:
+async def test_dict_tool_response_serialized_to_string(
+    only_call: OnlyCall,
+) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     hooks = ArksimClaudeHooks()
@@ -148,7 +139,7 @@ async def test_dict_tool_response_serialized_to_string() -> None:
         cast("Any", {}),
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.result == str({"status": "ok"})
 
 

--- a/tests/unit/integrations/test_crewai_adapter.py
+++ b/tests/unit/integrations/test_crewai_adapter.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ArksimCrewEventListener."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from crewai.events import (
+    ToolUsageErrorEvent,
+    ToolUsageFinishedEvent,
+    crewai_event_bus,
+)
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.integrations.crewai import ArksimCrewEventListener
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> Iterator[None]:
+    _clear_trace_context()
+    yield
+    _clear_trace_context()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_bus() -> Iterator[None]:
+    """Each test gets a fresh crewai event-bus state.
+
+    ``BaseEventListener.__init__`` registers handlers eagerly into the global
+    ``crewai_event_bus`` singleton; without isolation, instances leak across
+    tests and a single emit fires every listener ever constructed.
+    """
+    with crewai_event_bus.scoped_handlers():
+        yield
+
+
+def _emit_and_wait(event: ToolUsageFinishedEvent | ToolUsageErrorEvent) -> None:
+    """Emit and block until handlers finish.
+
+    ``crewai_event_bus.emit`` dispatches sync handlers via a
+    ``ThreadPoolExecutor`` and returns a ``Future``; tests must wait on it
+    or the next assertion races the worker thread.
+    """
+    future = crewai_event_bus.emit(source=object(), event=event)
+    if future is not None:
+        future.result(timeout=5.0)
+
+
+def _finished_event(
+    *, tool_name: str = "get_weather", tool_args: object = None, output: object = "ok"
+) -> ToolUsageFinishedEvent:
+    now = datetime.now(timezone.utc)
+    return ToolUsageFinishedEvent(
+        timestamp=now,
+        tool_name=tool_name,
+        tool_args=tool_args if tool_args is not None else {},
+        started_at=now,
+        finished_at=now,
+        output=output,
+    )
+
+
+def _error_event(
+    *, tool_name: str = "get_weather", tool_args: object = None, error: object = "boom"
+) -> ToolUsageErrorEvent:
+    now = datetime.now(timezone.utc)
+    return ToolUsageErrorEvent(
+        timestamp=now,
+        tool_name=tool_name,
+        tool_args=tool_args if tool_args is not None else {},
+        error=error,
+    )
+
+
+def _only_call(receiver: MagicMock) -> ToolCall:
+    assert receiver.submit_tool_calls.call_count == 1
+    args, _ = receiver.submit_tool_calls.call_args
+    conv, turn, tool_calls = args
+    assert conv == "conv-1"
+    assert turn == 0
+    assert len(tool_calls) == 1
+    return tool_calls[0]
+
+
+def test_happy_path_finished_event_submits_tool_call() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    ArksimCrewEventListener()
+
+    _emit_and_wait(
+        _finished_event(
+            tool_name="get_weather",
+            tool_args={"city": "NYC"},
+            output="sunny 75F",
+        )
+    )
+
+    tc = _only_call(receiver)
+    assert tc.name == "get_weather"
+    assert tc.arguments == {"city": "NYC"}
+    assert tc.result == "sunny 75F"
+    assert tc.error is None
+    assert tc.source == ToolCallSource.CREWAI
+
+
+def test_error_event_populates_error_field() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    ArksimCrewEventListener()
+
+    _emit_and_wait(
+        _error_event(
+            tool_name="get_weather",
+            tool_args={"city": "NYC"},
+            error=ValueError("nope"),
+        )
+    )
+
+    tc = _only_call(receiver)
+    assert tc.name == "get_weather"
+    assert tc.arguments == {"city": "NYC"}
+    assert tc.error == "ValueError: nope"
+    assert tc.result is None
+    assert tc.source == ToolCallSource.CREWAI
+
+
+def test_no_trace_context_silently_drops() -> None:
+    receiver = MagicMock()
+    # Deliberately do NOT call _set_trace_context.
+    ArksimCrewEventListener()
+
+    _emit_and_wait(_finished_event(tool_args={"city": "NYC"}, output="sunny"))
+
+    receiver.submit_tool_calls.assert_not_called()
+
+
+def test_missing_tool_args_yields_empty_arguments() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    ArksimCrewEventListener()
+
+    # tool_args is dict | str on the model; empty dict represents the
+    # "missing" case for required-field events.
+    _emit_and_wait(_finished_event(tool_args={}, output="ok"))
+
+    tc = _only_call(receiver)
+    assert tc.arguments == {}
+
+
+def test_non_dict_tool_args_wrapped_in_value() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    ArksimCrewEventListener()
+
+    _emit_and_wait(_finished_event(tool_args="raw-string", output="ok"))
+
+    tc = _only_call(receiver)
+    assert tc.arguments == {"_value": "raw-string"}
+
+
+def test_multiple_events_each_submitted() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    ArksimCrewEventListener()
+
+    _emit_and_wait(_finished_event(tool_name="a", tool_args={"x": 1}, output="r1"))
+    _emit_and_wait(_finished_event(tool_name="b", tool_args={"y": 2}, output="r2"))
+
+    assert receiver.submit_tool_calls.call_count == 2
+    first = receiver.submit_tool_calls.call_args_list[0].args[2][0]
+    second = receiver.submit_tool_calls.call_args_list[1].args[2][0]
+    assert first.name == "a"
+    assert first.arguments == {"x": 1}
+    assert first.result == "r1"
+    assert second.name == "b"
+    assert second.arguments == {"y": 2}
+    assert second.result == "r2"
+
+
+def test_source_field_set_on_both_success_and_error() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    ArksimCrewEventListener()
+
+    _emit_and_wait(_finished_event())
+    _emit_and_wait(_error_event())
+
+    assert receiver.submit_tool_calls.call_count == 2
+    for call in receiver.submit_tool_calls.call_args_list:
+        tool_call = call.args[2][0]
+        assert tool_call.source == ToolCallSource.CREWAI

--- a/tests/unit/integrations/test_crewai_adapter.py
+++ b/tests/unit/integrations/test_crewai_adapter.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
@@ -15,15 +15,10 @@ from crewai.events import (
 )
 
 from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
-from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.context import _set_trace_context
 from arksim.tracing.integrations.crewai import ArksimCrewEventListener
 
-
-@pytest.fixture(autouse=True)
-def _clean_context() -> Iterator[None]:
-    _clear_trace_context()
-    yield
-    _clear_trace_context()
+OnlyCall = Callable[[MagicMock], ToolCall]
 
 
 @pytest.fixture(autouse=True)
@@ -76,17 +71,7 @@ def _error_event(
     )
 
 
-def _only_call(receiver: MagicMock) -> ToolCall:
-    assert receiver.submit_tool_calls.call_count == 1
-    args, _ = receiver.submit_tool_calls.call_args
-    conv, turn, tool_calls = args
-    assert conv == "conv-1"
-    assert turn == 0
-    assert len(tool_calls) == 1
-    return tool_calls[0]
-
-
-def test_happy_path_finished_event_submits_tool_call() -> None:
+def test_happy_path_finished_event_submits_tool_call(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     ArksimCrewEventListener()
@@ -99,7 +84,7 @@ def test_happy_path_finished_event_submits_tool_call() -> None:
         )
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.name == "get_weather"
     assert tc.arguments == {"city": "NYC"}
     assert tc.result == "sunny 75F"
@@ -107,7 +92,7 @@ def test_happy_path_finished_event_submits_tool_call() -> None:
     assert tc.source == ToolCallSource.CREWAI
 
 
-def test_error_event_populates_error_field() -> None:
+def test_error_event_populates_error_field(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     ArksimCrewEventListener()
@@ -120,7 +105,7 @@ def test_error_event_populates_error_field() -> None:
         )
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.name == "get_weather"
     assert tc.arguments == {"city": "NYC"}
     assert tc.error == "ValueError: nope"
@@ -138,7 +123,7 @@ def test_no_trace_context_silently_drops() -> None:
     receiver.submit_tool_calls.assert_not_called()
 
 
-def test_missing_tool_args_yields_empty_arguments() -> None:
+def test_missing_tool_args_yields_empty_arguments(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     ArksimCrewEventListener()
@@ -147,18 +132,18 @@ def test_missing_tool_args_yields_empty_arguments() -> None:
     # "missing" case for required-field events.
     _emit_and_wait(_finished_event(tool_args={}, output="ok"))
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.arguments == {}
 
 
-def test_non_dict_tool_args_wrapped_in_value() -> None:
+def test_non_dict_tool_args_wrapped_in_value(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     ArksimCrewEventListener()
 
     _emit_and_wait(_finished_event(tool_args="raw-string", output="ok"))
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.arguments == {"_value": "raw-string"}
 
 

--- a/tests/unit/integrations/test_google_adk_adapter.py
+++ b/tests/unit/integrations/test_google_adk_adapter.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ArksimADKPlugin."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.integrations.google_adk import ArksimADKPlugin
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> Iterator[None]:
+    _clear_trace_context()
+    yield
+    _clear_trace_context()
+
+
+def _only_call(receiver: MagicMock) -> ToolCall:
+    assert receiver.submit_tool_calls.call_count == 1
+    args, _ = receiver.submit_tool_calls.call_args
+    conv, turn, tool_calls = args
+    assert conv == "conv-1"
+    assert turn == 0
+    assert len(tool_calls) == 1
+    return tool_calls[0]
+
+
+def _tool(name: str = "lookup_order") -> Any:  # noqa: ANN401
+    tool = MagicMock()
+    tool.name = name
+    return tool
+
+
+def _tool_context(invocation_id: str | None = "inv-1") -> Any:  # noqa: ANN401
+    ctx = MagicMock(spec=["invocation_id"])
+    if invocation_id is not None:
+        ctx.invocation_id = invocation_id
+    else:
+        # Remove the attribute so getattr falls back to default.
+        del ctx.invocation_id
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_happy_path_after_tool_callback_submits_tool_call() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    plugin = ArksimADKPlugin()
+
+    out = await plugin.after_tool_callback(
+        tool=_tool("lookup_order"),
+        tool_args={"order_id": "12345"},
+        tool_context=_tool_context("inv-1"),
+        result={"status": "shipped"},
+    )
+
+    assert out is None
+    tc = _only_call(receiver)
+    assert tc.id == "inv-1"
+    assert tc.name == "lookup_order"
+    assert tc.arguments == {"order_id": "12345"}
+    assert tc.result == str({"status": "shipped"})
+    assert tc.error is None
+    assert tc.source == ToolCallSource.GOOGLE_ADK
+
+
+@pytest.mark.asyncio
+async def test_source_field_set_on_every_emission() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    plugin = ArksimADKPlugin()
+
+    await plugin.after_tool_callback(
+        tool=_tool("a"),
+        tool_args={},
+        tool_context=_tool_context("inv-1"),
+        result={"ok": True},
+    )
+    await plugin.after_tool_callback(
+        tool=_tool("b"),
+        tool_args={},
+        tool_context=_tool_context("inv-2"),
+        result={"ok": True},
+    )
+
+    assert receiver.submit_tool_calls.call_count == 2
+    for call in receiver.submit_tool_calls.call_args_list:
+        tool_call = call.args[2][0]
+        assert tool_call.source == ToolCallSource.GOOGLE_ADK
+
+
+@pytest.mark.asyncio
+async def test_no_trace_context_silently_drops() -> None:
+    receiver = MagicMock()
+    # Deliberately do NOT call _set_trace_context.
+    plugin = ArksimADKPlugin()
+
+    await plugin.after_tool_callback(
+        tool=_tool("lookup_order"),
+        tool_args={"order_id": "12345"},
+        tool_context=_tool_context("inv-1"),
+        result={"status": "shipped"},
+    )
+
+    receiver.submit_tool_calls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_none_tool_args_yields_empty_arguments() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    plugin = ArksimADKPlugin()
+
+    await plugin.after_tool_callback(
+        tool=_tool("lookup_order"),
+        tool_args=cast("Any", None),
+        tool_context=_tool_context("inv-1"),
+        result={"ok": True},
+    )
+
+    tc = _only_call(receiver)
+    assert tc.arguments == {}
+
+
+@pytest.mark.asyncio
+async def test_non_dict_tool_args_wrapped_in_value() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    plugin = ArksimADKPlugin()
+
+    await plugin.after_tool_callback(
+        tool=_tool("lookup_order"),
+        tool_args=cast("Any", "raw"),
+        tool_context=_tool_context("inv-1"),
+        result={"ok": True},
+    )
+
+    tc = _only_call(receiver)
+    assert tc.arguments == {"_value": "raw"}
+
+
+@pytest.mark.asyncio
+async def test_return_value_is_none_to_preserve_original_result() -> None:
+    """ADK BasePlugin.after_tool_callback can return Optional[dict].
+
+    Returning a non-None value short-circuits remaining plugins and replaces
+    the tool result. Tracing must be observation-only: always return None so
+    the agent sees the original tool output.
+    """
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    plugin = ArksimADKPlugin()
+
+    out = await plugin.after_tool_callback(
+        tool=_tool("lookup_order"),
+        tool_args={"order_id": "12345"},
+        tool_context=_tool_context("inv-1"),
+        result={"status": "shipped"},
+    )
+
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_missing_invocation_id_falls_back_to_empty_string() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    plugin = ArksimADKPlugin()
+
+    await plugin.after_tool_callback(
+        tool=_tool("lookup_order"),
+        tool_args={"order_id": "12345"},
+        tool_context=_tool_context(None),
+        result={"status": "shipped"},
+    )
+
+    tc = _only_call(receiver)
+    assert tc.id == ""

--- a/tests/unit/integrations/test_google_adk_adapter.py
+++ b/tests/unit/integrations/test_google_adk_adapter.py
@@ -3,32 +3,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable
 from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 
 from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
-from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.context import _set_trace_context
 from arksim.tracing.integrations.google_adk import ArksimADKPlugin
 
-
-@pytest.fixture(autouse=True)
-def _clean_context() -> Iterator[None]:
-    _clear_trace_context()
-    yield
-    _clear_trace_context()
-
-
-def _only_call(receiver: MagicMock) -> ToolCall:
-    assert receiver.submit_tool_calls.call_count == 1
-    args, _ = receiver.submit_tool_calls.call_args
-    conv, turn, tool_calls = args
-    assert conv == "conv-1"
-    assert turn == 0
-    assert len(tool_calls) == 1
-    return tool_calls[0]
+OnlyCall = Callable[[MagicMock], ToolCall]
 
 
 def _tool(name: str = "lookup_order") -> Any:  # noqa: ANN401
@@ -48,7 +33,9 @@ def _tool_context(invocation_id: str | None = "inv-1") -> Any:  # noqa: ANN401
 
 
 @pytest.mark.asyncio
-async def test_happy_path_after_tool_callback_submits_tool_call() -> None:
+async def test_happy_path_after_tool_callback_submits_tool_call(
+    only_call: OnlyCall,
+) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     plugin = ArksimADKPlugin()
@@ -61,7 +48,7 @@ async def test_happy_path_after_tool_callback_submits_tool_call() -> None:
     )
 
     assert out is None
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.id == "inv-1"
     assert tc.name == "lookup_order"
     assert tc.arguments == {"order_id": "12345"}
@@ -112,7 +99,7 @@ async def test_no_trace_context_silently_drops() -> None:
 
 
 @pytest.mark.asyncio
-async def test_none_tool_args_yields_empty_arguments() -> None:
+async def test_none_tool_args_yields_empty_arguments(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     plugin = ArksimADKPlugin()
@@ -124,12 +111,12 @@ async def test_none_tool_args_yields_empty_arguments() -> None:
         result={"ok": True},
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.arguments == {}
 
 
 @pytest.mark.asyncio
-async def test_non_dict_tool_args_wrapped_in_value() -> None:
+async def test_non_dict_tool_args_wrapped_in_value(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     plugin = ArksimADKPlugin()
@@ -141,7 +128,7 @@ async def test_non_dict_tool_args_wrapped_in_value() -> None:
         result={"ok": True},
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.arguments == {"_value": "raw"}
 
 
@@ -168,7 +155,9 @@ async def test_return_value_is_none_to_preserve_original_result() -> None:
 
 
 @pytest.mark.asyncio
-async def test_missing_invocation_id_falls_back_to_empty_string() -> None:
+async def test_missing_invocation_id_falls_back_to_empty_string(
+    only_call: OnlyCall,
+) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     plugin = ArksimADKPlugin()
@@ -180,5 +169,5 @@ async def test_missing_invocation_id_falls_back_to_empty_string() -> None:
         result={"status": "shipped"},
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.id == ""

--- a/tests/unit/integrations/test_langchain_adapter.py
+++ b/tests/unit/integrations/test_langchain_adapter.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
@@ -11,32 +11,17 @@ import pytest
 from langchain_core.callbacks import AsyncCallbackHandler, BaseCallbackHandler
 
 from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
-from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.context import _set_trace_context
 from arksim.tracing.integrations.langchain import ArksimLangChainHandler
 
-
-@pytest.fixture(autouse=True)
-def _clean_context() -> Iterator[None]:
-    _clear_trace_context()
-    yield
-    _clear_trace_context()
+OnlyCall = Callable[[MagicMock], ToolCall]
 
 
 def _serialized(name: str = "get_weather") -> dict[str, object]:
     return {"name": name}
 
 
-def _only_call(receiver: MagicMock) -> ToolCall:
-    assert receiver.submit_tool_calls.call_count == 1
-    args, _ = receiver.submit_tool_calls.call_args
-    conv, turn, tool_calls = args
-    assert conv == "conv-1"
-    assert turn == 0
-    assert len(tool_calls) == 1
-    return tool_calls[0]
-
-
-def test_happy_path_sync_produces_single_tool_call() -> None:
+def test_happy_path_sync_produces_single_tool_call(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     handler = ArksimLangChainHandler()
@@ -45,7 +30,7 @@ def test_happy_path_sync_produces_single_tool_call() -> None:
     handler.on_tool_start(_serialized("get_weather"), '{"city": "NYC"}', run_id=run_id)
     handler.on_tool_end("sunny 75F", run_id=run_id)
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.id == str(run_id)
     assert tc.name == "get_weather"
     assert tc.arguments == {"city": "NYC"}
@@ -54,7 +39,7 @@ def test_happy_path_sync_produces_single_tool_call() -> None:
     assert tc.source == ToolCallSource.LANGCHAIN
 
 
-def test_error_path_populates_error_field() -> None:
+def test_error_path_populates_error_field(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     handler = ArksimLangChainHandler()
@@ -63,7 +48,7 @@ def test_error_path_populates_error_field() -> None:
     handler.on_tool_start(_serialized("get_weather"), '{"city": "NYC"}', run_id=run_id)
     handler.on_tool_error(ValueError("nope"), run_id=run_id)
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.id == str(run_id)
     assert tc.name == "get_weather"
     assert tc.arguments == {"city": "NYC"}
@@ -134,7 +119,7 @@ def test_multiple_overlapping_calls_correlate_correctly() -> None:
     assert second.result == "res_b"
 
 
-def test_non_json_input_str_wrapped_in_value() -> None:
+def test_non_json_input_str_wrapped_in_value(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     handler = ArksimLangChainHandler()
@@ -143,11 +128,11 @@ def test_non_json_input_str_wrapped_in_value() -> None:
     handler.on_tool_start(_serialized("t"), "not-json", run_id=run_id)
     handler.on_tool_end("ok", run_id=run_id)
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.arguments == {"_value": "not-json"}
 
 
-def test_empty_input_str_yields_empty_arguments() -> None:
+def test_empty_input_str_yields_empty_arguments(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     handler = ArksimLangChainHandler()
@@ -156,7 +141,7 @@ def test_empty_input_str_yields_empty_arguments() -> None:
     handler.on_tool_start(_serialized("t"), "", run_id=run_id)
     handler.on_tool_end("ok", run_id=run_id)
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.arguments == {}
 
 

--- a/tests/unit/integrations/test_langchain_adapter.py
+++ b/tests/unit/integrations/test_langchain_adapter.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ArksimLangChainHandler split-event correlation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from langchain_core.callbacks import AsyncCallbackHandler, BaseCallbackHandler
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.integrations.langchain import ArksimLangChainHandler
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> Iterator[None]:
+    _clear_trace_context()
+    yield
+    _clear_trace_context()
+
+
+def _serialized(name: str = "get_weather") -> dict[str, object]:
+    return {"name": name}
+
+
+def _only_call(receiver: MagicMock) -> ToolCall:
+    assert receiver.submit_tool_calls.call_count == 1
+    args, _ = receiver.submit_tool_calls.call_args
+    conv, turn, tool_calls = args
+    assert conv == "conv-1"
+    assert turn == 0
+    assert len(tool_calls) == 1
+    return tool_calls[0]
+
+
+def test_happy_path_sync_produces_single_tool_call() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLangChainHandler()
+    run_id = uuid4()
+
+    handler.on_tool_start(_serialized("get_weather"), '{"city": "NYC"}', run_id=run_id)
+    handler.on_tool_end("sunny 75F", run_id=run_id)
+
+    tc = _only_call(receiver)
+    assert tc.id == str(run_id)
+    assert tc.name == "get_weather"
+    assert tc.arguments == {"city": "NYC"}
+    assert tc.result == "sunny 75F"
+    assert tc.error is None
+    assert tc.source == ToolCallSource.LANGCHAIN
+
+
+def test_error_path_populates_error_field() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLangChainHandler()
+    run_id = uuid4()
+
+    handler.on_tool_start(_serialized("get_weather"), '{"city": "NYC"}', run_id=run_id)
+    handler.on_tool_error(ValueError("nope"), run_id=run_id)
+
+    tc = _only_call(receiver)
+    assert tc.id == str(run_id)
+    assert tc.name == "get_weather"
+    assert tc.arguments == {"city": "NYC"}
+    assert tc.error == "nope"
+    assert tc.result is None
+    assert tc.source == ToolCallSource.LANGCHAIN
+
+
+def test_unmatched_end_logs_debug_and_does_not_submit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLangChainHandler()
+    stray = UUID("00000000-0000-0000-0000-000000000abc")
+
+    with caplog.at_level("DEBUG", logger="arksim.tracing.integrations.langchain"):
+        handler.on_tool_end("late", run_id=stray)
+
+    receiver.submit_tool_calls.assert_not_called()
+    assert any(
+        "unmatched on_tool_end" in r.getMessage() and str(stray) in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_no_trace_context_silently_drops() -> None:
+    receiver = MagicMock()
+    # Deliberately do NOT call _set_trace_context.
+    handler = ArksimLangChainHandler()
+    run_id = uuid4()
+
+    handler.on_tool_start(_serialized(), '{"city": "NYC"}', run_id=run_id)
+    handler.on_tool_end("sunny", run_id=run_id)
+
+    receiver.submit_tool_calls.assert_not_called()
+
+
+def test_dual_inheritance_sync_and_async() -> None:
+    handler = ArksimLangChainHandler()
+    assert isinstance(handler, BaseCallbackHandler)
+    assert isinstance(handler, AsyncCallbackHandler)
+
+
+def test_multiple_overlapping_calls_correlate_correctly() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLangChainHandler()
+    r1 = uuid4()
+    r2 = uuid4()
+
+    handler.on_tool_start(_serialized("a"), '{"x": 1}', run_id=r1)
+    handler.on_tool_start(_serialized("b"), '{"y": 2}', run_id=r2)
+    handler.on_tool_end("res_a", run_id=r1)
+    handler.on_tool_end("res_b", run_id=r2)
+
+    assert receiver.submit_tool_calls.call_count == 2
+    calls = receiver.submit_tool_calls.call_args_list
+    first = calls[0].args[2][0]
+    second = calls[1].args[2][0]
+    assert first.id == str(r1)
+    assert first.name == "a"
+    assert first.arguments == {"x": 1}
+    assert first.result == "res_a"
+    assert second.id == str(r2)
+    assert second.name == "b"
+    assert second.arguments == {"y": 2}
+    assert second.result == "res_b"
+
+
+def test_non_json_input_str_wrapped_in_value() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLangChainHandler()
+    run_id = uuid4()
+
+    handler.on_tool_start(_serialized("t"), "not-json", run_id=run_id)
+    handler.on_tool_end("ok", run_id=run_id)
+
+    tc = _only_call(receiver)
+    assert tc.arguments == {"_value": "not-json"}
+
+
+def test_empty_input_str_yields_empty_arguments() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLangChainHandler()
+    run_id = uuid4()
+
+    handler.on_tool_start(_serialized("t"), "", run_id=run_id)
+    handler.on_tool_end("ok", run_id=run_id)
+
+    tc = _only_call(receiver)
+    assert tc.arguments == {}

--- a/tests/unit/integrations/test_langchain_adapter.py
+++ b/tests/unit/integrations/test_langchain_adapter.py
@@ -67,7 +67,7 @@ def test_error_path_populates_error_field() -> None:
     assert tc.id == str(run_id)
     assert tc.name == "get_weather"
     assert tc.arguments == {"city": "NYC"}
-    assert tc.error == "nope"
+    assert tc.error == "ValueError: nope"
     assert tc.result is None
     assert tc.source == ToolCallSource.LANGCHAIN
 
@@ -158,3 +158,17 @@ def test_empty_input_str_yields_empty_arguments() -> None:
 
     tc = _only_call(receiver)
     assert tc.arguments == {}
+
+
+def test_sync_overrides_satisfy_async_dispatch_invariant() -> None:
+    """LangChain's async manager picks sync override when iscoroutinefunction is False.
+
+    If a future refactor makes any on_tool_* method async on this class, the
+    invariant breaks and chain.ainvoke() stops routing through our override.
+    """
+    import inspect
+
+    handler = ArksimLangChainHandler()
+    assert not inspect.iscoroutinefunction(handler.on_tool_start)
+    assert not inspect.iscoroutinefunction(handler.on_tool_end)
+    assert not inspect.iscoroutinefunction(handler.on_tool_error)

--- a/tests/unit/integrations/test_livekit_adapter.py
+++ b/tests/unit/integrations/test_livekit_adapter.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -12,6 +13,8 @@ from livekit.agents.voice.events import FunctionToolsExecutedEvent
 from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
 from arksim.tracing.context import _set_trace_context
 from arksim.tracing.integrations.livekit import ArksimLiveKitHandler
+
+OnlyCall = Callable[[MagicMock], ToolCall]
 
 
 def _call(
@@ -68,16 +71,14 @@ def _calls_received(receiver: MagicMock) -> list[ToolCall]:
     return collected
 
 
-def test_happy_path_single_call_submits_tool_call() -> None:
+def test_happy_path_single_call_submits_tool_call(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     handler = ArksimLiveKitHandler()
 
     handler.on_function_tools_executed(_event())
 
-    calls = _calls_received(receiver)
-    assert len(calls) == 1
-    tc = calls[0]
+    tc = only_call(receiver)
     assert tc.id == "call_1"
     assert tc.name == "get_weather"
     assert tc.arguments == {"city": "NYC"}
@@ -86,7 +87,7 @@ def test_happy_path_single_call_submits_tool_call() -> None:
     assert tc.source == ToolCallSource.LIVEKIT
 
 
-def test_is_error_output_populates_error_field() -> None:
+def test_is_error_output_populates_error_field(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     handler = ArksimLiveKitHandler()
@@ -98,9 +99,7 @@ def test_is_error_output_populates_error_field() -> None:
         )
     )
 
-    calls = _calls_received(receiver)
-    assert len(calls) == 1
-    tc = calls[0]
+    tc = only_call(receiver)
     assert tc.name == "get_weather"
     assert tc.error == "ValueError: nope"
     assert tc.result is None
@@ -166,7 +165,7 @@ def test_batch_event_with_multiple_parallel_calls() -> None:
     assert calls[1].result == "r2"
 
 
-def test_none_output_leaves_result_and_error_unset() -> None:
+def test_none_output_leaves_result_and_error_unset(only_call: OnlyCall) -> None:
     """LiveKit sets output to None when a tool raises StopResponse."""
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
@@ -179,16 +178,14 @@ def test_none_output_leaves_result_and_error_unset() -> None:
         )
     )
 
-    calls = _calls_received(receiver)
-    assert len(calls) == 1
-    tc = calls[0]
+    tc = only_call(receiver)
     assert tc.name == "get_weather"
     assert tc.result is None
     assert tc.error is None
     assert tc.source == ToolCallSource.LIVEKIT
 
 
-def test_non_json_arguments_wrapped_in_value() -> None:
+def test_non_json_arguments_wrapped_in_value(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     handler = ArksimLiveKitHandler()
@@ -200,12 +197,11 @@ def test_non_json_arguments_wrapped_in_value() -> None:
         )
     )
 
-    calls = _calls_received(receiver)
-    assert len(calls) == 1
-    assert calls[0].arguments == {"_value": "raw-string-not-json"}
+    tc = only_call(receiver)
+    assert tc.arguments == {"_value": "raw-string-not-json"}
 
 
-def test_non_string_output_coerced_to_str() -> None:
+def test_non_string_output_coerced_to_str(only_call: OnlyCall) -> None:
     """Defensive coercion: if LiveKit ever emits a non-string error/result
     object, the adapter must stringify rather than raise ``ValidationError``
     inside the event loop. LiveKit's current model types ``output`` as
@@ -229,9 +225,7 @@ def test_non_string_output_coerced_to_str() -> None:
 
     handler.on_function_tools_executed(event)
 
-    calls = _calls_received(receiver)
-    assert len(calls) == 1
-    tc = calls[0]
+    tc = only_call(receiver)
     assert tc.error == str(structured)
     assert tc.result is None
 

--- a/tests/unit/integrations/test_livekit_adapter.py
+++ b/tests/unit/integrations/test_livekit_adapter.py
@@ -3,24 +3,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
 from livekit.agents.llm.chat_context import FunctionCall, FunctionCallOutput
 from livekit.agents.voice.events import FunctionToolsExecutedEvent
 
 from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
-from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.context import _set_trace_context
 from arksim.tracing.integrations.livekit import ArksimLiveKitHandler
-
-
-@pytest.fixture(autouse=True)
-def _clean_context() -> Iterator[None]:
-    _clear_trace_context()
-    yield
-    _clear_trace_context()
 
 
 def _call(

--- a/tests/unit/integrations/test_livekit_adapter.py
+++ b/tests/unit/integrations/test_livekit_adapter.py
@@ -214,6 +214,37 @@ def test_non_json_arguments_wrapped_in_value() -> None:
     assert calls[0].arguments == {"_value": "raw-string-not-json"}
 
 
+def test_non_string_output_coerced_to_str() -> None:
+    """Defensive coercion: if LiveKit ever emits a non-string error/result
+    object, the adapter must stringify rather than raise ``ValidationError``
+    inside the event loop. LiveKit's current model types ``output`` as
+    ``str``; ``model_construct`` bypasses that to exercise the coercion.
+    """
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLiveKitHandler()
+
+    structured = {"code": 500, "msg": "boom"}
+    bad_output = FunctionCallOutput.model_construct(
+        call_id="call_1",
+        name="get_weather",
+        output=structured,  # type: ignore[arg-type]
+        is_error=True,
+    )
+    event = FunctionToolsExecutedEvent(
+        function_calls=[_call()],
+        function_call_outputs=[bad_output],
+    )
+
+    handler.on_function_tools_executed(event)
+
+    calls = _calls_received(receiver)
+    assert len(calls) == 1
+    tc = calls[0]
+    assert tc.error == str(structured)
+    assert tc.result is None
+
+
 def test_attach_to_session_subscribes_event() -> None:
     """attach_to must call session.on with the verified event name."""
     handler = ArksimLiveKitHandler()

--- a/tests/unit/integrations/test_livekit_adapter.py
+++ b/tests/unit/integrations/test_livekit_adapter.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ArksimLiveKitHandler."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from livekit.agents.llm.chat_context import FunctionCall, FunctionCallOutput
+from livekit.agents.voice.events import FunctionToolsExecutedEvent
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.integrations.livekit import ArksimLiveKitHandler
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> Iterator[None]:
+    _clear_trace_context()
+    yield
+    _clear_trace_context()
+
+
+def _call(
+    *,
+    name: str = "get_weather",
+    arguments: str = '{"city": "NYC"}',
+    call_id: str = "call_1",
+) -> FunctionCall:
+    return FunctionCall(
+        call_id=call_id,
+        arguments=arguments,
+        name=name,
+    )
+
+
+def _output(
+    *,
+    call_id: str = "call_1",
+    name: str = "get_weather",
+    output: str = "sunny 75F",
+    is_error: bool = False,
+) -> FunctionCallOutput:
+    return FunctionCallOutput(
+        call_id=call_id,
+        name=name,
+        output=output,
+        is_error=is_error,
+    )
+
+
+def _event(
+    *,
+    function_calls: list[FunctionCall] | None = None,
+    function_call_outputs: list[FunctionCallOutput | None] | None = None,
+) -> FunctionToolsExecutedEvent:
+    if function_calls is None:
+        function_calls = [_call()]
+    if function_call_outputs is None:
+        function_call_outputs = [_output()]
+    return FunctionToolsExecutedEvent(
+        function_calls=function_calls,
+        function_call_outputs=function_call_outputs,
+    )
+
+
+def _calls_received(receiver: MagicMock) -> list[ToolCall]:
+    """Flatten all tool_calls passed to receiver.submit_tool_calls."""
+    collected: list[ToolCall] = []
+    for call in receiver.submit_tool_calls.call_args_list:
+        conv, turn, tool_calls = call.args
+        assert conv == "conv-1"
+        assert turn == 0
+        collected.extend(tool_calls)
+    return collected
+
+
+def test_happy_path_single_call_submits_tool_call() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLiveKitHandler()
+
+    handler.on_function_tools_executed(_event())
+
+    calls = _calls_received(receiver)
+    assert len(calls) == 1
+    tc = calls[0]
+    assert tc.id == "call_1"
+    assert tc.name == "get_weather"
+    assert tc.arguments == {"city": "NYC"}
+    assert tc.result == "sunny 75F"
+    assert tc.error is None
+    assert tc.source == ToolCallSource.LIVEKIT
+
+
+def test_is_error_output_populates_error_field() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLiveKitHandler()
+
+    handler.on_function_tools_executed(
+        _event(
+            function_calls=[_call()],
+            function_call_outputs=[_output(output="ValueError: nope", is_error=True)],
+        )
+    )
+
+    calls = _calls_received(receiver)
+    assert len(calls) == 1
+    tc = calls[0]
+    assert tc.name == "get_weather"
+    assert tc.error == "ValueError: nope"
+    assert tc.result is None
+    assert tc.source == ToolCallSource.LIVEKIT
+
+
+def test_source_field_set_on_success_and_error() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLiveKitHandler()
+
+    handler.on_function_tools_executed(_event())
+    handler.on_function_tools_executed(
+        _event(
+            function_calls=[_call()],
+            function_call_outputs=[_output(output="boom", is_error=True)],
+        )
+    )
+
+    calls = _calls_received(receiver)
+    assert len(calls) == 2
+    for tc in calls:
+        assert tc.source == ToolCallSource.LIVEKIT
+
+
+def test_no_trace_context_silently_drops() -> None:
+    receiver = MagicMock()
+    # Deliberately do NOT call _set_trace_context.
+    handler = ArksimLiveKitHandler()
+
+    handler.on_function_tools_executed(_event())
+
+    receiver.submit_tool_calls.assert_not_called()
+
+
+def test_batch_event_with_multiple_parallel_calls() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLiveKitHandler()
+
+    handler.on_function_tools_executed(
+        _event(
+            function_calls=[
+                _call(name="a", arguments='{"x": 1}', call_id="c1"),
+                _call(name="b", arguments='{"y": 2}', call_id="c2"),
+            ],
+            function_call_outputs=[
+                _output(call_id="c1", name="a", output="r1"),
+                _output(call_id="c2", name="b", output="r2"),
+            ],
+        )
+    )
+
+    calls = _calls_received(receiver)
+    assert len(calls) == 2
+    assert calls[0].id == "c1"
+    assert calls[0].name == "a"
+    assert calls[0].arguments == {"x": 1}
+    assert calls[0].result == "r1"
+    assert calls[1].id == "c2"
+    assert calls[1].name == "b"
+    assert calls[1].arguments == {"y": 2}
+    assert calls[1].result == "r2"
+
+
+def test_none_output_leaves_result_and_error_unset() -> None:
+    """LiveKit sets output to None when a tool raises StopResponse."""
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLiveKitHandler()
+
+    handler.on_function_tools_executed(
+        _event(
+            function_calls=[_call()],
+            function_call_outputs=[None],
+        )
+    )
+
+    calls = _calls_received(receiver)
+    assert len(calls) == 1
+    tc = calls[0]
+    assert tc.name == "get_weather"
+    assert tc.result is None
+    assert tc.error is None
+    assert tc.source == ToolCallSource.LIVEKIT
+
+
+def test_non_json_arguments_wrapped_in_value() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    handler = ArksimLiveKitHandler()
+
+    handler.on_function_tools_executed(
+        _event(
+            function_calls=[_call(arguments="raw-string-not-json")],
+            function_call_outputs=[_output()],
+        )
+    )
+
+    calls = _calls_received(receiver)
+    assert len(calls) == 1
+    assert calls[0].arguments == {"_value": "raw-string-not-json"}
+
+
+def test_attach_to_session_subscribes_event() -> None:
+    """attach_to must call session.on with the verified event name."""
+    handler = ArksimLiveKitHandler()
+    session: Any = MagicMock()
+
+    handler.attach_to(session)
+
+    session.on.assert_called_once_with(
+        "function_tools_executed", handler.on_function_tools_executed
+    )

--- a/tests/unit/integrations/test_llamaindex_adapter.py
+++ b/tests/unit/integrations/test_llamaindex_adapter.py
@@ -230,3 +230,43 @@ def test_non_tool_event_ignored() -> None:
     observer.observe(object())
 
     receiver.submit_tool_calls.assert_not_called()
+
+
+def test_non_string_content_coerced_to_str() -> None:
+    """Defensive coercion: if a custom ToolOutput returns a non-string
+    content, the adapter must stringify rather than raise ValidationError
+    when constructing ToolCall.result.
+    """
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimLlamaIndexObserver()
+
+    structured = {"status": "ok", "rows": 3}
+
+    class _StructuredToolOutput(ToolOutput):
+        @property
+        def content(self) -> object:  # type: ignore[override]
+            return structured
+
+    custom = _StructuredToolOutput(
+        tool_name="get_weather",
+        content="placeholder",
+        raw_input={"city": "NYC"},
+        raw_output=structured,
+        is_error=False,
+        exception=None,
+    )
+    result = LIToolCallResult(
+        tool_name="get_weather",
+        tool_kwargs={"city": "NYC"},
+        tool_id="t1",
+        tool_output=custom,
+        return_direct=False,
+    )
+
+    observer.observe(_start())
+    observer.observe(result)
+
+    tc = _only_call(receiver)
+    assert tc.result == str(structured)
+    assert tc.error is None

--- a/tests/unit/integrations/test_llamaindex_adapter.py
+++ b/tests/unit/integrations/test_llamaindex_adapter.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,15 +12,10 @@ from llama_index.core.agent.workflow import ToolCallResult as LIToolCallResult
 from llama_index.core.tools.types import ToolOutput
 
 from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
-from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.context import _set_trace_context
 from arksim.tracing.integrations.llamaindex import ArksimLlamaIndexObserver
 
-
-@pytest.fixture(autouse=True)
-def _clean_context() -> Iterator[None]:
-    _clear_trace_context()
-    yield
-    _clear_trace_context()
+OnlyCall = Callable[[MagicMock], ToolCall]
 
 
 def _start(
@@ -62,17 +57,9 @@ def _result(
     )
 
 
-def _only_call(receiver: MagicMock) -> ToolCall:
-    assert receiver.submit_tool_calls.call_count == 1
-    args, _ = receiver.submit_tool_calls.call_args
-    conv, turn, tool_calls = args
-    assert conv == "conv-1"
-    assert turn == 0
-    assert len(tool_calls) == 1
-    return tool_calls[0]
-
-
-def test_happy_path_split_events_produce_single_tool_call() -> None:
+def test_happy_path_split_events_produce_single_tool_call(
+    only_call: OnlyCall,
+) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     observer = ArksimLlamaIndexObserver()
@@ -80,7 +67,7 @@ def test_happy_path_split_events_produce_single_tool_call() -> None:
     observer.observe(_start())
     observer.observe(_result())
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.id == "t1"
     assert tc.name == "get_weather"
     assert tc.arguments == {"city": "NYC"}
@@ -89,7 +76,9 @@ def test_happy_path_split_events_produce_single_tool_call() -> None:
     assert tc.source == ToolCallSource.LLAMAINDEX
 
 
-def test_error_path_with_exception_formats_type_and_message() -> None:
+def test_error_path_with_exception_formats_type_and_message(
+    only_call: OnlyCall,
+) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     observer = ArksimLlamaIndexObserver()
@@ -103,7 +92,7 @@ def test_error_path_with_exception_formats_type_and_message() -> None:
         )
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.name == "get_weather"
     assert tc.arguments == {"city": "NYC"}
     assert tc.error == "ValueError: nope"
@@ -111,7 +100,9 @@ def test_error_path_with_exception_formats_type_and_message() -> None:
     assert tc.source == ToolCallSource.LLAMAINDEX
 
 
-def test_is_error_without_exception_falls_back_to_content() -> None:
+def test_is_error_without_exception_falls_back_to_content(
+    only_call: OnlyCall,
+) -> None:
     """is_error=True with no exception means error message is in content."""
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
@@ -126,7 +117,7 @@ def test_is_error_without_exception_falls_back_to_content() -> None:
         )
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.error == "Tool get_weather not found."
     assert tc.result is None
     assert tc.source == ToolCallSource.LLAMAINDEX
@@ -207,7 +198,7 @@ def test_multiple_concurrent_tool_calls_correlate_by_tool_id() -> None:
     assert second.result == "r1"
 
 
-def test_empty_tool_kwargs_yields_empty_arguments() -> None:
+def test_empty_tool_kwargs_yields_empty_arguments(only_call: OnlyCall) -> None:
     """LlamaIndex always types tool_kwargs as dict, so {} is the no-arg case."""
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
@@ -216,7 +207,7 @@ def test_empty_tool_kwargs_yields_empty_arguments() -> None:
     observer.observe(_start(tool_kwargs={}))
     observer.observe(_result(tool_kwargs={}))
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.arguments == {}
 
 
@@ -232,7 +223,7 @@ def test_non_tool_event_ignored() -> None:
     receiver.submit_tool_calls.assert_not_called()
 
 
-def test_non_string_content_coerced_to_str() -> None:
+def test_non_string_content_coerced_to_str(only_call: OnlyCall) -> None:
     """Defensive coercion: if a custom ToolOutput returns a non-string
     content, the adapter must stringify rather than raise ValidationError
     when constructing ToolCall.result.
@@ -267,6 +258,6 @@ def test_non_string_content_coerced_to_str() -> None:
     observer.observe(_start())
     observer.observe(result)
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.result == str(structured)
     assert tc.error is None

--- a/tests/unit/integrations/test_llamaindex_adapter.py
+++ b/tests/unit/integrations/test_llamaindex_adapter.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ArksimLlamaIndexObserver split-event correlation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+from llama_index.core.agent.workflow import ToolCall as LIToolCall
+from llama_index.core.agent.workflow import ToolCallResult as LIToolCallResult
+from llama_index.core.tools.types import ToolOutput
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.integrations.llamaindex import ArksimLlamaIndexObserver
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> Iterator[None]:
+    _clear_trace_context()
+    yield
+    _clear_trace_context()
+
+
+def _start(
+    *,
+    tool_name: str = "get_weather",
+    tool_kwargs: dict[str, object] | None = None,
+    tool_id: str = "t1",
+) -> LIToolCall:
+    return LIToolCall(
+        tool_name=tool_name,
+        tool_kwargs=tool_kwargs if tool_kwargs is not None else {"city": "NYC"},
+        tool_id=tool_id,
+    )
+
+
+def _result(
+    *,
+    tool_name: str = "get_weather",
+    tool_kwargs: dict[str, object] | None = None,
+    tool_id: str = "t1",
+    output: str = "sunny 75F",
+    is_error: bool = False,
+    exception: Exception | None = None,
+) -> LIToolCallResult:
+    tool_output = ToolOutput(
+        tool_name=tool_name,
+        content=output,
+        raw_input=tool_kwargs if tool_kwargs is not None else {"city": "NYC"},
+        raw_output=output,
+        is_error=is_error,
+        exception=exception,
+    )
+    return LIToolCallResult(
+        tool_name=tool_name,
+        tool_kwargs=tool_kwargs if tool_kwargs is not None else {"city": "NYC"},
+        tool_id=tool_id,
+        tool_output=tool_output,
+        return_direct=False,
+    )
+
+
+def _only_call(receiver: MagicMock) -> ToolCall:
+    assert receiver.submit_tool_calls.call_count == 1
+    args, _ = receiver.submit_tool_calls.call_args
+    conv, turn, tool_calls = args
+    assert conv == "conv-1"
+    assert turn == 0
+    assert len(tool_calls) == 1
+    return tool_calls[0]
+
+
+def test_happy_path_split_events_produce_single_tool_call() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimLlamaIndexObserver()
+
+    observer.observe(_start())
+    observer.observe(_result())
+
+    tc = _only_call(receiver)
+    assert tc.id == "t1"
+    assert tc.name == "get_weather"
+    assert tc.arguments == {"city": "NYC"}
+    assert tc.result == "sunny 75F"
+    assert tc.error is None
+    assert tc.source == ToolCallSource.LLAMAINDEX
+
+
+def test_error_path_with_exception_formats_type_and_message() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimLlamaIndexObserver()
+
+    observer.observe(_start())
+    observer.observe(
+        _result(
+            output="",
+            is_error=True,
+            exception=ValueError("nope"),
+        )
+    )
+
+    tc = _only_call(receiver)
+    assert tc.name == "get_weather"
+    assert tc.arguments == {"city": "NYC"}
+    assert tc.error == "ValueError: nope"
+    assert tc.result is None
+    assert tc.source == ToolCallSource.LLAMAINDEX
+
+
+def test_is_error_without_exception_falls_back_to_content() -> None:
+    """is_error=True with no exception means error message is in content."""
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimLlamaIndexObserver()
+
+    observer.observe(_start())
+    observer.observe(
+        _result(
+            output="Tool get_weather not found.",
+            is_error=True,
+            exception=None,
+        )
+    )
+
+    tc = _only_call(receiver)
+    assert tc.error == "Tool get_weather not found."
+    assert tc.result is None
+    assert tc.source == ToolCallSource.LLAMAINDEX
+
+
+def test_source_field_set_on_success_and_error() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimLlamaIndexObserver()
+
+    observer.observe(_start(tool_id="t1"))
+    observer.observe(_result(tool_id="t1"))
+    observer.observe(_start(tool_id="t2"))
+    observer.observe(
+        _result(
+            tool_id="t2",
+            is_error=True,
+            exception=RuntimeError("x"),
+        )
+    )
+
+    assert receiver.submit_tool_calls.call_count == 2
+    for call in receiver.submit_tool_calls.call_args_list:
+        tool_call = call.args[2][0]
+        assert tool_call.source == ToolCallSource.LLAMAINDEX
+
+
+def test_no_trace_context_silently_drops() -> None:
+    receiver = MagicMock()
+    # Deliberately do NOT call _set_trace_context.
+    observer = ArksimLlamaIndexObserver()
+
+    observer.observe(_start())
+    observer.observe(_result())
+
+    receiver.submit_tool_calls.assert_not_called()
+
+
+def test_unmatched_result_logs_and_does_not_submit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimLlamaIndexObserver()
+
+    with caplog.at_level("DEBUG", logger="arksim.tracing.integrations.llamaindex"):
+        observer.observe(_result(tool_id="unknown"))
+
+    receiver.submit_tool_calls.assert_not_called()
+    assert "unmatched" in caplog.text.lower()
+
+
+def test_multiple_concurrent_tool_calls_correlate_by_tool_id() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimLlamaIndexObserver()
+
+    observer.observe(_start(tool_name="a", tool_kwargs={"x": 1}, tool_id="t1"))
+    observer.observe(_start(tool_name="b", tool_kwargs={"y": 2}, tool_id="t2"))
+    observer.observe(
+        _result(tool_name="b", tool_kwargs={"y": 2}, tool_id="t2", output="r2")
+    )
+    observer.observe(
+        _result(tool_name="a", tool_kwargs={"x": 1}, tool_id="t1", output="r1")
+    )
+
+    assert receiver.submit_tool_calls.call_count == 2
+    first = receiver.submit_tool_calls.call_args_list[0].args[2][0]
+    second = receiver.submit_tool_calls.call_args_list[1].args[2][0]
+    # results arrive in the order they were observed (b then a)
+    assert first.id == "t2"
+    assert first.name == "b"
+    assert first.arguments == {"y": 2}
+    assert first.result == "r2"
+    assert second.id == "t1"
+    assert second.name == "a"
+    assert second.arguments == {"x": 1}
+    assert second.result == "r1"
+
+
+def test_empty_tool_kwargs_yields_empty_arguments() -> None:
+    """LlamaIndex always types tool_kwargs as dict, so {} is the no-arg case."""
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimLlamaIndexObserver()
+
+    observer.observe(_start(tool_kwargs={}))
+    observer.observe(_result(tool_kwargs={}))
+
+    tc = _only_call(receiver)
+    assert tc.arguments == {}
+
+
+def test_non_tool_event_ignored() -> None:
+    """Non-ToolCall/ToolCallResult events from the workflow stream are no-ops."""
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimLlamaIndexObserver()
+
+    # An AgentStream/AgentOutput would be an Event subclass that isn't a tool event.
+    observer.observe(object())
+
+    receiver.submit_tool_calls.assert_not_called()

--- a/tests/unit/integrations/test_pending_tool_calls.py
+++ b/tests/unit/integrations/test_pending_tool_calls.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for PendingToolCalls split-event correlation helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from arksim.tracing.integrations import _pending
+from arksim.tracing.integrations._pending import PendingToolCalls
+
+
+def test_add_then_pop_returns_payload() -> None:
+    pending = PendingToolCalls()
+    payload = {"name": "search", "args": {"q": "x"}}
+    pending.add("r1", payload)
+    assert pending.pop("r1") == payload
+
+
+def test_pop_missing_returns_none() -> None:
+    pending = PendingToolCalls()
+    assert pending.pop("never-added") is None
+
+
+def test_stale_entries_swept_on_add(monkeypatch: pytest.MonkeyPatch) -> None:
+    pending = PendingToolCalls(max_age_seconds=60.0)
+    now = 1000.0
+    monkeypatch.setattr(_pending.time, "monotonic", lambda: now)
+    pending.add("r1", {"k": "v"})
+
+    later = now + 100.0
+    monkeypatch.setattr(_pending.time, "monotonic", lambda: later)
+    pending.add("r2", {"k2": "v2"})
+
+    assert pending.pop("r1") is None
+    assert pending.pop("r2") == {"k2": "v2"}
+
+
+def test_stale_entries_swept_on_pop(monkeypatch: pytest.MonkeyPatch) -> None:
+    pending = PendingToolCalls(max_age_seconds=60.0)
+    now = 1000.0
+    monkeypatch.setattr(_pending.time, "monotonic", lambda: now)
+    pending.add("r1", {"k": "v"})
+
+    later = now + 100.0
+    monkeypatch.setattr(_pending.time, "monotonic", lambda: later)
+    assert pending.pop("r1") is None
+
+
+def test_pop_consumes_entry() -> None:
+    pending = PendingToolCalls()
+    payload = {"k": "v"}
+    pending.add("r1", payload)
+    assert pending.pop("r1") == payload
+    assert pending.pop("r1") is None

--- a/tests/unit/integrations/test_pending_tool_calls.py
+++ b/tests/unit/integrations/test_pending_tool_calls.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import threading
+from uuid import uuid4
+
 import pytest
 
 from arksim.tracing.integrations import _pending
@@ -52,3 +55,38 @@ def test_pop_consumes_entry() -> None:
     pending.add("r1", payload)
     assert pending.pop("r1") == payload
     assert pending.pop("r1") is None
+
+
+def test_concurrent_add_pop_thread_safety() -> None:
+    """Concurrent add/pop from 10 threads must not raise or corrupt state.
+
+    LangChain dispatches sync ``BaseCallbackHandler`` methods on a thread
+    pool when tools block, so ``PendingToolCalls`` is reachable from
+    multiple threads. Without the internal lock, ``dict`` iteration during
+    sweep can race with mutation and raise ``RuntimeError: dictionary
+    changed size during iteration``.
+    """
+    pending = PendingToolCalls()
+    iterations = 100
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(10)
+
+    def worker() -> None:
+        barrier.wait()
+        try:
+            for _ in range(iterations):
+                rid = uuid4().hex
+                pending.add(rid, {"k": rid})
+                pending.pop(rid)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    # Each worker pops what it adds, so the map ends empty.
+    assert pending.pop("anything") is None

--- a/tests/unit/integrations/test_smolagents_adapter.py
+++ b/tests/unit/integrations/test_smolagents_adapter.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 from smolagents.memory import ActionStep, PlanningStep
@@ -10,9 +11,11 @@ from smolagents.memory import ToolCall as SmolToolCall
 from smolagents.models import ChatMessage, MessageRole
 from smolagents.monitoring import Timing
 
-from arksim.simulation_engine.tool_types import ToolCallSource
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
 from arksim.tracing.context import _set_trace_context
 from arksim.tracing.integrations.smolagents import ArksimSmolagentsCallback
+
+OnlyCall = Callable[[MagicMock], ToolCall]
 
 
 def _action_step(
@@ -43,7 +46,7 @@ def _planning_step() -> PlanningStep:
     )
 
 
-def test_happy_path_action_step_submits_tool_call() -> None:
+def test_happy_path_action_step_submits_tool_call(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     observer = ArksimSmolagentsCallback()
@@ -61,13 +64,7 @@ def test_happy_path_action_step_submits_tool_call() -> None:
         )
     )
 
-    assert receiver.submit_tool_calls.call_count == 1
-    args, _ = receiver.submit_tool_calls.call_args
-    conv, turn, tool_calls = args
-    assert conv == "conv-1"
-    assert turn == 0
-    assert len(tool_calls) == 1
-    tc = tool_calls[0]
+    tc = only_call(receiver)
     assert tc.id == "call_1"
     assert tc.name == "get_weather"
     assert tc.arguments == {"city": "NYC"}
@@ -153,7 +150,7 @@ def test_multiple_tool_calls_in_one_step_each_submitted() -> None:
     assert second.result == "shared result"
 
 
-def test_none_arguments_yields_empty_dict() -> None:
+def test_none_arguments_yields_empty_dict(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     observer = ArksimSmolagentsCallback()
@@ -165,12 +162,11 @@ def test_none_arguments_yields_empty_dict() -> None:
         )
     )
 
-    args, _ = receiver.submit_tool_calls.call_args
-    tc = args[2][0]
+    tc = only_call(receiver)
     assert tc.arguments == {}
 
 
-def test_non_dict_arguments_wrapped_in_value() -> None:
+def test_non_dict_arguments_wrapped_in_value(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     observer = ArksimSmolagentsCallback()
@@ -182,12 +178,11 @@ def test_non_dict_arguments_wrapped_in_value() -> None:
         )
     )
 
-    args, _ = receiver.submit_tool_calls.call_args
-    tc = args[2][0]
+    tc = only_call(receiver)
     assert tc.arguments == {"_value": "raw"}
 
 
-def test_empty_observation_preserved_as_empty_string() -> None:
+def test_empty_observation_preserved_as_empty_string(only_call: OnlyCall) -> None:
     """observations='' should round-trip as result='', distinguishable from None."""
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
@@ -200,6 +195,5 @@ def test_empty_observation_preserved_as_empty_string() -> None:
         )
     )
 
-    args, _ = receiver.submit_tool_calls.call_args
-    tc = args[2][0]
+    tc = only_call(receiver)
     assert tc.result == ""

--- a/tests/unit/integrations/test_smolagents_adapter.py
+++ b/tests/unit/integrations/test_smolagents_adapter.py
@@ -185,3 +185,21 @@ def test_non_dict_arguments_wrapped_in_value() -> None:
     args, _ = receiver.submit_tool_calls.call_args
     tc = args[2][0]
     assert tc.arguments == {"_value": "raw"}
+
+
+def test_empty_observation_preserved_as_empty_string() -> None:
+    """observations='' should round-trip as result='', distinguishable from None."""
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimSmolagentsCallback()
+
+    observer(
+        _action_step(
+            tool_calls=[_smol_tool_call(arguments={"x": 1})],
+            observations="",
+        )
+    )
+
+    args, _ = receiver.submit_tool_calls.call_args
+    tc = args[2][0]
+    assert tc.result == ""

--- a/tests/unit/integrations/test_smolagents_adapter.py
+++ b/tests/unit/integrations/test_smolagents_adapter.py
@@ -3,25 +3,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from unittest.mock import MagicMock
 
-import pytest
 from smolagents.memory import ActionStep, PlanningStep
 from smolagents.memory import ToolCall as SmolToolCall
 from smolagents.models import ChatMessage, MessageRole
 from smolagents.monitoring import Timing
 
 from arksim.simulation_engine.tool_types import ToolCallSource
-from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.context import _set_trace_context
 from arksim.tracing.integrations.smolagents import ArksimSmolagentsCallback
-
-
-@pytest.fixture(autouse=True)
-def _clean_context() -> Iterator[None]:
-    _clear_trace_context()
-    yield
-    _clear_trace_context()
 
 
 def _action_step(

--- a/tests/unit/integrations/test_smolagents_adapter.py
+++ b/tests/unit/integrations/test_smolagents_adapter.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ArksimSmolagentsCallback."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+from smolagents.memory import ActionStep, PlanningStep
+from smolagents.memory import ToolCall as SmolToolCall
+from smolagents.models import ChatMessage, MessageRole
+from smolagents.monitoring import Timing
+
+from arksim.simulation_engine.tool_types import ToolCallSource
+from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.integrations.smolagents import ArksimSmolagentsCallback
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> Iterator[None]:
+    _clear_trace_context()
+    yield
+    _clear_trace_context()
+
+
+def _action_step(
+    *,
+    tool_calls: list[SmolToolCall] | None = None,
+    observations: str | None = None,
+) -> ActionStep:
+    return ActionStep(
+        step_number=1,
+        timing=Timing(start_time=0.0, end_time=1.0),
+        tool_calls=tool_calls,
+        observations=observations,
+    )
+
+
+def _smol_tool_call(
+    *, name: str = "get_weather", arguments: object = None, call_id: str = "call_1"
+) -> SmolToolCall:
+    return SmolToolCall(name=name, arguments=arguments, id=call_id)
+
+
+def _planning_step() -> PlanningStep:
+    return PlanningStep(
+        model_input_messages=[],
+        model_output_message=ChatMessage(role=MessageRole.ASSISTANT, content=""),
+        plan="plan text",
+        timing=Timing(start_time=0.0, end_time=1.0),
+    )
+
+
+def test_happy_path_action_step_submits_tool_call() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimSmolagentsCallback()
+
+    observer(
+        _action_step(
+            tool_calls=[
+                _smol_tool_call(
+                    name="get_weather",
+                    arguments={"city": "NYC"},
+                    call_id="call_1",
+                )
+            ],
+            observations="sunny 75F",
+        )
+    )
+
+    assert receiver.submit_tool_calls.call_count == 1
+    args, _ = receiver.submit_tool_calls.call_args
+    conv, turn, tool_calls = args
+    assert conv == "conv-1"
+    assert turn == 0
+    assert len(tool_calls) == 1
+    tc = tool_calls[0]
+    assert tc.id == "call_1"
+    assert tc.name == "get_weather"
+    assert tc.arguments == {"city": "NYC"}
+    assert tc.result == "sunny 75F"
+    assert tc.error is None
+    assert tc.source == ToolCallSource.SMOLAGENTS
+
+
+def test_source_field_set_on_every_emission() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimSmolagentsCallback()
+
+    observer(
+        _action_step(
+            tool_calls=[_smol_tool_call(arguments={"x": 1})],
+            observations="r1",
+        )
+    )
+    observer(
+        _action_step(
+            tool_calls=[_smol_tool_call(arguments={"y": 2}, call_id="call_2")],
+            observations="r2",
+        )
+    )
+
+    assert receiver.submit_tool_calls.call_count == 2
+    for call in receiver.submit_tool_calls.call_args_list:
+        tool_call = call.args[2][0]
+        assert tool_call.source == ToolCallSource.SMOLAGENTS
+
+
+def test_no_trace_context_silently_drops() -> None:
+    receiver = MagicMock()
+    # Deliberately do NOT call _set_trace_context.
+    observer = ArksimSmolagentsCallback()
+
+    observer(
+        _action_step(
+            tool_calls=[_smol_tool_call(arguments={"x": 1})],
+            observations="r",
+        )
+    )
+
+    receiver.submit_tool_calls.assert_not_called()
+
+
+def test_non_action_step_ignored() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimSmolagentsCallback()
+
+    observer(_planning_step())
+
+    receiver.submit_tool_calls.assert_not_called()
+
+
+def test_multiple_tool_calls_in_one_step_each_submitted() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimSmolagentsCallback()
+
+    observer(
+        _action_step(
+            tool_calls=[
+                _smol_tool_call(name="a", arguments={"x": 1}, call_id="c1"),
+                _smol_tool_call(name="b", arguments={"y": 2}, call_id="c2"),
+            ],
+            observations="shared result",
+        )
+    )
+
+    assert receiver.submit_tool_calls.call_count == 2
+    first = receiver.submit_tool_calls.call_args_list[0].args[2][0]
+    second = receiver.submit_tool_calls.call_args_list[1].args[2][0]
+    assert first.id == "c1"
+    assert first.name == "a"
+    assert first.arguments == {"x": 1}
+    assert first.result == "shared result"
+    assert second.id == "c2"
+    assert second.name == "b"
+    assert second.arguments == {"y": 2}
+    assert second.result == "shared result"
+
+
+def test_none_arguments_yields_empty_dict() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimSmolagentsCallback()
+
+    observer(
+        _action_step(
+            tool_calls=[_smol_tool_call(arguments=None)],
+            observations="ok",
+        )
+    )
+
+    args, _ = receiver.submit_tool_calls.call_args
+    tc = args[2][0]
+    assert tc.arguments == {}
+
+
+def test_non_dict_arguments_wrapped_in_value() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    observer = ArksimSmolagentsCallback()
+
+    observer(
+        _action_step(
+            tool_calls=[_smol_tool_call(arguments="raw")],
+            observations="ok",
+        )
+    )
+
+    args, _ = receiver.submit_tool_calls.call_args
+    tc = args[2][0]
+    assert tc.arguments == {"_value": "raw"}

--- a/tests/unit/integrations/test_strands_adapter.py
+++ b/tests/unit/integrations/test_strands_adapter.py
@@ -3,24 +3,18 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable
 from typing import Any, cast
 from unittest.mock import MagicMock
 
-import pytest
 from strands.hooks import AfterToolCallEvent, HookRegistry
 from strands.types.tools import AgentTool, ToolResult, ToolUse
 
 from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
-from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.context import _set_trace_context
 from arksim.tracing.integrations.strands import ArksimStrandsHookProvider
 
-
-@pytest.fixture(autouse=True)
-def _clean_context() -> Iterator[None]:
-    _clear_trace_context()
-    yield
-    _clear_trace_context()
+OnlyCall = Callable[[MagicMock], ToolCall]
 
 
 def _tool_use(
@@ -76,17 +70,7 @@ def _fire(registry: HookRegistry, event: AfterToolCallEvent) -> None:
     registry.invoke_callbacks(event)
 
 
-def _only_call(receiver: MagicMock) -> ToolCall:
-    assert receiver.submit_tool_calls.call_count == 1
-    args, _ = receiver.submit_tool_calls.call_args
-    conv, turn, tool_calls = args
-    assert conv == "conv-1"
-    assert turn == 0
-    assert len(tool_calls) == 1
-    return tool_calls[0]
-
-
-def test_happy_path_after_tool_call_submits_tool_call() -> None:
+def test_happy_path_after_tool_call_submits_tool_call(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     registry = _register(ArksimStrandsHookProvider())
@@ -101,7 +85,7 @@ def test_happy_path_after_tool_call_submits_tool_call() -> None:
         ),
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.id == "u1"
     assert tc.name == "get_weather"
     assert tc.arguments == {"city": "NYC"}
@@ -111,7 +95,7 @@ def test_happy_path_after_tool_call_submits_tool_call() -> None:
     assert tc.source == ToolCallSource.STRANDS
 
 
-def test_exception_populates_error_field() -> None:
+def test_exception_populates_error_field(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     registry = _register(ArksimStrandsHookProvider())
@@ -124,7 +108,7 @@ def test_exception_populates_error_field() -> None:
         ),
     )
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.name == "get_weather"
     assert tc.arguments == {"city": "NYC"}
     assert tc.error == "ValueError: nope"
@@ -156,25 +140,25 @@ def test_no_trace_context_silently_drops() -> None:
     receiver.submit_tool_calls.assert_not_called()
 
 
-def test_missing_tool_use_input_yields_empty_arguments() -> None:
+def test_missing_tool_use_input_yields_empty_arguments(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     registry = _register(ArksimStrandsHookProvider())
 
     _fire(registry, _make_event(tool_use=_tool_use(tool_input=None)))
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.arguments == {}
 
 
-def test_non_dict_tool_use_input_wrapped_in_value() -> None:
+def test_non_dict_tool_use_input_wrapped_in_value(only_call: OnlyCall) -> None:
     receiver = MagicMock()
     _set_trace_context("conv-1", 0, receiver=receiver)
     registry = _register(ArksimStrandsHookProvider())
 
     _fire(registry, _make_event(tool_use=_tool_use(tool_input="raw")))
 
-    tc = _only_call(receiver)
+    tc = only_call(receiver)
     assert tc.arguments == {"_value": "raw"}
 
 

--- a/tests/unit/integrations/test_strands_adapter.py
+++ b/tests/unit/integrations/test_strands_adapter.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ArksimStrandsHookProvider."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from strands.hooks import AfterToolCallEvent, HookRegistry
+from strands.types.tools import AgentTool, ToolResult, ToolUse
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.context import _clear_trace_context, _set_trace_context
+from arksim.tracing.integrations.strands import ArksimStrandsHookProvider
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> Iterator[None]:
+    _clear_trace_context()
+    yield
+    _clear_trace_context()
+
+
+def _tool_use(
+    *, name: str = "get_weather", tool_input: object = None, use_id: str = "u1"
+) -> ToolUse:
+    """Build a ToolUse TypedDict.
+
+    ``input`` is typed ``Any``, so we can stuff a non-dict in for the
+    "raw value" test case without bending typing.
+    """
+    return cast(
+        "ToolUse",
+        {"name": name, "toolUseId": use_id, "input": tool_input},
+    )
+
+
+def _tool_result(*, output: str = "ok", use_id: str = "u1") -> ToolResult:
+    return cast(
+        "ToolResult",
+        {
+            "toolUseId": use_id,
+            "status": "success",
+            "content": [{"text": output}],
+        },
+    )
+
+
+def _make_event(
+    *,
+    selected_tool: AgentTool | None = None,
+    tool_use: ToolUse | None = None,
+    result: ToolResult | None = None,
+    exception: Exception | None = None,
+) -> AfterToolCallEvent:
+    return AfterToolCallEvent(
+        agent=cast("Any", MagicMock()),
+        selected_tool=selected_tool,
+        tool_use=tool_use if tool_use is not None else _tool_use(),
+        invocation_state={},
+        result=result if result is not None else _tool_result(),
+        exception=exception,
+    )
+
+
+def _register(provider: ArksimStrandsHookProvider) -> HookRegistry:
+    """Run the provider's hook registration and return the populated registry."""
+    registry = HookRegistry()
+    provider.register_hooks(registry)
+    return registry
+
+
+def _fire(registry: HookRegistry, event: AfterToolCallEvent) -> None:
+    registry.invoke_callbacks(event)
+
+
+def _only_call(receiver: MagicMock) -> ToolCall:
+    assert receiver.submit_tool_calls.call_count == 1
+    args, _ = receiver.submit_tool_calls.call_args
+    conv, turn, tool_calls = args
+    assert conv == "conv-1"
+    assert turn == 0
+    assert len(tool_calls) == 1
+    return tool_calls[0]
+
+
+def test_happy_path_after_tool_call_submits_tool_call() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    registry = _register(ArksimStrandsHookProvider())
+
+    _fire(
+        registry,
+        _make_event(
+            tool_use=_tool_use(
+                name="get_weather", tool_input={"city": "NYC"}, use_id="u1"
+            ),
+            result=_tool_result(output="sunny 75F", use_id="u1"),
+        ),
+    )
+
+    tc = _only_call(receiver)
+    assert tc.id == "u1"
+    assert tc.name == "get_weather"
+    assert tc.arguments == {"city": "NYC"}
+    assert tc.result is not None
+    assert "sunny 75F" in tc.result
+    assert tc.error is None
+    assert tc.source == ToolCallSource.STRANDS
+
+
+def test_exception_populates_error_field() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    registry = _register(ArksimStrandsHookProvider())
+
+    _fire(
+        registry,
+        _make_event(
+            tool_use=_tool_use(name="get_weather", tool_input={"city": "NYC"}),
+            exception=ValueError("nope"),
+        ),
+    )
+
+    tc = _only_call(receiver)
+    assert tc.name == "get_weather"
+    assert tc.arguments == {"city": "NYC"}
+    assert tc.error == "ValueError: nope"
+    assert tc.result is None
+    assert tc.source == ToolCallSource.STRANDS
+
+
+def test_source_field_set_on_success_and_exception() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    registry = _register(ArksimStrandsHookProvider())
+
+    _fire(registry, _make_event())
+    _fire(registry, _make_event(exception=RuntimeError("x")))
+
+    assert receiver.submit_tool_calls.call_count == 2
+    for call in receiver.submit_tool_calls.call_args_list:
+        tool_call = call.args[2][0]
+        assert tool_call.source == ToolCallSource.STRANDS
+
+
+def test_no_trace_context_silently_drops() -> None:
+    receiver = MagicMock()
+    # Deliberately do NOT call _set_trace_context.
+    registry = _register(ArksimStrandsHookProvider())
+
+    _fire(registry, _make_event())
+
+    receiver.submit_tool_calls.assert_not_called()
+
+
+def test_missing_tool_use_input_yields_empty_arguments() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    registry = _register(ArksimStrandsHookProvider())
+
+    _fire(registry, _make_event(tool_use=_tool_use(tool_input=None)))
+
+    tc = _only_call(receiver)
+    assert tc.arguments == {}
+
+
+def test_non_dict_tool_use_input_wrapped_in_value() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    registry = _register(ArksimStrandsHookProvider())
+
+    _fire(registry, _make_event(tool_use=_tool_use(tool_input="raw")))
+
+    tc = _only_call(receiver)
+    assert tc.arguments == {"_value": "raw"}
+
+
+def test_multiple_calls_each_submitted() -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+    registry = _register(ArksimStrandsHookProvider())
+
+    _fire(
+        registry,
+        _make_event(
+            tool_use=_tool_use(name="a", tool_input={"x": 1}, use_id="u1"),
+            result=_tool_result(output="r1", use_id="u1"),
+        ),
+    )
+    _fire(
+        registry,
+        _make_event(
+            tool_use=_tool_use(name="b", tool_input={"y": 2}, use_id="u2"),
+            result=_tool_result(output="r2", use_id="u2"),
+        ),
+    )
+
+    assert receiver.submit_tool_calls.call_count == 2
+    first = receiver.submit_tool_calls.call_args_list[0].args[2][0]
+    second = receiver.submit_tool_calls.call_args_list[1].args[2][0]
+    assert first.id == "u1"
+    assert first.name == "a"
+    assert first.arguments == {"x": 1}
+    assert "r1" in (first.result or "")
+    assert second.id == "u2"
+    assert second.name == "b"
+    assert second.arguments == {"y": 2}
+    assert "r2" in (second.result or "")

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -286,3 +286,207 @@ def test_adapter_produces_tool_call_with_correct_source(factory: Factory) -> Non
     assert len(tool_calls) == 1
     assert isinstance(tool_calls[0], ToolCall)
     assert tool_calls[0].source == expected_source
+
+
+@pytest.mark.parametrize("factory", _FACTORIES)
+def test_adapter_no_routing_context_drops(factory: Factory) -> None:
+    """With no trace context set, no adapter must call the receiver.
+
+    Routing context is the only signal that arksim is observing; without
+    it the adapter is being invoked outside a simulation and must stay
+    silent. This is the cross-cutting drop-on-no-context contract.
+    """
+    receiver = MagicMock()
+    # Deliberately do NOT call _set_trace_context.
+
+    fire, _expected_source = factory()
+    fire()
+
+    receiver.submit_tool_calls.assert_not_called()
+
+
+# --- Error-path factories ---------------------------------------------------
+
+
+def _make_langchain_error() -> tuple[Callable[[], None], ToolCallSource]:
+    from arksim.tracing.integrations.langchain import ArksimLangChainHandler
+
+    handler = ArksimLangChainHandler()
+    run_id = uuid4()
+
+    def fire() -> None:
+        handler.on_tool_start({"name": "get_weather"}, '{"city": "NYC"}', run_id=run_id)
+        handler.on_tool_error(ValueError("nope"), run_id=run_id)
+
+    return fire, ToolCallSource.LANGCHAIN
+
+
+def _make_crewai_error() -> tuple[Callable[[], None], ToolCallSource]:
+    from crewai.events import ToolUsageErrorEvent, crewai_event_bus
+
+    from arksim.tracing.integrations.crewai import ArksimCrewEventListener
+
+    scope = crewai_event_bus.scoped_handlers()
+    scope.__enter__()
+    ArksimCrewEventListener()
+    now = datetime.now(timezone.utc)
+    event = ToolUsageErrorEvent(
+        timestamp=now,
+        tool_name="get_weather",
+        tool_args={"city": "NYC"},
+        error=ValueError("nope"),
+    )
+
+    def fire() -> None:
+        try:
+            future = crewai_event_bus.emit(source=object(), event=event)
+            if future is not None:
+                future.result(timeout=5.0)
+        finally:
+            scope.__exit__(None, None, None)
+
+    return fire, ToolCallSource.CREWAI
+
+
+def _make_livekit_error() -> tuple[Callable[[], None], ToolCallSource]:
+    from livekit.agents.llm.chat_context import FunctionCall, FunctionCallOutput
+    from livekit.agents.voice.events import FunctionToolsExecutedEvent
+
+    from arksim.tracing.integrations.livekit import ArksimLiveKitHandler
+
+    handler = ArksimLiveKitHandler()
+    event = FunctionToolsExecutedEvent(
+        function_calls=[
+            FunctionCall(
+                call_id="call_1", arguments='{"city": "NYC"}', name="get_weather"
+            )
+        ],
+        function_call_outputs=[
+            FunctionCallOutput(
+                call_id="call_1",
+                name="get_weather",
+                output="ValueError: nope",
+                is_error=True,
+            )
+        ],
+    )
+
+    def fire() -> None:
+        handler.on_function_tools_executed(event)
+
+    return fire, ToolCallSource.LIVEKIT
+
+
+def _make_strands_error() -> tuple[Callable[[], None], ToolCallSource]:
+    from strands.hooks import AfterToolCallEvent, HookRegistry
+    from strands.types.tools import ToolResult, ToolUse
+
+    from arksim.tracing.integrations.strands import ArksimStrandsHookProvider
+
+    registry = HookRegistry()
+    ArksimStrandsHookProvider().register_hooks(registry)
+    tool_use = cast(
+        "ToolUse",
+        {"name": "get_weather", "toolUseId": "u1", "input": {"city": "NYC"}},
+    )
+    result = cast(
+        "ToolResult",
+        {
+            "toolUseId": "u1",
+            "status": "error",
+            "content": [{"text": "boom"}],
+        },
+    )
+    event = AfterToolCallEvent(
+        agent=cast("Any", MagicMock()),
+        selected_tool=None,
+        tool_use=tool_use,
+        invocation_state={},
+        result=result,
+        exception=ValueError("nope"),
+    )
+
+    def fire() -> None:
+        registry.invoke_callbacks(event)
+
+    return fire, ToolCallSource.STRANDS
+
+
+def _make_llamaindex_error() -> tuple[Callable[[], None], ToolCallSource]:
+    from llama_index.core.agent.workflow import ToolCall as LIToolCall
+    from llama_index.core.agent.workflow import ToolCallResult as LIToolCallResult
+    from llama_index.core.tools.types import ToolOutput
+
+    from arksim.tracing.integrations.llamaindex import ArksimLlamaIndexObserver
+
+    observer = ArksimLlamaIndexObserver()
+    args = {"city": "NYC"}
+    start = LIToolCall(tool_name="get_weather", tool_kwargs=args, tool_id="t1")
+    tool_output = ToolOutput(
+        tool_name="get_weather",
+        content="",
+        raw_input=args,
+        raw_output=None,
+        is_error=True,
+        exception=ValueError("nope"),
+    )
+    result = LIToolCallResult(
+        tool_name="get_weather",
+        tool_kwargs=args,
+        tool_id="t1",
+        tool_output=tool_output,
+        return_direct=False,
+    )
+
+    def fire() -> None:
+        observer.observe(start)
+        observer.observe(result)
+
+    return fire, ToolCallSource.LLAMAINDEX
+
+
+_ERROR_FACTORIES: list[Any] = [
+    pytest.param(_make_langchain_error, id="langchain"),
+    pytest.param(_make_crewai_error, id="crewai"),
+    pytest.param(_make_livekit_error, id="livekit"),
+    pytest.param(_make_strands_error, id="strands"),
+    pytest.param(_make_llamaindex_error, id="llamaindex"),
+    pytest.param(
+        None,
+        id="claude_agent_sdk",
+        marks=pytest.mark.skip(reason="SDK has no separate error event"),
+    ),
+    pytest.param(
+        None,
+        id="google_adk",
+        marks=pytest.mark.skip(reason="SDK has no separate error event"),
+    ),
+    pytest.param(
+        None,
+        id="smolagents",
+        marks=pytest.mark.skip(reason="SDK has no separate error event"),
+    ),
+]
+
+
+@pytest.mark.parametrize("factory", _ERROR_FACTORIES)
+def test_adapter_error_path_populates_error_field(factory: Factory) -> None:
+    """Adapters that expose a distinct error event must surface it on
+    ToolCall.error rather than ToolCall.result. Skipped for SDKs whose
+    callbacks carry only the success/result shape (Claude Agent SDK,
+    Google ADK, Smolagents).
+    """
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+
+    fire, expected_source = factory()
+    fire()
+
+    receiver.submit_tool_calls.assert_called_once()
+    args, _ = receiver.submit_tool_calls.call_args
+    _, _, tool_calls = args
+    assert len(tool_calls) == 1
+    tc = tool_calls[0]
+    assert tc.source == expected_source
+    assert tc.error is not None and tc.error != ""
+    assert tc.result is None

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cross-adapter contract: events in produce ToolCall out for every SDK adapter.
+
+This is the capstone test for the 8-adapter tracing batch. Each adapter has its
+own quirks (split-event correlation, async vs sync, event-bus dispatch, etc.),
+but the contract is uniform: fire one synthetic tool-use event into the
+adapter while routing context is set, and the configured receiver receives a
+single ``ToolCall`` tagged with the correct ``ToolCallSource``.
+
+One factory per adapter. Each factory returns ``(fire_callable,
+expected_source)``. The parameterized test sets routing context, invokes
+``fire()``, and asserts a single ``ToolCall`` lands on the receiver with the
+expected source.
+
+If you add a new adapter, add a factory below and one ``pytest.param`` entry.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from datetime import datetime, timezone
+from typing import Any, cast
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from arksim.simulation_engine.tool_types import ToolCall, ToolCallSource
+from arksim.tracing.context import _clear_trace_context, _set_trace_context
+
+Factory = Callable[[], tuple[Callable[[], None], ToolCallSource]]
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> Iterator[None]:
+    _clear_trace_context()
+    yield
+    _clear_trace_context()
+
+
+# --- Per-adapter factories ---------------------------------------------------
+
+
+def _make_langchain() -> tuple[Callable[[], None], ToolCallSource]:
+    from arksim.tracing.integrations.langchain import ArksimLangChainHandler
+
+    handler = ArksimLangChainHandler()
+    run_id = uuid4()
+
+    def fire() -> None:
+        handler.on_tool_start({"name": "get_weather"}, '{"city": "NYC"}', run_id=run_id)
+        handler.on_tool_end("sunny 75F", run_id=run_id)
+
+    return fire, ToolCallSource.LANGCHAIN
+
+
+def _make_crewai() -> tuple[Callable[[], None], ToolCallSource]:
+    from crewai.events import ToolUsageFinishedEvent, crewai_event_bus
+
+    from arksim.tracing.integrations.crewai import ArksimCrewEventListener
+
+    # ``crewai_event_bus`` is a module-level singleton; enter a scoped-handlers
+    # block inside the factory so this listener does not leak to other tests,
+    # then exit it after the dispatched future completes.
+    scope = crewai_event_bus.scoped_handlers()
+    scope.__enter__()
+    ArksimCrewEventListener()
+    now = datetime.now(timezone.utc)
+    event = ToolUsageFinishedEvent(
+        timestamp=now,
+        tool_name="get_weather",
+        tool_args={"city": "NYC"},
+        started_at=now,
+        finished_at=now,
+        output="sunny 75F",
+    )
+
+    def fire() -> None:
+        try:
+            future = crewai_event_bus.emit(source=object(), event=event)
+            if future is not None:
+                # Dispatcher uses a ThreadPoolExecutor; wait to avoid racing
+                # the assertion against the worker thread.
+                future.result(timeout=5.0)
+        finally:
+            scope.__exit__(None, None, None)
+
+    return fire, ToolCallSource.CREWAI
+
+
+def _make_claude_agent_sdk() -> tuple[Callable[[], None], ToolCallSource]:
+    import asyncio
+
+    from arksim.tracing.integrations.claude_agent_sdk import ArksimClaudeHooks
+
+    hooks = ArksimClaudeHooks()
+
+    def fire() -> None:
+        asyncio.run(
+            hooks.post_tool_use(
+                {
+                    "tool_name": "lookup_order",
+                    "tool_input": {"order_id": "12345"},
+                    "tool_response": "shipped",
+                },
+                "t1",
+                cast("Any", {}),
+            )
+        )
+
+    return fire, ToolCallSource.CLAUDE_AGENT_SDK
+
+
+def _make_google_adk() -> tuple[Callable[[], None], ToolCallSource]:
+    import asyncio
+
+    from arksim.tracing.integrations.google_adk import ArksimADKPlugin
+
+    plugin = ArksimADKPlugin()
+    tool = MagicMock()
+    tool.name = "lookup_order"
+    tool_context = MagicMock(spec=["invocation_id"])
+    tool_context.invocation_id = "inv-1"
+
+    def fire() -> None:
+        asyncio.run(
+            plugin.after_tool_callback(
+                tool=tool,
+                tool_args={"order_id": "12345"},
+                tool_context=tool_context,
+                result={"status": "shipped"},
+            )
+        )
+
+    return fire, ToolCallSource.GOOGLE_ADK
+
+
+def _make_livekit() -> tuple[Callable[[], None], ToolCallSource]:
+    from livekit.agents.llm.chat_context import FunctionCall, FunctionCallOutput
+    from livekit.agents.voice.events import FunctionToolsExecutedEvent
+
+    from arksim.tracing.integrations.livekit import ArksimLiveKitHandler
+
+    handler = ArksimLiveKitHandler()
+    event = FunctionToolsExecutedEvent(
+        function_calls=[
+            FunctionCall(
+                call_id="call_1", arguments='{"city": "NYC"}', name="get_weather"
+            )
+        ],
+        function_call_outputs=[
+            FunctionCallOutput(
+                call_id="call_1",
+                name="get_weather",
+                output="sunny 75F",
+                is_error=False,
+            )
+        ],
+    )
+
+    def fire() -> None:
+        handler.on_function_tools_executed(event)
+
+    return fire, ToolCallSource.LIVEKIT
+
+
+def _make_strands() -> tuple[Callable[[], None], ToolCallSource]:
+    from strands.hooks import AfterToolCallEvent, HookRegistry
+    from strands.types.tools import ToolResult, ToolUse
+
+    from arksim.tracing.integrations.strands import ArksimStrandsHookProvider
+
+    registry = HookRegistry()
+    ArksimStrandsHookProvider().register_hooks(registry)
+    tool_use = cast(
+        "ToolUse",
+        {"name": "get_weather", "toolUseId": "u1", "input": {"city": "NYC"}},
+    )
+    result = cast(
+        "ToolResult",
+        {
+            "toolUseId": "u1",
+            "status": "success",
+            "content": [{"text": "sunny 75F"}],
+        },
+    )
+    event = AfterToolCallEvent(
+        agent=cast("Any", MagicMock()),
+        selected_tool=None,
+        tool_use=tool_use,
+        invocation_state={},
+        result=result,
+        exception=None,
+    )
+
+    def fire() -> None:
+        registry.invoke_callbacks(event)
+
+    return fire, ToolCallSource.STRANDS
+
+
+def _make_llamaindex() -> tuple[Callable[[], None], ToolCallSource]:
+    from llama_index.core.agent.workflow import ToolCall as LIToolCall
+    from llama_index.core.agent.workflow import ToolCallResult as LIToolCallResult
+    from llama_index.core.tools.types import ToolOutput
+
+    from arksim.tracing.integrations.llamaindex import ArksimLlamaIndexObserver
+
+    observer = ArksimLlamaIndexObserver()
+    args = {"city": "NYC"}
+    start = LIToolCall(tool_name="get_weather", tool_kwargs=args, tool_id="t1")
+    tool_output = ToolOutput(
+        tool_name="get_weather",
+        content="sunny 75F",
+        raw_input=args,
+        raw_output="sunny 75F",
+        is_error=False,
+        exception=None,
+    )
+    result = LIToolCallResult(
+        tool_name="get_weather",
+        tool_kwargs=args,
+        tool_id="t1",
+        tool_output=tool_output,
+        return_direct=False,
+    )
+
+    def fire() -> None:
+        observer.observe(start)
+        observer.observe(result)
+
+    return fire, ToolCallSource.LLAMAINDEX
+
+
+def _make_smolagents() -> tuple[Callable[[], None], ToolCallSource]:
+    from smolagents.memory import ActionStep
+    from smolagents.memory import ToolCall as SmolToolCall
+    from smolagents.monitoring import Timing
+
+    from arksim.tracing.integrations.smolagents import ArksimSmolagentsCallback
+
+    observer = ArksimSmolagentsCallback()
+    step = ActionStep(
+        step_number=1,
+        timing=Timing(start_time=0.0, end_time=1.0),
+        tool_calls=[
+            SmolToolCall(name="get_weather", arguments={"city": "NYC"}, id="call_1")
+        ],
+        observations="sunny 75F",
+    )
+
+    def fire() -> None:
+        observer(step)
+
+    return fire, ToolCallSource.SMOLAGENTS
+
+
+# --- The contract test ------------------------------------------------------
+
+
+_FACTORIES: list[Any] = [
+    pytest.param(_make_langchain, id="langchain"),
+    pytest.param(_make_crewai, id="crewai"),
+    pytest.param(_make_claude_agent_sdk, id="claude_agent_sdk"),
+    pytest.param(_make_google_adk, id="google_adk"),
+    pytest.param(_make_livekit, id="livekit"),
+    pytest.param(_make_strands, id="strands"),
+    pytest.param(_make_llamaindex, id="llamaindex"),
+    pytest.param(_make_smolagents, id="smolagents"),
+]
+
+
+@pytest.mark.parametrize("factory", _FACTORIES)
+def test_adapter_produces_tool_call_with_correct_source(factory: Factory) -> None:
+    receiver = MagicMock()
+    _set_trace_context("conv-1", 0, receiver=receiver)
+
+    fire, expected_source = factory()
+    fire()
+
+    receiver.submit_tool_calls.assert_called_once()
+    args, _ = receiver.submit_tool_calls.call_args
+    conv, turn, tool_calls = args
+    assert conv == "conv-1"
+    assert turn == 0
+    assert len(tool_calls) == 1
+    assert isinstance(tool_calls[0], ToolCall)
+    assert tool_calls[0].source == expected_source

--- a/tests/unit/test_dify_agent.py
+++ b/tests/unit/test_dify_agent.py
@@ -64,7 +64,7 @@ class TestDifyAgentExecute:
         return _load_dify_agent_class()(_make_agent_config())
 
     async def test_returns_answer(self, agent: BaseAgent) -> None:
-        """Successful response returns the answer string."""
+        """Chatbot-app response (no agent_thoughts) returns content with empty tool_calls."""
         mock_response = httpx.Response(
             200,
             json=_dify_response(answer="I can help with that."),
@@ -73,7 +73,35 @@ class TestDifyAgentExecute:
         agent._client = AsyncMock()
         agent._client.post = AsyncMock(return_value=mock_response)
         result = await agent.execute("How do I return an item?")
-        assert result == "I can help with that."
+        assert result.content == "I can help with that."
+        assert result.tool_calls == []
+
+    async def test_agent_thoughts_become_tool_calls(self, agent: BaseAgent) -> None:
+        """Agent-app response with agent_thoughts surfaces ToolCall entries."""
+        payload = _dify_response(answer="Order ORD-1001 ships Tuesday.")
+        payload["agent_thoughts"] = [
+            {
+                "id": "thought-1",
+                "tool": "lookup_order",
+                "tool_input": '{"order_id": "ORD-1001"}',
+                "observation": "Order ORD-1001: shipped, arrives Tuesday.",
+            }
+        ]
+        mock_response = httpx.Response(
+            200,
+            json=payload,
+            request=httpx.Request("POST", "https://api.dify.ai/v1/chat-messages"),
+        )
+        agent._client = AsyncMock()
+        agent._client.post = AsyncMock(return_value=mock_response)
+        result = await agent.execute("Where is ORD-1001?")
+        assert len(result.tool_calls) == 1
+        call = result.tool_calls[0]
+        assert call.name == "lookup_order"
+        assert call.arguments == {"order_id": "ORD-1001"}
+        assert call.result == "Order ORD-1001: shipped, arrives Tuesday."
+        assert call.source is not None
+        assert call.source.value == "dify"
 
     async def test_conversation_id_persists(self, agent: BaseAgent) -> None:
         """Second call sends conversation_id from first response."""

--- a/tests/unit/test_tool_types.py
+++ b/tests/unit/test_tool_types.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for tool_types module."""
+
+from __future__ import annotations
+
+from arksim.simulation_engine.tool_types import ToolCallSource
+
+
+def test_tool_call_source_has_new_sdk_adapter_variants() -> None:
+    """8 new variants for SDK tracing adapters added in 2026-05 rollout."""
+    assert ToolCallSource.LANGCHAIN.value == "langchain"
+    assert ToolCallSource.CREWAI.value == "crewai"
+    assert ToolCallSource.CLAUDE_AGENT_SDK.value == "claude_agent_sdk"
+    assert ToolCallSource.GOOGLE_ADK.value == "google_adk"
+    assert ToolCallSource.LIVEKIT.value == "livekit"
+    assert ToolCallSource.STRANDS.value == "strands"
+    assert ToolCallSource.LLAMAINDEX.value == "llamaindex"
+    assert ToolCallSource.SMOLAGENTS.value == "smolagents"

--- a/tests/unit/test_tool_types.py
+++ b/tests/unit/test_tool_types.py
@@ -16,3 +16,9 @@ def test_tool_call_source_has_new_sdk_adapter_variants() -> None:
     assert ToolCallSource.STRANDS.value == "strands"
     assert ToolCallSource.LLAMAINDEX.value == "llamaindex"
     assert ToolCallSource.SMOLAGENTS.value == "smolagents"
+
+
+def test_tool_call_source_has_doesnt_fit_example_variants() -> None:
+    """2 variants for HTTP-wrapper examples that capture outside the adapter path."""
+    assert ToolCallSource.DIFY.value == "dify"
+    assert ToolCallSource.RASA.value == "rasa"


### PR DESCRIPTION
## Summary

Adds 8 per-SDK tracing adapters under `arksim/tracing/integrations/` so users of LangChain/LangGraph, CrewAI, Claude Agent SDK, Google ADK, LiveKit Agents, Strands Agents, LlamaIndex, and Smolagents get zero-config tool-call capture through the Python connector. All 13 existing integration examples updated; 2 new examples added (LiveKit, Strands).

## What ships

- `BaseTracingAdapter` (contextvars-based, no registry) under `arksim/tracing/integrations/_base.py`
- `PendingToolCalls` split-event correlation helper (used by LangChain and LlamaIndex)
- `parse_tool_arguments` shared argument normalization helper
- 8 adapter modules covering 9 frameworks (LangChain adapter covers LangGraph)
- 10 new `ToolCallSource` enum variants (8 adapters + Dify + Rasa)
- 8 new pip extras in `pyproject.toml`
- `detect-secrets` pre-commit hook + initial baseline
- Multi-extra resolver CI check
- 95+ unit tests + cross-adapter contract test

## Non-goals (explicit)

- OpenAI Agents SDK adapter changes (already shipped in #114; canonical path `arksim.tracing.openai`)
- Restructuring `arksim/tracing/openai.py` (file stays in place)
- OTel + W3C wrapper instrumentation track (post-launch follow-up)
- Platform-bridge work
- Response-body tool-call evaluation on raw Chat Completions (decided no per wiki/decisions/no-response-parsed-tool-call-eval.md)

## Test plan

- [x] Unit suite: 915 passing, 4 skipped (was 820 on origin/main, +95 across the rollout)
- [x] Per-adapter tests cover happy path, error path, source field, no-context, missing fields, multiple calls, split-event correlation (where applicable)
- [x] Cross-adapter contract test parameterized across 8 adapters
- [x] `ruff check` + `ruff format --check` clean
- [x] Multi-extra resolver: `pip install 'arksim[langchain,crewai,llamaindex,claude-agent,google-adk,livekit,strands,smolagents]'` resolves cleanly
- [x] Pre-commit clean across the full 37-commit diff (120 files, +5525 / -4755)

## Manual verification needed before merge

- Each of the 8 per-SDK adapter examples (LangChain, LangGraph, CrewAI, Claude Agent SDK, Google ADK, LiveKit, Strands, LlamaIndex, Smolagents) runs end-to-end against the respective SDK with a real API key, producing `tool_calls` in `simulation.json`.
- Native-OTel examples (AutoGen, Pydantic AI, Mastra) run E2E. Mastra requires `npm install` first.
- Doesn't-fit examples: Dify needs a Dify Agent app with `lookup_order` + `book_table` tools configured server-side. Rasa needs a running Rasa server with the included `rasa_project`. Vercel AI SDK needs `npm install && npm start` first.

## Follow-ups (intentionally NOT in this PR)

- LangGraph migration from `create_react_agent` to `langchain.agents.create_agent` (v1 deprecation)
- CrewAI ToolCall.id synthesis (currently empty)
- Claude Agent SDK error path via `PostToolUseFailure` event
- README / quickstart retool leading with `examples/customer-service/` as canonical demo
- Ecosystem scan: Agno, Haystack, LangGraph Platform, OpenAI Swarm handoff coverage
- `parse_openai` honoring `message.tool_calls` (would let agent servers skip OTel for simple cases)
- Mastra deprecation: migrate to Mastra's proprietary AI Tracing when stable
