### PR TITLE
feat(examples): add EvalHub adapter for running arksim evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **tracing:** add dual attribute convention support (OTel GenAI semconv and OpenInference)
 * **tracing:** add `ToolCallSource` enum (`a2a_protocol`, `openai_agents`, `otel_trace`) for tool call provenance tracking on `ToolCall.source`
 * **examples:** add Dify chatbot integration example
+* **examples:** add EvalHub adapter integration to run arksim as an EvalHub benchmark provider (`examples/integrations/evalhub/`)
 * **evaluator:** focus file generation after evaluation for targeted reruns of failing scenarios
 * **evaluator:** scenario IDs shown in CLI error output alongside focus file paths
 * **evaluator:** error-to-scenario mappings included in `evaluation.json` output

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ See the [integration README](integrations/claude_code/README.md) for the install
 | [Mastra](https://github.com/arklexai/arksim/tree/main/examples/integrations/mastra) | TypeScript |
 | [Vercel AI SDK](https://github.com/arklexai/arksim/tree/main/examples/integrations/vercel-ai-sdk) | TypeScript |
 
+ArkSim also runs as a provider *inside* eval platforms: [EvalHub](https://github.com/arklexai/arksim/tree/main/examples/integrations/evalhub).
+
 See [examples](https://github.com/arklexai/arksim/tree/main/examples) for end-to-end projects with custom metrics and scenarios.
 
 ## Learn More

--- a/docs/main/integrations.mdx
+++ b/docs/main/integrations.mdx
@@ -68,6 +68,16 @@ This example uses the `custom` connector with a `BaseAgent` subclass that forwar
   </Card>
 </CardGroup>
 
+## Eval platform integrations
+
+These examples run ArkSim *inside* another evaluation platform as a provider, rather than connecting ArkSim to your agent. ArkSim performs the multi-turn simulation and scoring; the platform schedules the job and stores the results.
+
+<CardGroup cols={2}>
+  <Card icon="layer-group" href="https://github.com/arklexai/arksim/tree/main/examples/integrations/evalhub/" title="EvalHub">
+    Run ArkSim as a benchmark provider in EvalHub, reporting aggregate metrics plus transcripts and an HTML report to MLflow.
+  </Card>
+</CardGroup>
+
 ---
 
 For details on each connection type, see [Agent configuration](./simulate-conversation#agent-configuration).

--- a/examples/integrations/evalhub/Containerfile
+++ b/examples/integrations/evalhub/Containerfile
@@ -1,0 +1,21 @@
+# Containerfile for the arksim EvalHub adapter.
+# Build:  podman build -t arksim-evalhub:latest .
+# EvalHub runs the image, mounts the JobSpec at $EVALHUB_JOB_SPEC_PATH
+# (default /meta/job.json) and the model secret at /var/run/secrets/model.
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY arksim_evalhub ./arksim_evalhub
+COPY main.py .
+
+# Run as non-root so a process compromise can't trivially read the mounted
+# model secret. For production, also pin the base image by digest
+# (FROM python:3.11-slim@sha256:...).
+RUN useradd --create-home --shell /usr/sbin/nologin appuser
+USER appuser
+
+CMD ["python", "main.py"]

--- a/examples/integrations/evalhub/README.md
+++ b/examples/integrations/evalhub/README.md
@@ -1,0 +1,108 @@
+# arksim on EvalHub
+
+Run arksim's multi-turn agent simulation and evaluation as an
+[EvalHub](https://eval-hub.github.io/) benchmark provider.
+
+EvalHub points at a target agent endpoint; this adapter drives that endpoint
+with simulated users across your scenarios, scores the transcripts, and reports
+aggregate metrics to EvalHub plus transcripts and an HTML report to MLflow.
+
+## How it maps
+
+| EvalHub | arksim |
+|---|---|
+| `JobSpec.model.url` / `.name` | target agent endpoint (`chat_completions` or `a2a`) |
+| `JobSpec.model.auth.secret_ref` → `/var/run/secrets/model/api-key` | bearer token on the agent's requests |
+| `JobSpec.parameters` (freeform JSON) | scenarios + simulator/judge config (see `ArksimJobParameters`) |
+| scalar metrics | `overall_agent_score`, `goal_completion_score`, `turn_success_ratio`, `num_conversations` |
+| MLflow artifacts | `simulation.json`, `evaluation.json`, `final_report.html` |
+
+Three distinct models are in play: the **target agent** (`JobSpec.model`), the
+**simulator** LLM that plays the user (`parameters.simulator_model`), and the
+**judge** LLM that scores transcripts (`parameters.evaluator_model`).
+
+## Layout
+
+```
+arksim_evalhub/
+  mapping.py   # pure EvalHub <-> arksim transforms (no I/O), unit-tested
+  adapter.py   # FrameworkAdapter, credential resolution, the run + main()
+main.py        # container entrypoint: python main.py
+run_local.py   # run locally without k8s/Docker
+job.example.json
+provider.yaml  # provider registration template for eval-hub-server --local
+Containerfile
+```
+
+## Run locally (no Kubernetes)
+
+```bash
+pip install -r requirements.txt           # arksim + eval-hub-sdk[adapter]
+export OPENAI_API_KEY=sk-...              # drives the simulator + judge, and
+                                          # the sample target endpoint
+python run_local.py
+```
+
+`run_local.py` writes `job.example.json` to the local job-spec path the SDK
+expects, sets `EVALHUB_JOB_SPEC_PATH`, and invokes the adapter. Edit
+`job.example.json` to point `model.url` at your own agent and to define your
+scenarios under `parameters.scenarios`.
+
+To log transcripts and the report to MLflow, also set
+`MLFLOW_TRACKING_URI=http://localhost:5000` (otherwise MLflow logging is
+skipped). Either way the three artifacts (`simulation.json`, `evaluation.json`,
+`final_report.html`) are written to a `results/` directory under the run's
+output path, which `run_local.py` prints; open `final_report.html` to view the
+run. Transcripts can contain PII from your scenarios and the agent's responses,
+so scope MLflow access accordingly.
+
+The `Connection refused` warnings for the callback URL are expected in local
+mode: EvalHub status callbacks are a no-op without a running server.
+
+## Configuring a run
+
+Everything benchmark-specific lives in `JobSpec.parameters`, validated by
+`ArksimJobParameters` (see `arksim_evalhub/mapping.py` for the full field set and
+descriptions). To point at your own agent, edit `job.example.json`:
+
+- `model.url` / `model.name`: your target agent endpoint and model id.
+- `parameters.protocol`: `chat_completions` (OpenAI-compatible) or `a2a`.
+- `parameters.target_api_key_env`: env var holding the target's key (local runs).
+  If set but unset at runtime, the job fails fast with a clear message.
+- `parameters.simulator_model` / `evaluator_model`: arksim's own LLMs (the
+  simulated user and the judge), independent of the target agent. Omitted, they
+  fall back to arksim's defaults (currently `gpt-5.1`), not the example's values.
+- `parameters.metrics_to_run`: any subset of `helpfulness`, `coherence`,
+  `verbosity`, `relevance`, `faithfulness`, `goal_completion`,
+  `agent_behavior_failure`. Omit to use arksim's defaults.
+- `parameters.num_workers`: a positive integer, or `"auto"`.
+- `parameters.scenarios`: at least one scenario (`scenario_id`, `user_id`,
+  `goal`, `agent_context`, `user_profile`).
+
+Only `scenarios` is required; everything else has defaults. Pass/fail is decided
+by EvalHub from `provider.yaml` (`primary_score` + `pass_criteria`), not here.
+
+## Tests
+
+The pure mapping and the adapter wiring are covered without any LLM calls (the
+sim/eval step is stubbed):
+
+```bash
+pip install pytest
+python -m pytest tests/
+```
+
+## Credentials note for the EvalHub team
+
+The model-authentication docs say EvalHub "applies credentials automatically,"
+but the SDK only auto-attaches the ServiceAccount token to control-plane
+callbacks. The adapter reads `read_model_auth_key("api-key")` itself and puts it
+on the agent's outbound requests. TLS `ca_cert` from the mounted secret is not
+yet wired into arksim's HTTP client; flag if you need custom-CA target
+endpoints.
+
+## Status
+
+Proof of concept for local mode. The `provider.yaml` field names are
+illustrative; confirm them against your EvalHub version before wiring CI or the
+k8s runtime.

--- a/examples/integrations/evalhub/README.md
+++ b/examples/integrations/evalhub/README.md
@@ -21,18 +21,19 @@ Three distinct models are in play: the **target agent** (`JobSpec.model`), the
 **simulator** LLM that plays the user (`parameters.simulator_model`), and the
 **judge** LLM that scores transcripts (`parameters.evaluator_model`).
 
-## Layout
+## Files
 
-```
-arksim_evalhub/
-  mapping.py   # pure EvalHub <-> arksim transforms (no I/O), unit-tested
-  adapter.py   # FrameworkAdapter, credential resolution, the run + main()
-main.py        # container entrypoint: python main.py
-run_local.py   # run locally without k8s/Docker
-job.example.json
-provider.yaml  # provider registration template for eval-hub-server --local
-Containerfile
-```
+| File | Description |
+|------|-------------|
+| `arksim_evalhub/mapping.py` | Pure EvalHub<->arksim transforms (no I/O), unit-tested |
+| `arksim_evalhub/adapter.py` | `FrameworkAdapter`, credential resolution, the run, and `main()` |
+| `main.py` | Container entrypoint (`python main.py`) |
+| `run_local.py` | Run locally without Kubernetes or Docker |
+| `job.example.json` | Sample EvalHub JobSpec |
+| `provider.yaml` | Provider registration template for `eval-hub-server --local` |
+| `Containerfile` | Container image build |
+| `requirements.txt` | `arksim` + `eval-hub-sdk[adapter]` |
+| `tests/` | Mapping + adapter wiring tests (no LLM calls) |
 
 ## Run locally (no Kubernetes)
 

--- a/examples/integrations/evalhub/arksim_evalhub/__init__.py
+++ b/examples/integrations/evalhub/arksim_evalhub/__init__.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""arksim adapter for the EvalHub evaluation platform."""
+
+from __future__ import annotations
+
+from arksim_evalhub.adapter import (
+    ArksimAdapter,
+    main,
+    resolve_target_api_key,
+    simulate_and_evaluate,
+)
+from arksim_evalhub.mapping import (
+    ArksimJobParameters,
+    aggregate_metrics,
+    build_agent_config,
+    compute_overall_score,
+)
+
+__all__ = [
+    "ArksimAdapter",
+    "ArksimJobParameters",
+    "aggregate_metrics",
+    "build_agent_config",
+    "compute_overall_score",
+    "main",
+    "resolve_target_api_key",
+    "simulate_and_evaluate",
+]

--- a/examples/integrations/evalhub/arksim_evalhub/adapter.py
+++ b/examples/integrations/evalhub/arksim_evalhub/adapter.py
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: Apache-2.0
+"""EvalHub ``FrameworkAdapter`` that runs an arksim simulation + evaluation.
+
+Lifecycle (driven by ``eval-hub-sdk``):
+
+1. EvalHub mounts the JobSpec at ``$EVALHUB_JOB_SPEC_PATH`` (default
+   ``/meta/job.json``) and the model secret at ``/var/run/secrets/model``.
+2. :class:`ArksimAdapter` is constructed; the SDK loads settings + job spec.
+3. :meth:`ArksimAdapter.run_benchmark_job` builds an arksim ``AgentConfig`` from
+   the target model, runs simulation then evaluation against it, and returns
+   aggregated scalar metrics as ``JobResults``.
+4. :func:`main` logs the transcripts + HTML report to MLflow (when configured)
+   and reports the terminal result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import tempfile
+import time
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+from evalhub.adapter import (
+    DefaultCallbacks,
+    FrameworkAdapter,
+    JobCallbacks,
+    JobPhase,
+    JobResults,
+    JobSpec,
+    JobStatus,
+    JobStatusUpdate,
+    MessageInfo,
+    read_model_auth_key,
+)
+from evalhub.adapter.mlflow import MlflowArtifact
+
+from arksim import AgentConfig, Scenarios
+from arksim.evaluator import EvaluationInput, run_evaluation
+
+# Result envelopes are not re-exported at the arksim top level; import them from
+# their defining modules. Used only for type hints here.
+from arksim.evaluator.entities import Evaluation
+from arksim.simulation_engine import SimulationInput, run_simulation
+from arksim.simulation_engine.entities import Simulation
+from arksim_evalhub.mapping import (
+    ArksimJobParameters,
+    aggregate_metrics,
+    build_agent_config,
+    compute_overall_score,
+)
+
+logger = logging.getLogger("arksim_evalhub")
+
+# Artifact filenames. simulation.json is set by us (below); evaluation.json and
+# final_report.html are arksim's own run_evaluation outputs.
+_SIMULATION_FILE = "simulation.json"
+_ARTIFACTS: tuple[tuple[str, str], ...] = (
+    (_SIMULATION_FILE, "application/json"),
+    ("evaluation.json", "application/json"),
+    ("final_report.html", "text/html"),
+)
+
+
+def resolve_target_api_key(params: ArksimJobParameters) -> str | None:
+    """Resolve the target agent's API key.
+
+    Prefers the EvalHub-mounted model secret
+    (``/var/run/secrets/model/api-key``). Falls back to the env var named by
+    ``target_api_key_env`` for local runs where no secret is mounted.
+    """
+    key = read_model_auth_key("api-key")
+    if key:
+        return key
+    if params.target_api_key_env:
+        env_key = os.environ.get(params.target_api_key_env)
+        if not env_key:
+            raise ValueError(
+                f"target_api_key_env='{params.target_api_key_env}' is set but that "
+                "environment variable is empty or unset. Export it, or remove "
+                "target_api_key_env if the target agent needs no credentials."
+            )
+        return env_key
+    return None
+
+
+# Best-effort secret patterns scrubbed from strings before they are logged or
+# sent to EvalHub: bearer tokens, URL userinfo, OpenAI-style keys.
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)bearer\s+[\w.\-+/=]+"),
+    re.compile(r"//[^/\s@]+@"),
+    re.compile(r"sk-[A-Za-z0-9_\-]{8,}"),
+)
+
+
+def _scrub(text: str) -> str:
+    """Redact likely secrets from a free-text string (defense in depth)."""
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub("[REDACTED]", text)
+    return text
+
+
+def _redact_url(url: str) -> str:
+    """Reduce a target URL to scheme://host[:port]/path for logging.
+
+    Drops any userinfo and query string, which can carry credentials. Falls
+    back to generic scrubbing for malformed or scheme-less URLs.
+    """
+    parts = urlsplit(url)
+    if not parts.netloc:
+        # Malformed/scheme-less: userinfo can hide in the path, so don't risk
+        # logging it. ModelConfig requires a non-empty url, not a well-formed one.
+        return "[redacted: malformed target url]"
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, host, parts.path, "", ""))
+
+
+async def simulate_and_evaluate(
+    agent_config: AgentConfig,
+    params: ArksimJobParameters,
+    scenarios: Scenarios,
+    output_dir: Path,
+) -> tuple[Simulation, Evaluation]:
+    """Run the arksim simulation then evaluation against the target agent.
+
+    Isolated as a module-level function so it can be substituted in tests
+    without making real model calls. Writes ``simulation.json``,
+    ``evaluation.json``, and ``final_report.html`` into ``output_dir``.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    simulation = await run_simulation(
+        SimulationInput(
+            agent_config=agent_config,
+            model=params.simulator_model,
+            provider=params.simulator_provider,
+            num_conversations_per_scenario=params.num_conversations_per_scenario,
+            max_turns=params.max_turns,
+            num_workers=params.num_workers,
+            output_file_path=str(output_dir / _SIMULATION_FILE),
+        ),
+        scenarios=scenarios,
+    )
+
+    # Pass optional fields only when set: EvaluationInput supplies its own
+    # defaults (e.g. metrics_to_run defaults to arksim's standard metric set),
+    # which passing None would override.
+    eval_kwargs: dict[str, object] = {
+        "output_dir": str(output_dir),
+        "model": params.evaluator_model,
+        "provider": params.evaluator_provider,
+        "generate_html_report": True,
+    }
+    if params.metrics_to_run is not None:
+        eval_kwargs["metrics_to_run"] = params.metrics_to_run
+    if params.numeric_thresholds is not None:
+        eval_kwargs["numeric_thresholds"] = params.numeric_thresholds
+    if params.qualitative_failure_labels is not None:
+        eval_kwargs["qualitative_failure_labels"] = params.qualitative_failure_labels
+
+    # run_evaluation is synchronous and CPU/IO bound; keep the event loop free.
+    evaluation = await asyncio.to_thread(
+        run_evaluation,
+        EvaluationInput(**eval_kwargs),
+        simulation,
+        scenarios,
+    )
+    return simulation, evaluation
+
+
+class ArksimAdapter(FrameworkAdapter):
+    """Runs arksim multi-turn agent evaluation as an EvalHub benchmark."""
+
+    def __init__(
+        self,
+        settings: object | None = None,
+        job_spec_path: str | None = None,
+    ) -> None:
+        super().__init__(settings=settings, job_spec_path=job_spec_path)
+        # Populated by run_benchmark_job; logged to MLflow by main().
+        self.mlflow_artifacts: list[MlflowArtifact] = []
+
+    def run_benchmark_job(self, config: JobSpec, callbacks: JobCallbacks) -> JobResults:
+        started = time.monotonic()
+
+        self._report(callbacks, JobPhase.INITIALIZING, "Parsing job parameters")
+        params = ArksimJobParameters.model_validate(config.parameters)
+        scenarios = self._select_scenarios(params.scenarios, config.num_examples)
+
+        api_key = resolve_target_api_key(params)
+        if api_key and any(h.lower() == "authorization" for h in params.extra_headers):
+            logger.warning(
+                "extra_headers includes 'Authorization'; it overrides the "
+                "resolved api-key for the target agent."
+            )
+        # Trust model: the JobSpec is operator-authored and the adapter runs
+        # single-tenant per job, so config.model.url is trusted (no SSRF
+        # allowlist). Revisit if EvalHub ever accepts cross-tenant submissions.
+        agent_config = build_agent_config(config.model, params, api_key)
+        output_dir = self._output_dir()
+
+        self._report(
+            callbacks,
+            JobPhase.RUNNING_EVALUATION,
+            f"Simulating {len(scenarios.scenarios)} scenario(s) against "
+            f"{_redact_url(config.model.url)}",
+        )
+        # run_benchmark_job is synchronous per the SDK contract (no enclosing
+        # event loop), so asyncio.run owns the loop for the duration of the job.
+        _simulation, evaluation = asyncio.run(
+            simulate_and_evaluate(agent_config, params, scenarios, output_dir)
+        )
+
+        self._report(callbacks, JobPhase.POST_PROCESSING, "Aggregating scores")
+        results = JobResults(
+            id=config.id,
+            benchmark_id=config.benchmark_id,
+            benchmark_index=config.benchmark_index,
+            model_name=config.model.name,
+            results=aggregate_metrics(evaluation),
+            overall_score=compute_overall_score(evaluation),
+            num_examples_evaluated=len(evaluation.conversations),
+            duration_seconds=time.monotonic() - started,
+        )
+        self.mlflow_artifacts = self._collect_artifacts(output_dir)
+        return results
+
+    @staticmethod
+    def _select_scenarios(scenarios: Scenarios, num_examples: int | None) -> Scenarios:
+        """Cap the scenario count when EvalHub requests a subset.
+
+        ``JobSpec.num_examples`` has no lower bound, so reject non-positive
+        values explicitly rather than producing an empty or negatively-sliced
+        scenario set that fails confusingly downstream.
+        """
+        if num_examples is None or num_examples >= len(scenarios.scenarios):
+            return scenarios
+        if num_examples <= 0:
+            raise ValueError(f"num_examples must be positive, got {num_examples}")
+        return Scenarios(
+            schema_version=scenarios.schema_version,
+            scenarios=scenarios.scenarios[:num_examples],
+        )
+
+    def _output_dir(self) -> Path:
+        """Per-run output directory.
+
+        In local mode the SDK scopes ``local_jobs_base_path`` per job and
+        benchmark, so outputs never collide across runs. Otherwise (e.g. in
+        cluster mode, where the property is None) fall back to a writable temp
+        dir keyed by job id; the installed package directory may be read-only or
+        root-owned.
+        """
+        base = self.local_jobs_base_path
+        if base is None:
+            base = Path(tempfile.gettempdir()) / "arksim-evalhub" / self.job_spec.id
+        return base / "results"
+
+    def _collect_artifacts(self, output_dir: Path) -> list[MlflowArtifact]:
+        artifacts: list[MlflowArtifact] = []
+        for name, content_type in _ARTIFACTS:
+            path = output_dir / name
+            if path.is_file():
+                artifacts.append(
+                    MlflowArtifact(
+                        path=name,
+                        content=path.read_bytes(),
+                        content_type=content_type,
+                    )
+                )
+            else:
+                logger.warning(
+                    "Job %s: expected artifact %s not found at %s",
+                    self.job_spec.id,
+                    name,
+                    path,
+                )
+        return artifacts
+
+    @staticmethod
+    def _report(callbacks: JobCallbacks, phase: JobPhase, message: str) -> None:
+        callbacks.report_status(
+            JobStatusUpdate(
+                status=JobStatus.RUNNING,
+                phase=phase,
+                message=MessageInfo(message=message, message_code=phase.value),
+            )
+        )
+
+
+def main() -> None:
+    """Adapter entrypoint. EvalHub runs ``python main.py`` inside the job."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    adapter = ArksimAdapter()
+    callbacks = DefaultCallbacks.from_adapter(adapter)
+
+    try:
+        results = adapter.run_benchmark_job(adapter.job_spec, callbacks)
+    except Exception as exc:
+        # logger.exception emits the traceback to local logs only; avoid log
+        # handlers that serialize frame locals, which could capture the api-key.
+        logger.exception("arksim benchmark failed")
+        # The message is forwarded off-box to EvalHub, so scrub likely secrets
+        # (an upstream error may echo a credentialed URL or token).
+        callbacks.report_status(
+            JobStatusUpdate(
+                status=JobStatus.FAILED,
+                phase=JobPhase.COMPLETED,
+                message=MessageInfo(
+                    message=_scrub(str(exc)), message_code="job_failed"
+                ),
+            )
+        )
+        raise
+
+    # MLflow is gated on the tracking URI (injected by EvalHub in-cluster).
+    # Skip it locally so the adapter runs without an MLflow server.
+    if os.environ.get("MLFLOW_TRACKING_URI"):
+        run_id = callbacks.mlflow.save(
+            results, adapter.job_spec, artifacts=adapter.mlflow_artifacts
+        )
+        if run_id:
+            results.mlflow_run_id = run_id
+    else:
+        logger.info(
+            "MLFLOW_TRACKING_URI not set; skipping MLflow logging "
+            "(%d artifact(s) available)",
+            len(adapter.mlflow_artifacts),
+        )
+
+    callbacks.report_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/integrations/evalhub/arksim_evalhub/mapping.py
+++ b/examples/integrations/evalhub/arksim_evalhub/mapping.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure translation between the EvalHub job contract and arksim.
+
+Only in-memory transforms live here: no filesystem, network, or LLM calls. That
+keeps this module unit-testable without credentials or a running EvalHub. The
+I/O-bound pieces (reading the mounted model secret, running the simulation,
+reading artifact files) live in :mod:`arksim_evalhub.adapter`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any, Literal
+
+from evalhub.adapter import EvaluationResult, ModelConfig
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from arksim import A2AConfig, AgentConfig, ChatCompletionsConfig, Scenarios
+from arksim.constants import DEFAULT_MODEL, DEFAULT_PROVIDER
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from arksim.evaluator.entities import Evaluation
+
+# Conversation-level scores reduced to scalar MLflow metrics. These are public,
+# stable fields on arksim's ConversationEvaluation.
+_CONVERSATION_SCORES = (
+    "overall_agent_score",
+    "goal_completion_score",
+    "turn_success_ratio",
+)
+
+# Body keys the adapter owns; the target model and message history must not be
+# overridden by caller-supplied request_body.
+_RESERVED_BODY_KEYS = {"model", "messages"}
+
+
+class ArksimJobParameters(BaseModel):
+    """Typed view of the EvalHub ``JobSpec.parameters`` freeform JSON.
+
+    EvalHub passes all benchmark-specific config through ``parameters``. This
+    model is the contract arksim expects to find there. ``extra="forbid"`` turns
+    a misspelled key into an immediate, actionable error rather than a setting
+    that is silently ignored.
+
+    Note the two distinct model roles. ``JobSpec.model`` (handled separately) is
+    the *target agent under test*. The ``simulator_*`` and ``evaluator_*`` fields
+    below are arksim's own LLMs: one drives the simulated user, the other judges
+    the resulting transcripts.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # -- Scenarios (required) -------------------------------------------------
+    scenarios: Scenarios = Field(
+        ...,
+        description=(
+            "arksim scenarios. Accepts a full {schema_version, scenarios} object "
+            "or a bare list of scenario objects."
+        ),
+    )
+
+    # -- How arksim drives the target agent (JobSpec.model.url) ---------------
+    protocol: Literal["chat_completions", "a2a"] = Field(
+        default="chat_completions",
+        description=(
+            "How arksim talks to the target agent at JobSpec.model.url. "
+            "'chat_completions' for an OpenAI-compatible endpoint, 'a2a' for an "
+            "A2A agent server."
+        ),
+    )
+    target_agent_name: str = Field(
+        default="target-agent",
+        description="Display name for the target agent in arksim output.",
+    )
+    request_body: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Extra chat_completions body fields merged into each request "
+            "(e.g. {'temperature': 0}). Ignored when protocol='a2a'. Must not "
+            "contain 'model' or 'messages'."
+        ),
+    )
+    extra_headers: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Extra HTTP headers sent to the target agent. An 'Authorization' "
+            "header here overrides the resolved api-key."
+        ),
+    )
+    target_api_key_env: str | None = Field(
+        default=None,
+        description=(
+            "Env var to read the target api-key from when no EvalHub model secret "
+            "is mounted. Intended for local runs only."
+        ),
+    )
+
+    # -- Simulator LLM (generates the simulated user) -------------------------
+    simulator_model: str = Field(
+        default=DEFAULT_MODEL,
+        description=f"LLM that plays the simulated user (arksim default: {DEFAULT_MODEL}).",
+    )
+    simulator_provider: str | None = Field(
+        default=DEFAULT_PROVIDER, description="Provider for simulator_model."
+    )
+    num_conversations_per_scenario: int = Field(
+        default=2, ge=1, description="Conversations simulated per scenario."
+    )
+    max_turns: int = Field(
+        default=5, ge=1, description="Maximum turns per conversation."
+    )
+    num_workers: Annotated[int, Field(ge=1)] | Literal["auto"] = Field(
+        default=50,
+        description="Parallel simulation/evaluation workers: a positive int, or 'auto'.",
+    )
+
+    # -- Evaluator (judge) LLM + metric selection -----------------------------
+    evaluator_model: str = Field(
+        default=DEFAULT_MODEL,
+        description=f"LLM that judges transcripts (arksim default: {DEFAULT_MODEL}).",
+    )
+    evaluator_provider: str | None = Field(
+        default=DEFAULT_PROVIDER, description="Provider for evaluator_model."
+    )
+    metrics_to_run: list[str] | None = Field(
+        default=None,
+        description=(
+            "Built-in metric names to run; None uses arksim's defaults. Options: "
+            "helpfulness, coherence, verbosity, relevance, faithfulness, "
+            "goal_completion, agent_behavior_failure."
+        ),
+    )
+    numeric_thresholds: dict[str, float] | None = Field(
+        default=None,
+        description=(
+            "Optional minimum scores keyed by metric name "
+            "(e.g. {'overall_score': 0.6})."
+        ),
+    )
+    qualitative_failure_labels: dict[str, list[str]] | None = Field(
+        default=None,
+        description=(
+            "Optional failing labels per qualitative metric keyed by metric name "
+            "(e.g. {'agent_behavior_failure': ['violated']})."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _wrap_bare_scenario_list(cls, data: object) -> object:
+        """Allow ``scenarios`` to be a bare list, not only a Scenarios object."""
+        if isinstance(data, dict) and isinstance(data.get("scenarios"), list):
+            data = {
+                **data,
+                "scenarios": {"schema_version": "v1", "scenarios": data["scenarios"]},
+            }
+        return data
+
+    @model_validator(mode="after")
+    def _validate(self) -> Self:
+        """Reject configurations that would fail late or silently mislead."""
+        if not self.scenarios.scenarios:
+            raise ValueError("'scenarios' must contain at least one scenario")
+        overridden = _RESERVED_BODY_KEYS & set(self.request_body)
+        if overridden:
+            raise ValueError(
+                f"request_body must not override reserved keys: {sorted(overridden)}; "
+                "the target model and message history are set by the adapter"
+            )
+        return self
+
+
+def build_agent_config(
+    model: ModelConfig,
+    params: ArksimJobParameters,
+    api_key: str | None,
+) -> AgentConfig:
+    """Map an EvalHub target model + parameters into an arksim ``AgentConfig``.
+
+    The target endpoint comes from ``model.url``; ``model.name`` becomes the
+    chat-completions ``model`` body field. The resolved api key (already read
+    from the mounted secret by the caller) is attached as a bearer token.
+    ``ModelConfig`` already guarantees ``url`` and ``name`` are non-empty.
+    """
+    headers: dict[str, str] = dict(params.extra_headers)
+    if api_key:
+        headers.setdefault("Authorization", f"Bearer {api_key}")
+
+    if params.protocol == "a2a":
+        return AgentConfig(
+            agent_type="a2a",
+            agent_name=params.target_agent_name,
+            api_config=A2AConfig(endpoint=model.url, headers=headers or None),
+        )
+
+    body: dict[str, Any] = {
+        "model": model.name,
+        "messages": [],
+        **params.request_body,
+    }
+    return AgentConfig(
+        agent_type="chat_completions",
+        agent_name=params.target_agent_name,
+        api_config=ChatCompletionsConfig(
+            endpoint=model.url,
+            headers=headers or None,
+            body=body,
+        ),
+    )
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values)
+
+
+def aggregate_metrics(evaluation: Evaluation) -> list[EvaluationResult]:
+    """Reduce per-conversation arksim scores to EvalHub scalar metrics.
+
+    EvalHub records scalar metrics; per-conversation and per-turn detail surface
+    as MLflow artifacts instead (see ``adapter._collect_artifacts``). Pass/fail
+    is applied by EvalHub via the provider's ``primary_score``/``pass_criteria``,
+    so this function stays purely descriptive.
+    """
+    convos = evaluation.conversations
+    n = len(convos)
+    results = [
+        EvaluationResult(
+            metric_name="num_conversations",
+            metric_value=n,
+            metric_type="int",
+            num_samples=n,
+        )
+    ]
+    if n == 0:
+        return results
+    for name in _CONVERSATION_SCORES:
+        results.append(
+            EvaluationResult(
+                metric_name=name,
+                metric_value=_mean([getattr(c, name) for c in convos]),
+                metric_type="float",
+                num_samples=n,
+            )
+        )
+    return results
+
+
+def compute_overall_score(evaluation: Evaluation) -> float | None:
+    """Mean overall agent score across conversations, or None when empty."""
+    convos = evaluation.conversations
+    if not convos:
+        return None
+    return _mean([c.overall_agent_score for c in convos])

--- a/examples/integrations/evalhub/conftest.py
+++ b/examples/integrations/evalhub/conftest.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Put the example directory on sys.path so tests can import ``arksim_evalhub``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/examples/integrations/evalhub/job.example.json
+++ b/examples/integrations/evalhub/job.example.json
@@ -1,0 +1,40 @@
+{
+  "id": "arksim-local-001",
+  "provider_id": "arksim",
+  "benchmark_id": "customer-service-smoke",
+  "benchmark_index": 0,
+  "callback_url": "http://localhost:8080",
+  "experiment_name": "arksim-eval",
+  "model": {
+    "url": "https://api.openai.com/v1/chat/completions",
+    "name": "gpt-4.1-mini"
+  },
+  "parameters": {
+    "protocol": "chat_completions",
+    "target_agent_name": "support-bot",
+    "target_api_key_env": "OPENAI_API_KEY",
+    "simulator_model": "gpt-4.1-mini",
+    "simulator_provider": "openai",
+    "evaluator_model": "gpt-4.1-mini",
+    "evaluator_provider": "openai",
+    "num_conversations_per_scenario": 1,
+    "max_turns": 3,
+    "metrics_to_run": ["helpfulness", "goal_completion", "agent_behavior_failure"],
+    "scenarios": [
+      {
+        "scenario_id": "order-status",
+        "user_id": "u1",
+        "goal": "Find out the delivery date for order #12345.",
+        "agent_context": "You are a customer support assistant for an online store.",
+        "user_profile": "A busy customer who is mildly impatient and wants a quick answer."
+      },
+      {
+        "scenario_id": "refund-request",
+        "user_id": "u2",
+        "goal": "Request a refund for a damaged item from order #67890.",
+        "agent_context": "You are a customer support assistant for an online store.",
+        "user_profile": "A polite customer who provides order details when asked."
+      }
+    ]
+  }
+}

--- a/examples/integrations/evalhub/job.example.json
+++ b/examples/integrations/evalhub/job.example.json
@@ -24,16 +24,16 @@
       {
         "scenario_id": "order-status",
         "user_id": "u1",
-        "goal": "Find out the delivery date for order #12345.",
+        "goal": "You placed order #12345 a few days ago and want to know exactly when it will arrive. Ask the support agent for the delivery date, and push for a specific date if the first answer is vague.",
         "agent_context": "You are a customer support assistant for an online store.",
-        "user_profile": "A busy customer who is mildly impatient and wants a quick answer."
+        "user_profile": "You are Priya, a 31-year-old nurse working long shifts. You are mildly impatient, value quick and direct answers, and get frustrated by generic responses that don't address your specific question."
       },
       {
         "scenario_id": "refund-request",
         "user_id": "u2",
-        "goal": "Request a refund for a damaged item from order #67890.",
+        "goal": "Your order #67890 arrived with a damaged item and you want a refund. Explain the problem, provide order details when the agent asks, and confirm the refund amount and timeline before ending the conversation.",
         "agent_context": "You are a customer support assistant for an online store.",
-        "user_profile": "A polite customer who provides order details when asked."
+        "user_profile": "You are Marcus, a 45-year-old small-business owner. You are polite and cooperative and provide details promptly when asked, but you expect clear confirmation and follow-through."
       }
     ]
   }

--- a/examples/integrations/evalhub/main.py
+++ b/examples/integrations/evalhub/main.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Container entrypoint. EvalHub runs ``python main.py`` inside the job pod."""
+
+from __future__ import annotations
+
+from arksim_evalhub import main
+
+if __name__ == "__main__":
+    main()

--- a/examples/integrations/evalhub/provider.yaml
+++ b/examples/integrations/evalhub/provider.yaml
@@ -1,0 +1,27 @@
+# EvalHub provider registration for arksim.
+#
+# Register for a local server run with:
+#   evalhub providers create --file provider.yaml
+#
+# NOTE: this is an illustrative template. Confirm field names against your
+# EvalHub version's provider schema before relying on it in CI.
+id: arksim
+name: arksim
+description: Multi-turn agent simulation and evaluation (github.com/arklexai/arksim).
+
+runtime:
+  local:
+    command: "python main.py"
+  # k8s:
+  #   image: <your-registry>/arksim-evalhub:latest
+
+benchmarks:
+  - id: customer-service-smoke
+    description: Smoke suite of customer-service scenarios.
+    metrics:
+      - overall_agent_score
+      - goal_completion_score
+      - turn_success_ratio
+      - num_conversations
+    primary_score: overall_agent_score
+    pass_criteria: "overall_agent_score >= 0.6"

--- a/examples/integrations/evalhub/requirements.txt
+++ b/examples/integrations/evalhub/requirements.txt
@@ -1,0 +1,4 @@
+# For reproducible production images, pin arksim to an exact version or install
+# from a compiled lockfile (e.g. pip-compile) instead of the floor below.
+arksim>=0.3.7
+eval-hub-sdk[adapter]==0.4.0

--- a/examples/integrations/evalhub/run_local.py
+++ b/examples/integrations/evalhub/run_local.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run the arksim EvalHub adapter locally, without Kubernetes or Docker.
+
+This uses the SDK-only local path: write a JobSpec to the conventional local
+job-spec location, point ``EVALHUB_JOB_SPEC_PATH`` at it, then invoke the
+adapter entrypoint.
+
+Prerequisites:
+  * An LLM key for the simulator/judge (e.g. ``OPENAI_API_KEY``), since arksim
+    generates the simulated user and judges transcripts with real models.
+  * A reachable target endpoint at the JobSpec's ``model.url``. The sample spec
+    points at OpenAI chat-completions and reuses ``OPENAI_API_KEY`` as the
+    target key via ``parameters.target_api_key_env``.
+
+Optional:
+  * ``MLFLOW_TRACKING_URI`` to log transcripts + report as MLflow artifacts.
+
+Usage:
+    python run_local.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+
+def main() -> None:
+    spec = json.loads((HERE / "job.example.json").read_text())
+
+    # EvalHub local layout the SDK expects, under a private (0700) temp dir:
+    #   .../{job_id}/{benchmark_index}/{provider_id}/{benchmark_id}/meta/job.json
+    spec_path = (
+        Path(tempfile.mkdtemp(prefix="evalhub-jobs-"))
+        / spec["id"]
+        / str(spec["benchmark_index"])
+        / spec["provider_id"]
+        / spec["benchmark_id"]
+        / "meta"
+        / "job.json"
+    )
+    spec_path.parent.mkdir(parents=True, exist_ok=True)
+    spec_path.write_text(json.dumps(spec, indent=2))
+
+    os.environ["EVALHUB_JOB_SPEC_PATH"] = str(spec_path)
+    os.environ.setdefault("EVALHUB_MODE", "local")
+
+    print(f"Job spec written to: {spec_path}")
+
+    from arksim_evalhub import main as adapter_main
+
+    adapter_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/integrations/evalhub/tests/test_adapter.py
+++ b/examples/integrations/evalhub/tests/test_adapter.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Adapter wiring tests. The LLM-driven sim/eval seam is stubbed, so these run
+without API keys or a target endpoint."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import arksim_evalhub.adapter as adapter_mod
+import pytest
+from arksim_evalhub.adapter import ArksimAdapter, resolve_target_api_key
+from arksim_evalhub.mapping import ArksimJobParameters
+
+from arksim.evaluator.entities import ConversationEvaluation, Evaluation
+from arksim.simulation_engine.entities import Simulation
+
+_SCENARIO = {
+    "scenario_id": "s",
+    "user_id": "u",
+    "goal": "g",
+    "agent_context": "c",
+    "user_profile": "p",
+}
+
+JOB_SPEC = {
+    "id": "job-1",
+    "provider_id": "arksim",
+    "benchmark_id": "bench",
+    "benchmark_index": 0,
+    "callback_url": "http://localhost:8080",
+    "model": {"url": "https://api/x", "name": "gpt-4.1-mini"},
+    "parameters": {
+        "target_api_key_env": "FAKE_KEY",
+        "scenarios": [
+            {**_SCENARIO, "scenario_id": "s1"},
+            {**_SCENARIO, "scenario_id": "s2"},
+        ],
+    },
+}
+
+
+class _RecordingCallbacks:
+    def __init__(self) -> None:
+        self.statuses: list[object] = []
+        self.results: object | None = None
+
+    def report_status(self, update: object) -> None:
+        self.statuses.append(update)
+
+    def report_results(self, results: object) -> None:
+        self.results = results
+
+    def create_oci_artifact(self, spec: object) -> object:
+        raise NotImplementedError
+
+
+def _write_job_spec(tmp_path: Path, spec: dict) -> Path:
+    path = (
+        tmp_path
+        / spec["id"]
+        / str(spec["benchmark_index"])
+        / spec["provider_id"]
+        / spec["benchmark_id"]
+        / "meta"
+        / "job.json"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(spec))
+    return path
+
+
+def _fake_sim_eval(
+    scores: list[float], *, write_artifacts: bool = True
+) -> Callable[..., Awaitable[tuple[Simulation, Evaluation]]]:
+    async def _fake(agent_config, params, scenarios, output_dir):  # noqa: ANN001, ANN202
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if write_artifacts:
+            (output_dir / "simulation.json").write_text("{}")
+            (output_dir / "evaluation.json").write_text("{}")
+            (output_dir / "final_report.html").write_text("<html></html>")
+        convos = [
+            ConversationEvaluation(
+                conversation_id=f"c{i}",
+                goal_completion_score=s,
+                goal_completion_reason="",
+                turn_success_ratio=s,
+                overall_agent_score=s,
+                evaluation_status="Done",
+                turn_scores=[],
+            )
+            for i, s in enumerate(scores)
+        ]
+        evaluation = Evaluation(
+            schema_version="v1.1",
+            generated_at="2026-01-01T00:00:00Z",
+            evaluator_version="v1",
+            evaluation_id="e",
+            simulation_id="s",
+            conversations=convos,
+            unique_errors=[],
+        )
+        simulation = Simulation(
+            schema_version="v1", simulator_version="v1", conversations=[]
+        )
+        return simulation, evaluation
+
+    return _fake
+
+
+@pytest.fixture
+def adapter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ArksimAdapter:
+    spec_path = _write_job_spec(tmp_path, JOB_SPEC)
+    monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(spec_path))
+    monkeypatch.setenv("EVALHUB_MODE", "local")
+    # JOB_SPEC names FAKE_KEY as the target api-key env var; provide it so the
+    # credential resolution succeeds for the wiring/main tests.
+    monkeypatch.setenv("FAKE_KEY", "test-key")
+    return ArksimAdapter()
+
+
+def test_run_benchmark_job_wiring(
+    adapter: ArksimAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        adapter_mod, "simulate_and_evaluate", _fake_sim_eval([0.4, 0.6])
+    )
+    callbacks = _RecordingCallbacks()
+
+    results = adapter.run_benchmark_job(adapter.job_spec, callbacks)
+
+    assert results.model_name == "gpt-4.1-mini"
+    assert results.num_examples_evaluated == 2
+    assert results.overall_score == pytest.approx(0.5)
+    metric_names = {r.metric_name for r in results.results}
+    assert {"num_conversations", "overall_agent_score"} <= metric_names
+    assert len(adapter.mlflow_artifacts) == 3
+    assert callbacks.statuses, "expected progress status updates"
+
+
+def test_missing_artifacts_are_skipped_not_fatal(
+    adapter: ArksimAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        adapter_mod,
+        "simulate_and_evaluate",
+        _fake_sim_eval([0.5], write_artifacts=False),
+    )
+    results = adapter.run_benchmark_job(adapter.job_spec, _RecordingCallbacks())
+    assert results.num_examples_evaluated == 1
+    assert adapter.mlflow_artifacts == []
+
+
+def test_num_examples_caps_scenarios(
+    adapter: ArksimAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, int] = {}
+
+    async def _fake(agent_config, params, scenarios, output_dir):  # noqa: ANN001, ANN202
+        captured["n"] = len(scenarios.scenarios)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        evaluation = Evaluation(
+            schema_version="v1.1",
+            generated_at="2026-01-01T00:00:00Z",
+            evaluator_version="v1",
+            evaluation_id="e",
+            simulation_id="s",
+            conversations=[],
+            unique_errors=[],
+        )
+        return (
+            Simulation(schema_version="v1", simulator_version="v1", conversations=[]),
+            evaluation,
+        )
+
+    monkeypatch.setattr(adapter_mod, "simulate_and_evaluate", _fake)
+    spec = adapter.job_spec
+    spec.num_examples = 1
+
+    adapter.run_benchmark_job(spec, _RecordingCallbacks())
+    assert captured["n"] == 1
+
+
+def _params_with_key_env() -> ArksimJobParameters:
+    return ArksimJobParameters.model_validate(
+        {"target_api_key_env": "FAKE_KEY", "scenarios": [_SCENARIO]}
+    )
+
+
+def test_resolve_api_key_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(adapter_mod, "read_model_auth_key", lambda key: None)
+    monkeypatch.setenv("FAKE_KEY", "from-env")
+    assert resolve_target_api_key(_params_with_key_env()) == "from-env"
+
+
+def test_resolve_api_key_prefers_mounted_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(adapter_mod, "read_model_auth_key", lambda key: "mounted")
+    monkeypatch.setenv("FAKE_KEY", "from-env")
+    assert resolve_target_api_key(_params_with_key_env()) == "mounted"
+
+
+class _RecordingMlflow:
+    def __init__(self) -> None:
+        self.saved: list[object] = []
+
+    def save(self, results: object, job_spec: object, artifacts: object = None) -> str:
+        self.saved.append((results, artifacts))
+        return "run-123"
+
+
+def _stub_callbacks(monkeypatch: pytest.MonkeyPatch) -> _RecordingCallbacks:
+    """Make main() use a recording callbacks double instead of the real SDK."""
+    cb = _RecordingCallbacks()
+    cb.mlflow = _RecordingMlflow()  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        adapter_mod.DefaultCallbacks, "from_adapter", staticmethod(lambda a: cb)
+    )
+    return cb
+
+
+def test_main_skips_mlflow_without_uri(
+    adapter: ArksimAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(adapter_mod, "simulate_and_evaluate", _fake_sim_eval([0.7]))
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+    cb = _stub_callbacks(monkeypatch)
+
+    adapter_mod.main()
+
+    assert cb.results is not None
+    assert cb.results.num_examples_evaluated == 1
+    assert cb.mlflow.saved == []  # type: ignore[attr-defined]
+
+
+def test_main_logs_mlflow_when_uri_set(
+    adapter: ArksimAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(adapter_mod, "simulate_and_evaluate", _fake_sim_eval([0.7]))
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://localhost:5000")
+    cb = _stub_callbacks(monkeypatch)
+
+    adapter_mod.main()
+
+    assert len(cb.mlflow.saved) == 1  # type: ignore[attr-defined]
+    assert cb.results.mlflow_run_id == "run-123"
+
+
+def test_main_success_with_real_callbacks_no_sidecar(
+    adapter: ArksimAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real DefaultCallbacks must degrade gracefully (log, not raise) when
+    no sidecar is reachable, so a local run completes instead of crashing."""
+    monkeypatch.setattr(adapter_mod, "simulate_and_evaluate", _fake_sim_eval([0.7]))
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+
+    adapter_mod.main()  # must not raise
+
+
+def test_main_reports_failed_and_reraises_on_error(
+    adapter: ArksimAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _boom(*args: object, **kwargs: object) -> tuple[object, object]:
+        raise RuntimeError("sim exploded")
+
+    monkeypatch.setattr(adapter_mod, "simulate_and_evaluate", _boom)
+    cb = _stub_callbacks(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="sim exploded"):
+        adapter_mod.main()
+
+    assert any(
+        getattr(s, "status", None) == adapter_mod.JobStatus.FAILED for s in cb.statuses
+    )
+
+
+def test_resolve_api_key_raises_when_named_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(adapter_mod, "read_model_auth_key", lambda key: None)
+    monkeypatch.delenv("FAKE_KEY", raising=False)
+    with pytest.raises(ValueError, match="target_api_key_env"):
+        resolve_target_api_key(_params_with_key_env())
+
+
+def test_resolve_api_key_none_when_no_secret_and_no_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(adapter_mod, "read_model_auth_key", lambda key: None)
+    params = ArksimJobParameters.model_validate({"scenarios": [_SCENARIO]})
+    assert resolve_target_api_key(params) is None
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://api.example.com/v1/chat", "https://api.example.com/v1/chat"),
+        ("https://user:secret@api.example.com/v1", "https://api.example.com/v1"),
+        ("https://api.example.com/v1?api_key=SECRET", "https://api.example.com/v1"),
+        ("https://host:8443/v1", "https://host:8443/v1"),
+    ],
+)
+def test_redact_url(url: str, expected: str) -> None:
+    assert adapter_mod._redact_url(url) == expected
+
+
+def test_redact_url_schemeless_does_not_leak() -> None:
+    assert "secret" not in adapter_mod._redact_url("user:secret@host.com/v1")
+
+
+def test_scrub_redacts_secrets() -> None:
+    scrubbed = adapter_mod._scrub(
+        "fail: Bearer sk-abc123DEF at https://u:p@host/x key sk-ZZZ12345abc"
+    )
+    assert "sk-abc123DEF" not in scrubbed
+    assert "sk-ZZZ12345abc" not in scrubbed
+    assert "u:p@" not in scrubbed
+    assert "[REDACTED]" in scrubbed
+
+
+def test_select_scenarios_rejects_nonpositive() -> None:
+    scenarios = ArksimJobParameters.model_validate(
+        {"scenarios": [_SCENARIO, {**_SCENARIO, "scenario_id": "s2"}]}
+    ).scenarios
+    for bad in (0, -1):
+        with pytest.raises(ValueError, match="num_examples must be positive"):
+            ArksimAdapter._select_scenarios(scenarios, bad)
+
+
+def test_run_benchmark_job_propagates_sim_failure(
+    adapter: ArksimAdapter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _boom(*args: object, **kwargs: object) -> tuple[object, object]:
+        raise RuntimeError("sim exploded")
+
+    monkeypatch.setattr(adapter_mod, "simulate_and_evaluate", _boom)
+    with pytest.raises(RuntimeError, match="sim exploded"):
+        adapter.run_benchmark_job(adapter.job_spec, _RecordingCallbacks())

--- a/examples/integrations/evalhub/tests/test_mapping.py
+++ b/examples/integrations/evalhub/tests/test_mapping.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the pure EvalHub <-> arksim mapping (no LLM, no credentials)."""
+
+from __future__ import annotations
+
+import pytest
+from arksim_evalhub.mapping import (
+    ArksimJobParameters,
+    aggregate_metrics,
+    build_agent_config,
+    compute_overall_score,
+)
+from evalhub.adapter import ModelConfig
+from pydantic import ValidationError
+
+from arksim import A2AConfig, ChatCompletionsConfig
+from arksim.evaluator.entities import ConversationEvaluation, Evaluation
+
+_SCENARIO = {
+    "scenario_id": "s1",
+    "user_id": "u1",
+    "goal": "g",
+    "agent_context": "c",
+    "user_profile": "p",
+}
+
+
+def _params(**overrides: object) -> ArksimJobParameters:
+    data: dict[str, object] = {"scenarios": [_SCENARIO]}
+    data.update(overrides)
+    return ArksimJobParameters.model_validate(data)
+
+
+def _convo(score: float) -> ConversationEvaluation:
+    return ConversationEvaluation(
+        conversation_id="c",
+        goal_completion_score=score,
+        goal_completion_reason="",
+        turn_success_ratio=score,
+        overall_agent_score=score,
+        evaluation_status="Done",
+        turn_scores=[],
+    )
+
+
+def _evaluation(scores: list[float]) -> Evaluation:
+    return Evaluation(
+        schema_version="v1.1",
+        generated_at="2026-01-01T00:00:00Z",
+        evaluator_version="v1",
+        evaluation_id="e1",
+        simulation_id="sim1",
+        conversations=[_convo(s) for s in scores],
+        unique_errors=[],
+    )
+
+
+class TestArksimJobParameters:
+    def test_wraps_bare_scenario_list(self) -> None:
+        params = _params()
+        assert params.scenarios.schema_version == "v1"
+        assert len(params.scenarios.scenarios) == 1
+
+    def test_accepts_full_scenarios_object(self) -> None:
+        params = _params(scenarios={"schema_version": "v2", "scenarios": [_SCENARIO]})
+        assert params.scenarios.schema_version == "v2"
+
+    def test_rejects_unknown_key(self) -> None:
+        with pytest.raises(ValidationError):
+            _params(simulater_model="typo")
+
+    def test_rejects_empty_scenarios(self) -> None:
+        with pytest.raises(ValidationError, match="at least one scenario"):
+            ArksimJobParameters.model_validate({"scenarios": []})
+
+    def test_rejects_reserved_request_body_keys(self) -> None:
+        with pytest.raises(ValidationError, match="reserved keys"):
+            _params(request_body={"messages": "nope"})
+
+    def test_defaults(self) -> None:
+        params = _params()
+        assert params.protocol == "chat_completions"
+        assert params.num_conversations_per_scenario == 2
+
+    def test_accepts_auto_num_workers(self) -> None:
+        assert _params(num_workers="auto").num_workers == "auto"
+
+    def test_rejects_junk_num_workers(self) -> None:
+        with pytest.raises(ValidationError):
+            _params(num_workers="fast")
+
+    def test_rejects_nonpositive_num_workers(self) -> None:
+        with pytest.raises(ValidationError):
+            _params(num_workers=0)
+
+
+class TestBuildAgentConfig:
+    def test_chat_completions_maps_endpoint_and_bearer(self) -> None:
+        model = ModelConfig(url="https://api/x", name="gpt-4.1-mini")
+        cfg = build_agent_config(model, _params(), api_key="secret")
+        assert cfg.agent_type == "chat_completions"
+        assert isinstance(cfg.api_config, ChatCompletionsConfig)
+        assert cfg.api_config.endpoint == "https://api/x"
+        assert cfg.api_config.body["model"] == "gpt-4.1-mini"
+        assert cfg.api_config.headers["Authorization"] == "Bearer secret"
+
+    def test_chat_completions_without_api_key_has_no_auth(self) -> None:
+        model = ModelConfig(url="https://api/x", name="m")
+        cfg = build_agent_config(model, _params(), api_key=None)
+        assert cfg.api_config.headers is None
+
+    def test_a2a_protocol(self) -> None:
+        model = ModelConfig(url="https://agent/a2a", name="m")
+        cfg = build_agent_config(model, _params(protocol="a2a"), api_key="k")
+        assert cfg.agent_type == "a2a"
+        assert isinstance(cfg.api_config, A2AConfig)
+        assert cfg.api_config.endpoint == "https://agent/a2a"
+        assert cfg.api_config.headers["Authorization"] == "Bearer k"
+
+    def test_request_body_merged(self) -> None:
+        model = ModelConfig(url="u", name="m")
+        cfg = build_agent_config(
+            model, _params(request_body={"temperature": 0.0}), api_key=None
+        )
+        assert cfg.api_config.body["temperature"] == 0.0
+
+
+class TestAggregation:
+    def test_aggregate_metrics_means(self) -> None:
+        results = aggregate_metrics(_evaluation([0.4, 0.6]))
+        by_name = {r.metric_name: r.metric_value for r in results}
+        assert by_name["num_conversations"] == 2
+        assert by_name["overall_agent_score"] == pytest.approx(0.5)
+        assert by_name["goal_completion_score"] == pytest.approx(0.5)
+        assert by_name["turn_success_ratio"] == pytest.approx(0.5)
+
+    def test_aggregate_metrics_empty(self) -> None:
+        results = aggregate_metrics(_evaluation([]))
+        assert len(results) == 1
+        assert results[0].metric_name == "num_conversations"
+        assert results[0].metric_value == 0
+
+    def test_compute_overall_score(self) -> None:
+        assert compute_overall_score(_evaluation([0.2, 0.8])) == pytest.approx(0.5)
+
+    def test_compute_overall_score_empty(self) -> None:
+        assert compute_overall_score(_evaluation([])) is None


### PR DESCRIPTION
## Summary

Adds a proof-of-concept adapter that runs arksim's multi-turn agent simulation
and evaluation as an [EvalHub](https://eval-hub.github.io/) benchmark provider,
under `examples/integrations/evalhub/`.

EvalHub points at a target agent endpoint; the adapter drives it with simulated
users across scenarios, scores the transcripts, and reports aggregate metrics to
EvalHub plus the transcripts and HTML report to MLflow.

## How it maps

| EvalHub | arksim |
|---|---|
| `JobSpec.model.url` / `.name` | target agent endpoint (`chat_completions` or `a2a`) |
| `JobSpec.model.auth.secret_ref` -> `/var/run/secrets/model/api-key` | bearer token on the agent's requests |
| `JobSpec.parameters` (freeform JSON) | scenarios + simulator/judge config (`ArksimJobParameters`) |
| scalar metrics | `overall_agent_score`, `goal_completion_score`, `turn_success_ratio`, `num_conversations` |
| MLflow artifacts | `simulation.json`, `evaluation.json`, `final_report.html` |

## What's included

- `arksim_evalhub/mapping.py` - pure EvalHub<->arksim transforms (no I/O), unit-tested.
- `arksim_evalhub/adapter.py` - `ArksimAdapter(FrameworkAdapter)`, credential resolution, the sim+eval run, and `main()`.
- `main.py` / `run_local.py` - container and local entrypoints.
- `job.example.json`, `provider.yaml`, `Containerfile`, `requirements.txt`, `README.md`.
- Tests for the mapping and adapter wiring (no LLM calls; the sim/eval step is stubbed).

## Verified

- Real end-to-end local run (simulation -> evaluation -> metrics -> artifacts) against OpenAI and a local MLflow server; 5 metrics and 3 artifacts confirmed in MLflow.
- 36 example tests pass; `ruff` check + format clean; the full `tests/unit` suite is unaffected.

## Out of scope (follow-ups)

- Real-cluster contract (sidecar callbacks, mounted secret, MLflow via the sidecar proxy, OCI push, `provider.yaml` schema) - needs a live EvalHub deployment.
- Richer per-metric / behavior-failure metrics (the data is already available from arksim's evaluation output).
- TLS `ca_cert` for custom-CA target endpoints.

## Note on credentials

Despite the EvalHub model-authentication docs, the SDK only auto-attaches the
ServiceAccount token to control-plane callbacks. The adapter reads the model
api-key itself (`read_model_auth_key("api-key")`) and attaches it to the agent's
outbound requests. Worth confirming with the EvalHub team.
