### PR TITLE
feat(voice): support Pipecat and LiveKit voice agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * **integrations:** Langfuse exporter (`arksim[langfuse]`) that maps scenarios to dataset items, conversations to traces via the Langfuse dataset-run/experiment API, and evaluation results to trace and turn scores; works against self-hosted Langfuse with the public SDK (`arksim.integrations.langfuse`)
-* **voice:** native `voice` agent type that drives a Pipecat voice agent through its real ASR/LLM/TTS stack; arksim voices the simulated user and transcribes the agent's audio reply, with pluggable local TTS/STT (Kokoro + faster-whisper) via `pip install 'arksim[voice]'`
+* **voice:** native `voice` agent type that drives Pipecat and LiveKit Agents through their real ASR/LLM/TTS stacks; arksim voices the simulated user and transcribes the agent's audio reply, with pluggable local TTS/STT (Kokoro + faster-whisper) via `arksim[voice]`, `arksim[livekit-voice]`, or the combined `arksim[voice-all]`
 * **integrations:** Claude Code integration with 6 skills (5 framework skills + arksim-simulate alias) and 6 MCP tools for IDE-native agent testing (`integrations/claude_code/`)
 * **cli:** `arksim setup-claude` command for one-command installation of Claude Code integration
 * **cli:** `arksim setup-claude --uninstall` to remove the integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * **integrations:** Langfuse exporter (`arksim[langfuse]`) that maps scenarios to dataset items, conversations to traces via the Langfuse dataset-run/experiment API, and evaluation results to trace and turn scores; works against self-hosted Langfuse with the public SDK (`arksim.integrations.langfuse`)
+* **voice:** native `voice` agent type that drives a Pipecat voice agent through its real ASR/LLM/TTS stack; arksim voices the simulated user and transcribes the agent's audio reply, with pluggable local TTS/STT (Kokoro + faster-whisper) via `pip install 'arksim[voice]'`
 * **integrations:** Claude Code integration with 6 skills (5 framework skills + arksim-simulate alias) and 6 MCP tools for IDE-native agent testing (`integrations/claude_code/`)
 * **cli:** `arksim setup-claude` command for one-command installation of Claude Code integration
 * **cli:** `arksim setup-claude --uninstall` to remove the integration

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The report tells you where your agent is strong and where it breaks. You get per
 from arksim.simulation_engine.agent.base import BaseAgent
 from arksim.simulation_engine.tool_types import AgentResponse
 
+
 class MyAgent(BaseAgent):
     async def get_chat_id(self) -> str:
         return "unique-id"

--- a/README.md
+++ b/README.md
@@ -117,13 +117,39 @@ agent_config:
 
 A2A agents can also surface tool calls for evaluation via the arksim [tool call capture extension](https://docs.arklex.ai/main/tool-call-capture). See `examples/customer-service/a2a_server/` for a runnable reference server.
 
+### Voice agents
+
+ArkSim can evaluate Pipecat and LiveKit Agents through their actual
+STT → LLM → TTS pipelines. It synthesizes each simulated-user turn, injects
+the audio into the framework, captures the spoken response, and transcribes it
+for the standard evaluators.
+
+```yaml
+agent_config:
+  agent_type: voice
+  agent_name: support-voice
+  voice_config:
+    framework: livekit # or pipecat
+    agent_factory: ./agent.py:build
+    tts:
+      provider: kokoro
+    stt:
+      provider: faster_whisper
+      model: base.en
+```
+
+Install `arksim[voice]` for Pipecat, `arksim[livekit-voice]` for LiveKit, or
+`arksim[voice-all]` for both. See the [Pipecat](https://github.com/arklexai/arksim/tree/main/examples/integrations/pipecat-voice)
+and [LiveKit](https://github.com/arklexai/arksim/tree/main/examples/integrations/livekit-voice)
+examples for their framework-specific factory contracts.
+
 Write scenarios that match your agent's domain. See the [Scenarios documentation](https://docs.arklex.ai/main/build-scenario) for how to define goals, user profiles, and knowledge.
 
 ## Why ArkSim?
 
 - **Simulation, not just evaluation.** Most tools score conversations you already have. ArkSim generates them with synthetic users who push back, ask follow-ups, and behave unpredictably.
 - **Multi-turn by default.** Every test is a full conversation, not a single prompt. Context loss, tool misuse, and contradictions only show up across turns.
-- **Any agent, any framework.** Works with [14+ frameworks](#integrations) through Chat Completions, A2A, or direct Python import.
+- **Any agent, any framework.** Works with [16+ frameworks](#integrations) through Chat Completions, A2A, direct Python import, or native voice pipelines.
 - **Runs in CI.** Add it as a quality gate on every PR. Exits non-zero when your agent drops below threshold.
 - **Fully open source.** Runs on your infrastructure. Your data never leaves.
 
@@ -169,6 +195,8 @@ See the [integration README](integrations/claude_code/README.md) for the install
 | [Smolagents](https://github.com/arklexai/arksim/tree/main/examples/integrations/smolagents) | Hugging Face |
 | [Mastra](https://github.com/arklexai/arksim/tree/main/examples/integrations/mastra) | TypeScript |
 | [Vercel AI SDK](https://github.com/arklexai/arksim/tree/main/examples/integrations/vercel-ai-sdk) | TypeScript |
+| [Pipecat Voice](https://github.com/arklexai/arksim/tree/main/examples/integrations/pipecat-voice) | Pipecat |
+| [LiveKit Voice](https://github.com/arklexai/arksim/tree/main/examples/integrations/livekit-voice) | LiveKit Agents |
 
 See [examples](https://github.com/arklexai/arksim/tree/main/examples) for end-to-end projects with custom metrics and scenarios.
 

--- a/arksim/config/__init__.py
+++ b/arksim/config/__init__.py
@@ -3,13 +3,23 @@
 
 from __future__ import annotations
 
-from .core.agent import A2AConfig, AgentConfig, ChatCompletionsConfig, CustomConfig
-from .types import AgentType
+from .core.agent import (
+    A2AConfig,
+    AgentConfig,
+    ChatCompletionsConfig,
+    CustomConfig,
+    SpeechProviderConfig,
+    VoiceConfig,
+)
+from .types import AgentType, VoiceFramework
 
 __all__ = [
     "AgentConfig",
     "ChatCompletionsConfig",
     "A2AConfig",
     "CustomConfig",
+    "SpeechProviderConfig",
+    "VoiceConfig",
     "AgentType",
+    "VoiceFramework",
 ]

--- a/arksim/config/core/agent.py
+++ b/arksim/config/core/agent.py
@@ -13,7 +13,7 @@ else:
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from arksim.config.types import AgentType
+from arksim.config.types import AgentType, VoiceFramework
 from arksim.config.utils import resolve_env_vars
 
 
@@ -111,6 +111,40 @@ class CustomConfig(BaseModel):
         return self
 
 
+class SpeechProviderConfig(BaseModel):
+    """A pluggable TTS or STT provider for the voice agent loop."""
+
+    provider: str = Field(
+        ..., description="Provider key, e.g. 'kokoro', 'faster_whisper'"
+    )
+    model: str | None = Field(None, description="Provider model id, if applicable")
+    options: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Provider-specific options (voice id, language, device)",
+    )
+
+
+class VoiceConfig(BaseModel):
+    """Configuration for the native ``voice`` agent type."""
+
+    framework: VoiceFramework = Field(
+        ..., description="Voice framework backing the agent"
+    )
+    agent_factory: str = Field(
+        ...,
+        description="Pointer to a zero-arg callable returning the framework agent. "
+        "Format: './agent.py:build' or 'pkg.module:build'.",
+    )
+    tts: SpeechProviderConfig = Field(
+        default_factory=lambda: SpeechProviderConfig(provider="kokoro"),
+        description="Provider that voices the simulated user",
+    )
+    stt: SpeechProviderConfig = Field(
+        default_factory=lambda: SpeechProviderConfig(provider="faster_whisper"),
+        description="Provider that transcribes the agent's audio reply",
+    )
+
+
 class AgentConfig(BaseModel):
     """Agent configuration."""
 
@@ -121,6 +155,9 @@ class AgentConfig(BaseModel):
     )
     custom_config: CustomConfig | None = Field(
         None, description="Configuration for custom agents"
+    )
+    voice_config: VoiceConfig | None = Field(
+        None, description="Configuration for voice agents"
     )
 
     @model_validator(mode="before")
@@ -152,6 +189,12 @@ class AgentConfig(BaseModel):
                     raise ValueError("a2a agent requires 'api_config'")
                 if not isinstance(config_data, A2AConfig):
                     data["api_config"] = A2AConfig(**config_data)
+            elif agent_type == AgentType.VOICE.value:
+                config_data = data.get("voice_config")
+                if not config_data:
+                    raise ValueError("voice agent requires 'voice_config'")
+                if not isinstance(config_data, VoiceConfig):
+                    data["voice_config"] = VoiceConfig(**config_data)
             else:
                 raise ValueError(f"Unsupported agent type: {agent_type}")
         else:
@@ -179,6 +222,8 @@ class AgentConfig(BaseModel):
             raise ValueError(f"'{self.agent_type}' agent requires 'api_config'")
         if self.agent_type == AgentType.CUSTOM.value and self.custom_config is None:
             raise ValueError("'custom' agent requires 'custom_config'")
+        if self.agent_type == AgentType.VOICE.value and self.voice_config is None:
+            raise ValueError("'voice' agent requires 'voice_config'")
         return self
 
     @classmethod

--- a/arksim/config/types.py
+++ b/arksim/config/types.py
@@ -16,4 +16,5 @@ class AgentType(Enum):
 class VoiceFramework(str, Enum):
     """Voice agent framework backing a ``voice`` agent."""
 
+    LIVEKIT = "livekit"
     PIPECAT = "pipecat"

--- a/arksim/config/types.py
+++ b/arksim/config/types.py
@@ -10,3 +10,11 @@ class AgentType(Enum):
     CHAT_COMPLETIONS = "chat_completions"
     A2A = "a2a"
     CUSTOM = "custom"
+    VOICE = "voice"
+
+
+class VoiceFramework(str, Enum):
+    """Voice agent framework backing a ``voice`` agent."""
+
+    PIPECAT = "pipecat"
+    LIVEKIT = "livekit"

--- a/arksim/config/types.py
+++ b/arksim/config/types.py
@@ -17,4 +17,3 @@ class VoiceFramework(str, Enum):
     """Voice agent framework backing a ``voice`` agent."""
 
     PIPECAT = "pipecat"
-    LIVEKIT = "livekit"

--- a/arksim/integrations/livekit.py
+++ b/arksim/integrations/livekit.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from collections.abc import Callable, Iterator
+
+import numpy as np
+
+from arksim.simulation_engine.tool_types import (
+    AgentResponse,
+    ToolCall,
+    ToolCallSource,
+)
+from arksim.speech.base import STTProvider, TTSProvider
+from arksim.speech.types import AudioBuffer, audio_from_pcm16, pcm16_bytes
+
+try:
+    from livekit import rtc
+    from livekit.agents import Agent, AgentSession
+    from livekit.agents.voice.events import FunctionToolsExecutedEvent
+    from livekit.agents.voice.io import (
+        AudioInput,
+        AudioOutput,
+        AudioOutputCapabilities,
+    )
+except ImportError as exc:  # pragma: no cover - exercised only without extras
+    raise ImportError(
+        "LiveKit voice support requires: pip install 'arksim[livekit-voice]'"
+    ) from exc
+
+_TURN_TIMEOUT_S = 120.0
+_TRANSCRIPT_TIMEOUT_S = 10.0
+_STT_FLUSH_DURATION_S = 1.0
+_FRAME_DURATION_MS = 20
+
+
+def _parse_arguments(raw: object) -> dict[str, object]:
+    """Normalize LiveKit's JSON-encoded function arguments."""
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str):
+        return {"_value": raw}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"_value": raw}
+    return parsed if isinstance(parsed, dict) else {"_value": parsed}
+
+
+def _rtc_frames(audio: AudioBuffer) -> Iterator[rtc.AudioFrame]:
+    """Split an audio buffer into LiveKit-compatible 20 ms PCM frames."""
+    if audio.num_channels < 1:
+        raise ValueError("Audio must have at least one channel")
+    pcm = pcm16_bytes(audio)
+    bytes_per_sample = 2 * audio.num_channels
+    if len(pcm) % bytes_per_sample:
+        raise ValueError("Audio sample count must be divisible by num_channels")
+
+    samples_per_channel = len(pcm) // bytes_per_sample
+    frame_samples = max(1, audio.sample_rate * _FRAME_DURATION_MS // 1000)
+    for start in range(0, samples_per_channel, frame_samples):
+        count = min(frame_samples, samples_per_channel - start)
+        byte_start = start * bytes_per_sample
+        byte_end = byte_start + count * bytes_per_sample
+        yield rtc.AudioFrame(
+            data=pcm[byte_start:byte_end],
+            sample_rate=audio.sample_rate,
+            num_channels=audio.num_channels,
+            samples_per_channel=count,
+        )
+
+
+class _QueueAudioInput(AudioInput):
+    """In-memory LiveKit audio source fed by arksim's simulated user."""
+
+    def __init__(self) -> None:
+        super().__init__(label="arksim")
+        self._frames: asyncio.Queue[rtc.AudioFrame | None] = asyncio.Queue()
+        self._attached = True
+        self._delivered_frame_pending = False
+
+    def push(self, audio: AudioBuffer) -> None:
+        if not self._attached:
+            raise RuntimeError("LiveKit audio input is detached")
+        for frame in _rtc_frames(audio):
+            self._frames.put_nowait(frame)
+
+    async def __anext__(self) -> rtc.AudioFrame:
+        # LiveKit asks for the next frame only after pushing the previous one
+        # into AgentSession. Mark it delivered at that point so wait_drained()
+        # cannot race commit_user_turn() ahead of the audio forwarding task.
+        if self._delivered_frame_pending:
+            self._frames.task_done()
+            self._delivered_frame_pending = False
+        frame = await self._frames.get()
+        if frame is None:
+            self._frames.task_done()
+            raise StopAsyncIteration
+        self._delivered_frame_pending = True
+        return frame
+
+    def on_attached(self) -> None:
+        self._attached = True
+
+    def on_detached(self) -> None:
+        self._attached = False
+
+    def close(self) -> None:
+        self._frames.put_nowait(None)
+
+    async def wait_drained(self) -> None:
+        await self._frames.join()
+
+
+class _CaptureAudioOutput(AudioOutput):
+    """In-memory LiveKit audio sink that captures complete speech segments."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            label="arksim",
+            capabilities=AudioOutputCapabilities(pause=False),
+        )
+        self.turn_done = asyncio.Event()
+        self._audio = bytearray()
+        self._sample_rate: int | None = None
+        self._num_channels: int | None = None
+        self._segment_duration = 0.0
+
+    def reset(self) -> None:
+        self.turn_done.clear()
+        self._audio.clear()
+        self._sample_rate = None
+        self._num_channels = None
+        self._segment_duration = 0.0
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        await super().capture_frame(frame)
+        if self._sample_rate is None:
+            self._sample_rate = frame.sample_rate
+            self._num_channels = frame.num_channels
+        elif (
+            frame.sample_rate != self._sample_rate
+            or frame.num_channels != self._num_channels
+        ):
+            raise RuntimeError("LiveKit changed audio format during one turn")
+        self._audio.extend(frame.data)
+        self._segment_duration += frame.duration
+
+    def flush(self) -> None:
+        super().flush()
+        if not self._segment_duration:
+            return
+        duration = self._segment_duration
+        self._segment_duration = 0.0
+        self.on_playback_finished(
+            playback_position=duration,
+            interrupted=False,
+        )
+        self.turn_done.set()
+
+    def clear_buffer(self) -> None:
+        duration = self._segment_duration
+        self._segment_duration = 0.0
+        self._audio.clear()
+        if duration:
+            self.on_playback_finished(
+                playback_position=duration,
+                interrupted=True,
+            )
+        self.turn_done.set()
+
+    def captured_audio(self) -> AudioBuffer | None:
+        if not self._audio:
+            return None
+        return audio_from_pcm16(
+            bytes(self._audio),
+            self._sample_rate or 24000,
+            self._num_channels or 1,
+        )
+
+
+class LiveKitVoiceDriver:
+    """Drive a LiveKit AgentSession through its STT/LLM/TTS audio path.
+
+    The factory must return ``(AgentSession, Agent)``. The session owns the
+    agent's real STT, LLM, and TTS providers; arksim replaces only its media
+    input and output with in-memory PCM endpoints.
+    """
+
+    def __init__(
+        self,
+        factory: Callable[[], tuple[AgentSession, Agent]],
+        *,
+        tts: TTSProvider,
+        stt: STTProvider,
+    ) -> None:
+        self._factory = factory
+        self._tts = tts
+        self._stt = stt
+        self._chat_id = str(uuid.uuid4())
+        self._session: AgentSession | None = None
+        self._audio_input: _QueueAudioInput | None = None
+        self._audio_output: _CaptureAudioOutput | None = None
+        self._tool_calls: list[ToolCall] = []
+
+    async def _ensure_started(self) -> None:
+        if self._session is not None:
+            return
+        built = self._factory()
+        if not isinstance(built, tuple) or len(built) != 2:
+            raise TypeError("LiveKit agent_factory must return (AgentSession, Agent)")
+        session, agent = built
+        if not isinstance(session, AgentSession) or not isinstance(agent, Agent):
+            raise TypeError("LiveKit agent_factory must return (AgentSession, Agent)")
+        if session.turn_detection != "manual":
+            raise ValueError(
+                "LiveKit AgentSession must use manual turn detection so arksim "
+                "controls audio turn boundaries"
+            )
+
+        audio_input = _QueueAudioInput()
+        audio_output = _CaptureAudioOutput()
+        self._session = session
+        self._audio_input = audio_input
+        self._audio_output = audio_output
+        try:
+            session.input.audio = audio_input
+            session.output.audio = audio_output
+            session.on("function_tools_executed", self._on_tools_executed)
+            await session.start(agent=agent, record=False)
+            await session.wait_for_idle()
+            audio_output.reset()
+        except BaseException:
+            await self.close()
+            raise
+
+    def _on_tools_executed(self, event: FunctionToolsExecutedEvent) -> None:
+        for fn_call, fn_output in event.zipped():
+            result: str | None = None
+            error: str | None = None
+            if fn_output is not None:
+                value = None if fn_output.output is None else str(fn_output.output)
+                if fn_output.is_error:
+                    error = value
+                else:
+                    result = value
+            self._tool_calls.append(
+                ToolCall(
+                    id=fn_call.call_id or fn_call.name,
+                    name=fn_call.name,
+                    arguments=_parse_arguments(fn_call.arguments),
+                    result=result,
+                    error=error,
+                    source=ToolCallSource.LIVEKIT,
+                )
+            )
+
+    async def run_turn(self, user_query: str) -> AgentResponse:
+        await self._ensure_started()
+        assert self._session is not None
+        assert self._audio_input is not None
+        assert self._audio_output is not None
+
+        self._tool_calls = []
+        self._audio_output.reset()
+        audio = self._perturb(await self._tts.synthesize(user_query))
+        self._audio_input.push(audio)
+        # AgentSession only adds flush silence when no audio input is attached.
+        # arksim attaches an in-memory input, so explicitly send silence through
+        # it to let streaming STT and VAD emit a final transcript before commit.
+        self._audio_input.push(
+            AudioBuffer(
+                samples=np.zeros(
+                    int(audio.sample_rate * _STT_FLUSH_DURATION_S * audio.num_channels),
+                    dtype=np.float32,
+                ),
+                sample_rate=audio.sample_rate,
+                num_channels=audio.num_channels,
+            )
+        )
+        await self._audio_input.wait_drained()
+
+        transcript_future = self._session.commit_user_turn(
+            transcript_timeout=_TRANSCRIPT_TIMEOUT_S,
+            stt_flush_duration=_STT_FLUSH_DURATION_S,
+        )
+        try:
+            await asyncio.wait_for(
+                transcript_future,
+                timeout=_TRANSCRIPT_TIMEOUT_S + _STT_FLUSH_DURATION_S + 1,
+            )
+            await asyncio.wait_for(
+                self._audio_output.turn_done.wait(), timeout=_TURN_TIMEOUT_S
+            )
+            await asyncio.wait_for(
+                self._session.wait_for_idle(), timeout=_TURN_TIMEOUT_S
+            )
+        except (TimeoutError, asyncio.TimeoutError) as exc:
+            await self.close()
+            raise TimeoutError(
+                f"LiveKit agent did not complete its audio turn for: {user_query!r}"
+            ) from exc
+
+        captured = self._audio_output.captured_audio()
+        if captured is None:
+            await self.close()
+            raise RuntimeError(f"LiveKit agent produced no audio for: {user_query!r}")
+        reply = await self._stt.transcribe(captured)
+        return AgentResponse(content=reply, tool_calls=list(self._tool_calls))
+
+    def _perturb(self, audio: AudioBuffer) -> AudioBuffer:
+        # v2 seam: accent / background-noise / volume perturbation hooks here.
+        return audio
+
+    async def get_chat_id(self) -> str:
+        return self._chat_id
+
+    async def close(self) -> None:
+        audio_input = self._audio_input
+        session = self._session
+        self._session = None
+        self._audio_input = None
+        self._audio_output = None
+        if audio_input is not None:
+            audio_input.close()
+        if session is not None:
+            await session.aclose()

--- a/arksim/integrations/pipecat.py
+++ b/arksim/integrations/pipecat.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from arksim.simulation_engine.tool_types import (
+    AgentResponse,
+    ToolCall,
+    ToolCallSource,
+)
+from arksim.speech.base import STTProvider, TTSProvider
+from arksim.speech.types import AudioBuffer, audio_from_pcm16, pcm16_bytes
+
+try:
+    from pipecat.frames.frames import (
+        EndFrame,
+        Frame,
+        FunctionCallResultFrame,
+        InputAudioRawFrame,
+        OutputAudioRawFrame,
+        TTSAudioRawFrame,
+        TTSStartedFrame,
+        TTSStoppedFrame,
+    )
+    from pipecat.pipeline.pipeline import Pipeline
+    from pipecat.pipeline.runner import PipelineRunner
+    from pipecat.pipeline.task import PipelineTask
+    from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+except ImportError as exc:  # pragma: no cover - exercised only without extras
+    raise ImportError(
+        "Pipecat voice support requires: pip install 'arksim[voice]'"
+    ) from exc
+
+# Seconds to wait for one agent turn (STT -> LLM -> TTS) to produce audio.
+_TURN_TIMEOUT_S = 120.0
+_DEFAULT_SAMPLE_RATE = 24000
+
+
+class _CaptureProcessor(FrameProcessor):
+    """Collects the agent's TTS audio and tool calls for a single turn."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._audio = bytearray()
+        self._sample_rate: int | None = None
+        self._num_channels = 1
+        self.tool_calls: list[ToolCall] = []
+        self._collecting = False
+        self.turn_done = asyncio.Event()
+
+    def reset(self) -> None:
+        self._audio = bytearray()
+        self._sample_rate = None
+        self._num_channels = 1
+        self.tool_calls = []
+        self._collecting = False
+        self.turn_done.clear()
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, TTSStartedFrame):
+            self._collecting = True
+        elif (
+            isinstance(frame, TTSAudioRawFrame | OutputAudioRawFrame)
+            and self._collecting
+        ):
+            self._audio.extend(frame.audio)
+            self._sample_rate = frame.sample_rate
+            self._num_channels = frame.num_channels
+        elif isinstance(frame, FunctionCallResultFrame):
+            self.tool_calls.append(
+                ToolCall(
+                    id=frame.tool_call_id or frame.function_name,
+                    name=frame.function_name,
+                    arguments=frame.arguments or {},
+                    result=None if frame.result is None else str(frame.result),
+                    source=ToolCallSource.PIPECAT,
+                )
+            )
+        elif isinstance(frame, TTSStoppedFrame):
+            self._collecting = False
+            self.turn_done.set()
+        await self.push_frame(frame, direction)
+
+    def captured_audio(self) -> AudioBuffer | None:
+        if not self._audio:
+            return None
+        return audio_from_pcm16(
+            bytes(self._audio),
+            self._sample_rate or _DEFAULT_SAMPLE_RATE,
+            self._num_channels,
+        )
+
+
+class PipecatVoiceDriver:
+    """Drives a Pipecat voice agent through its ASR/LLM/TTS stack.
+
+    arksim synthesizes the simulated user's utterance (``tts``), injects it as
+    audio, captures the agent's spoken reply, and transcribes it (``stt``).
+    """
+
+    def __init__(
+        self,
+        factory: Callable[[], Any],
+        *,
+        tts: TTSProvider,
+        stt: STTProvider,
+    ) -> None:
+        self._factory = factory
+        self._tts = tts
+        self._stt = stt
+        self._chat_id = str(uuid.uuid4())
+        self._task: PipelineTask | None = None
+        self._runner_run: asyncio.Task[Any] | None = None
+        self._capture: _CaptureProcessor | None = None
+
+    async def _ensure_started(self) -> None:
+        if self._task is not None:
+            return
+        built = self._factory()
+        stages = built[1] if isinstance(built, tuple) else built
+        self._capture = _CaptureProcessor()
+        self._task = PipelineTask(Pipeline([*stages, self._capture]))
+        runner = PipelineRunner()
+        self._runner_run = asyncio.create_task(runner.run(self._task))
+        # Yield so the runner emits StartFrame before the first turn is queued.
+        await asyncio.sleep(0.1)
+
+    async def run_turn(self, user_query: str) -> AgentResponse:
+        await self._ensure_started()
+        assert self._task is not None
+        assert self._capture is not None
+        self._capture.reset()
+        audio = self._perturb(await self._tts.synthesize(user_query))
+        await self._task.queue_frames(
+            [
+                InputAudioRawFrame(
+                    audio=pcm16_bytes(audio),
+                    sample_rate=audio.sample_rate,
+                    num_channels=audio.num_channels,
+                )
+            ]
+        )
+        try:
+            await asyncio.wait_for(self._capture.turn_done.wait(), _TURN_TIMEOUT_S)
+        except (TimeoutError, asyncio.TimeoutError) as exc:
+            raise TimeoutError(
+                f"Pipecat agent produced no audio within {_TURN_TIMEOUT_S}s "
+                f"for: {user_query!r}"
+            ) from exc
+        captured = self._capture.captured_audio()
+        if captured is None:
+            raise RuntimeError(f"Pipecat agent produced no audio for: {user_query!r}")
+        reply = await self._stt.transcribe(captured)
+        return AgentResponse(content=reply, tool_calls=list(self._capture.tool_calls))
+
+    def _perturb(self, audio: AudioBuffer) -> AudioBuffer:
+        # v2 seam: accent / background-noise / volume perturbation hooks here.
+        return audio
+
+    async def get_chat_id(self) -> str:
+        return self._chat_id
+
+    async def close(self) -> None:
+        if self._task is not None:
+            await self._task.queue_frames([EndFrame()])
+            self._task = None
+        if self._runner_run is not None:
+            try:
+                await asyncio.wait_for(self._runner_run, timeout=10)
+            except (TimeoutError, asyncio.TimeoutError):
+                self._runner_run.cancel()
+            self._runner_run = None
+
+
+def _build_echo_stages_for_test() -> tuple[None, list[FrameProcessor]]:
+    """A fake voice pipeline for unit tests: no real models or network.
+
+    On each injected user audio frame it emits one tool-call result then a
+    short TTS audio burst bracketed by TTS start/stop, mimicking real Pipecat
+    frame ordering.
+    """
+
+    class _Echo(FrameProcessor):
+        async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+            await super().process_frame(frame, direction)
+            if isinstance(frame, InputAudioRawFrame):
+                await self.push_frame(
+                    FunctionCallResultFrame(
+                        function_name="lookup_order",
+                        tool_call_id="call_1",
+                        arguments={"order_id": "A123"},
+                        result="shipped",
+                    ),
+                    FrameDirection.DOWNSTREAM,
+                )
+                await self.push_frame(TTSStartedFrame(), FrameDirection.DOWNSTREAM)
+                await self.push_frame(
+                    TTSAudioRawFrame(
+                        audio=frame.audio,
+                        sample_rate=frame.sample_rate,
+                        num_channels=frame.num_channels,
+                    ),
+                    FrameDirection.DOWNSTREAM,
+                )
+                await self.push_frame(TTSStoppedFrame(), FrameDirection.DOWNSTREAM)
+            else:
+                await self.push_frame(frame, direction)
+
+    return None, [_Echo()]

--- a/arksim/integrations/pipecat.py
+++ b/arksim/integrations/pipecat.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -49,10 +50,16 @@ _PIPELINE_INPUT_RATE = 16000
 
 
 def _resample(audio: AudioBuffer, target_rate: int) -> AudioBuffer:
-    """Nearest-neighbor resample a mono ``AudioBuffer`` to ``target_rate``."""
-    if audio.sample_rate == target_rate:
+    """Downmix and nearest-neighbor resample audio for Pipecat input."""
+    if target_rate <= 0:
+        raise ValueError("target_rate must be positive")
+    if audio.sample_rate == target_rate and audio.num_channels == 1:
         return audio
     samples = np.asarray(audio.samples, dtype=np.float32)
+    if audio.num_channels > 1:
+        samples = samples.reshape(-1, audio.num_channels).mean(axis=1)
+    if audio.sample_rate == target_rate:
+        return AudioBuffer(samples=samples, sample_rate=target_rate)
     ratio = target_rate / audio.sample_rate
     idx = np.round(np.arange(0, len(samples) * ratio) / ratio).astype(int)
     return AudioBuffer(
@@ -180,12 +187,14 @@ class PipecatVoiceDriver:
         try:
             await asyncio.wait_for(self._capture.turn_done.wait(), _TURN_TIMEOUT_S)
         except (TimeoutError, asyncio.TimeoutError) as exc:
+            await self.close()
             raise TimeoutError(
                 f"Pipecat agent produced no audio within {_TURN_TIMEOUT_S}s "
                 f"for: {user_query!r}"
             ) from exc
         captured = self._capture.captured_audio()
         if captured is None:
+            await self.close()
             raise RuntimeError(f"Pipecat agent produced no audio for: {user_query!r}")
         reply = await self._stt.transcribe(captured)
         return AgentResponse(content=reply, tool_calls=list(self._capture.tool_calls))
@@ -206,6 +215,8 @@ class PipecatVoiceDriver:
                 await asyncio.wait_for(self._runner_run, timeout=10)
             except (TimeoutError, asyncio.TimeoutError):
                 self._runner_run.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._runner_run
             self._runner_run = None
 
 

--- a/arksim/integrations/pipecat.py
+++ b/arksim/integrations/pipecat.py
@@ -6,6 +6,8 @@ import uuid
 from collections.abc import Callable
 from typing import Any
 
+import numpy as np
+
 from arksim.simulation_engine.tool_types import (
     AgentResponse,
     ToolCall,
@@ -24,6 +26,10 @@ try:
         TTSAudioRawFrame,
         TTSStartedFrame,
         TTSStoppedFrame,
+        UserStartedSpeakingFrame,
+        UserStoppedSpeakingFrame,
+        VADUserStartedSpeakingFrame,
+        VADUserStoppedSpeakingFrame,
     )
     from pipecat.pipeline.pipeline import Pipeline
     from pipecat.pipeline.runner import PipelineRunner
@@ -37,6 +43,23 @@ except ImportError as exc:  # pragma: no cover - exercised only without extras
 # Seconds to wait for one agent turn (STT -> LLM -> TTS) to produce audio.
 _TURN_TIMEOUT_S = 120.0
 _DEFAULT_SAMPLE_RATE = 24000
+# Pipecat's default audio_in_sample_rate; segmented STT writes its buffer as a
+# WAV at this rate without resampling, so injected audio must match it.
+_PIPELINE_INPUT_RATE = 16000
+
+
+def _resample(audio: AudioBuffer, target_rate: int) -> AudioBuffer:
+    """Nearest-neighbor resample a mono ``AudioBuffer`` to ``target_rate``."""
+    if audio.sample_rate == target_rate:
+        return audio
+    samples = np.asarray(audio.samples, dtype=np.float32)
+    ratio = target_rate / audio.sample_rate
+    idx = np.round(np.arange(0, len(samples) * ratio) / ratio).astype(int)
+    return AudioBuffer(
+        samples=samples[idx[idx < len(samples)]],
+        sample_rate=target_rate,
+        num_channels=1,
+    )
 
 
 class _CaptureProcessor(FrameProcessor):
@@ -135,13 +158,23 @@ class PipecatVoiceDriver:
         assert self._capture is not None
         self._capture.reset()
         audio = self._perturb(await self._tts.synthesize(user_query))
+        # The agent's segmented STT writes its buffered audio as a WAV at its
+        # own input sample rate (no resampling), so match that rate; and it
+        # segments on VAD speaking frames. Bracket the audio with both VAD and
+        # plain speaking frames so the STT transcribes and the user-context
+        # aggregator advances the turn.
+        audio = _resample(audio, _PIPELINE_INPUT_RATE)
         await self._task.queue_frames(
             [
+                VADUserStartedSpeakingFrame(),
+                UserStartedSpeakingFrame(),
                 InputAudioRawFrame(
                     audio=pcm16_bytes(audio),
-                    sample_rate=audio.sample_rate,
-                    num_channels=audio.num_channels,
-                )
+                    sample_rate=_PIPELINE_INPUT_RATE,
+                    num_channels=1,
+                ),
+                UserStoppedSpeakingFrame(),
+                VADUserStoppedSpeakingFrame(),
             ]
         )
         try:

--- a/arksim/simulation_engine/agent/clients/voice.py
+++ b/arksim/simulation_engine/agent/clients/voice.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import uuid
+from typing import Protocol
+
+from arksim.config import AgentConfig, AgentType, VoiceFramework
+from arksim.simulation_engine.agent.base import BaseAgent
+from arksim.simulation_engine.tool_types import AgentResponse
+from arksim.utils.module_loader import load_callable
+
+
+class VoiceDriver(Protocol):
+    """Framework-specific driver that runs one voice turn."""
+
+    async def run_turn(self, user_query: str) -> AgentResponse: ...
+
+    async def get_chat_id(self) -> str: ...
+
+    async def close(self) -> None: ...
+
+
+def _build_driver_for(agent_config: AgentConfig) -> VoiceDriver:
+    """Resolve the user factory and build the framework driver.
+
+    The framework is checked before constructing speech providers so an
+    unsupported framework fails fast without requiring the voice extras.
+    """
+    vc = agent_config.voice_config
+    if vc.framework == VoiceFramework.PIPECAT:
+        from arksim.integrations.pipecat import PipecatVoiceDriver
+        from arksim.speech import create_stt, create_tts
+
+        factory = load_callable(vc.agent_factory)
+        return PipecatVoiceDriver(
+            factory, tts=create_tts(vc.tts), stt=create_stt(vc.stt)
+        )
+    raise NotImplementedError("LiveKit voice support lands in v2.")
+
+
+class VoiceAgent(BaseAgent):
+    """Native voice agent: drives a framework agent through its ASR/LLM/TTS stack."""
+
+    def __init__(self, agent_config: AgentConfig) -> None:
+        super().__init__(agent_config)
+        if agent_config.agent_type != AgentType.VOICE.value:
+            raise ValueError("Agent config must be of type voice")
+        self._chat_id = str(uuid.uuid4())
+        self._driver: VoiceDriver | None = None
+
+    def _driver_or_build(self) -> VoiceDriver:
+        if self._driver is None:
+            self._driver = _build_driver_for(self.agent_config)
+        return self._driver
+
+    async def get_chat_id(self) -> str:
+        if self._driver is not None:
+            return await self._driver.get_chat_id()
+        return self._chat_id
+
+    async def execute(self, user_query: str, **kwargs: object) -> AgentResponse:
+        return await self._driver_or_build().run_turn(user_query)
+
+    async def close(self) -> None:
+        if self._driver is not None:
+            await self._driver.close()

--- a/arksim/simulation_engine/agent/clients/voice.py
+++ b/arksim/simulation_engine/agent/clients/voice.py
@@ -35,7 +35,7 @@ def _build_driver_for(agent_config: AgentConfig) -> VoiceDriver:
         return PipecatVoiceDriver(
             factory, tts=create_tts(vc.tts), stt=create_stt(vc.stt)
         )
-    raise NotImplementedError("LiveKit voice support lands in v2.")
+    raise ValueError(f"Unsupported voice framework: {vc.framework}")
 
 
 class VoiceAgent(BaseAgent):

--- a/arksim/simulation_engine/agent/clients/voice.py
+++ b/arksim/simulation_engine/agent/clients/voice.py
@@ -27,6 +27,16 @@ def _build_driver_for(agent_config: AgentConfig) -> VoiceDriver:
     unsupported framework fails fast without requiring the voice extras.
     """
     vc = agent_config.voice_config
+    if vc is None:
+        raise ValueError("Voice agent requires voice_config")
+    if vc.framework == VoiceFramework.LIVEKIT:
+        from arksim.integrations.livekit import LiveKitVoiceDriver
+        from arksim.speech import create_stt, create_tts
+
+        factory = load_callable(vc.agent_factory)
+        return LiveKitVoiceDriver(
+            factory, tts=create_tts(vc.tts), stt=create_stt(vc.stt)
+        )
     if vc.framework == VoiceFramework.PIPECAT:
         from arksim.integrations.pipecat import PipecatVoiceDriver
         from arksim.speech import create_stt, create_tts
@@ -62,5 +72,7 @@ class VoiceAgent(BaseAgent):
         return await self._driver_or_build().run_turn(user_query)
 
     async def close(self) -> None:
-        if self._driver is not None:
-            await self._driver.close()
+        driver = self._driver
+        self._driver = None
+        if driver is not None:
+            await driver.close()

--- a/arksim/simulation_engine/agent/factory.py
+++ b/arksim/simulation_engine/agent/factory.py
@@ -7,6 +7,7 @@ from .base import BaseAgent
 from .clients.a2a import A2AAgent
 from .clients.chat_completions import ChatCompletionsAgent
 from .clients.custom import CustomAgent
+from .clients.voice import VoiceAgent
 
 
 def create_agent(agent_config: AgentConfig) -> BaseAgent:
@@ -19,5 +20,7 @@ def create_agent(agent_config: AgentConfig) -> BaseAgent:
         return A2AAgent(agent_config)
     elif agent_type == AgentType.CUSTOM.value:
         return CustomAgent(agent_config)
+    elif agent_type == AgentType.VOICE.value:
+        return VoiceAgent(agent_config)
     else:
         raise ValueError(f"Unsupported agent type: {agent_type}")

--- a/arksim/simulation_engine/entities.py
+++ b/arksim/simulation_engine/entities.py
@@ -111,6 +111,29 @@ class SimulationInput(BaseModel):
                     resolved = os.path.normpath(os.path.join(config_dir, module_path))
                 object.__setattr__(custom_cfg, "module_path", resolved)
 
+            # Resolve the file-path component of a voice agent_factory the same
+            # way. The spec is "<path-or-module>:<attr>"; only a file path
+            # (not a dotted module) is rebased.
+            voice_cfg = (
+                getattr(self.agent_config, "voice_config", None)
+                if self.agent_config
+                else None
+            )
+            factory = getattr(voice_cfg, "agent_factory", None) if voice_cfg else None
+            if factory and ":" in factory:
+                target, _, attr = factory.rpartition(":")
+                is_file = target.endswith(".py") or "/" in target or "\\" in target
+                if is_file and not os.path.isabs(target):
+                    if "agent_factory" in cli_overrides:
+                        resolved_target = os.path.abspath(target)
+                    else:
+                        resolved_target = os.path.normpath(
+                            os.path.join(config_dir, target)
+                        )
+                    object.__setattr__(
+                        voice_cfg, "agent_factory", f"{resolved_target}:{attr}"
+                    )
+
         if not self.agent_config and not self.agent_config_file_path:
             raise ValueError(
                 "Either inline agent_config or agent_config_file_path must be provided."

--- a/arksim/simulation_engine/tool_types.py
+++ b/arksim/simulation_engine/tool_types.py
@@ -32,9 +32,6 @@ class ToolCallSource(str, Enum):
     #: Captured from a Pipecat voice agent's function-call frames.
     PIPECAT = "pipecat"
 
-    #: Captured from a LiveKit voice agent (v2).
-    LIVEKIT = "livekit"
-
 
 class A2AToolCaptureExtension:
     """A2A AgentExtension URI for arksim's tool call capture convention.

--- a/arksim/simulation_engine/tool_types.py
+++ b/arksim/simulation_engine/tool_types.py
@@ -29,6 +29,12 @@ class ToolCallSource(str, Enum):
     #: Captured from an OTLP / OpenInference span (via the trace receiver).
     OTEL_TRACE = "otel_trace"
 
+    #: Captured from a Pipecat voice agent's function-call frames.
+    PIPECAT = "pipecat"
+
+    #: Captured from a LiveKit voice agent (v2).
+    LIVEKIT = "livekit"
+
 
 class A2AToolCaptureExtension:
     """A2A AgentExtension URI for arksim's tool call capture convention.

--- a/arksim/simulation_engine/tool_types.py
+++ b/arksim/simulation_engine/tool_types.py
@@ -32,6 +32,9 @@ class ToolCallSource(str, Enum):
     #: Captured from a Pipecat voice agent's function-call frames.
     PIPECAT = "pipecat"
 
+    #: Captured from a LiveKit Agents function-tools-executed event.
+    LIVEKIT = "livekit"
+
 
 class A2AToolCaptureExtension:
     """A2A AgentExtension URI for arksim's tool call capture convention.

--- a/arksim/speech/__init__.py
+++ b/arksim/speech/__init__.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+# Import built-in providers for their registration side effects.
+from arksim.speech import providers as _providers  # noqa: E402, F401
 from arksim.speech.base import STTProvider, TTSProvider
 from arksim.speech.registry import (
     create_stt,

--- a/arksim/speech/__init__.py
+++ b/arksim/speech/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pluggable text-to-speech and speech-to-text providers for the voice loop."""
+
+from __future__ import annotations
+
+from arksim.speech.base import STTProvider, TTSProvider
+from arksim.speech.registry import (
+    create_stt,
+    create_tts,
+    register_stt,
+    register_tts,
+)
+from arksim.speech.types import AudioBuffer
+
+__all__ = [
+    "AudioBuffer",
+    "TTSProvider",
+    "STTProvider",
+    "create_tts",
+    "create_stt",
+    "register_tts",
+    "register_stt",
+]

--- a/arksim/speech/base.py
+++ b/arksim/speech/base.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from arksim.config import SpeechProviderConfig
+from arksim.speech.types import AudioBuffer
+
+
+class TTSProvider(ABC):
+    """Synthesizes the simulated user's utterance into audio."""
+
+    def __init__(self, cfg: SpeechProviderConfig) -> None:
+        self.cfg = cfg
+
+    @abstractmethod
+    async def synthesize(self, text: str) -> AudioBuffer: ...
+
+
+class STTProvider(ABC):
+    """Transcribes the agent's audio reply back to text."""
+
+    def __init__(self, cfg: SpeechProviderConfig) -> None:
+        self.cfg = cfg
+
+    @abstractmethod
+    async def transcribe(self, audio: AudioBuffer) -> str: ...

--- a/arksim/speech/providers/__init__.py
+++ b/arksim/speech/providers/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Built-in speech providers, imported for registration side effects.
+
+Guarded so importing ``arksim.speech`` never fails when the optional voice
+extra (``pip install 'arksim[voice]'``) is not installed.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+with contextlib.suppress(ImportError):
+    from arksim.speech.providers import faster_whisper, kokoro  # noqa: F401

--- a/arksim/speech/providers/faster_whisper.py
+++ b/arksim/speech/providers/faster_whisper.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import numpy as np
+
+from arksim.config import SpeechProviderConfig
+from arksim.speech.base import STTProvider
+from arksim.speech.registry import register_stt
+from arksim.speech.types import AudioBuffer
+
+_WHISPER_SAMPLE_RATE = 16000
+
+
+@register_stt("faster_whisper")
+class FasterWhisperSTT(STTProvider):
+    """Local faster-whisper STT. Requires ``arksim[voice]``."""
+
+    def __init__(self, cfg: SpeechProviderConfig) -> None:
+        super().__init__(cfg)
+        try:
+            from faster_whisper import WhisperModel
+        except ImportError as exc:
+            raise ImportError(
+                "faster-whisper STT requires: pip install 'arksim[voice]'"
+            ) from exc
+        self._model = WhisperModel(
+            cfg.model or "base.en",
+            device=cfg.options.get("device", "cpu"),
+            compute_type=cfg.options.get("compute_type", "int8"),
+        )
+
+    async def transcribe(self, audio: AudioBuffer) -> str:
+        samples = _to_whisper_mono16k(audio)
+        segments, _ = self._model.transcribe(samples, language="en")
+        return "".join(segment.text for segment in segments).strip()
+
+
+def _to_whisper_mono16k(audio: AudioBuffer) -> np.ndarray:
+    """Downmix to mono and resample to 16 kHz float32 for Whisper."""
+    samples = np.asarray(audio.samples, dtype=np.float32)
+    if audio.num_channels > 1:
+        samples = samples.reshape(-1, audio.num_channels).mean(axis=1)
+    if audio.sample_rate != _WHISPER_SAMPLE_RATE:
+        ratio = _WHISPER_SAMPLE_RATE / audio.sample_rate
+        idx = np.round(np.arange(0, len(samples) * ratio) / ratio).astype(int)
+        idx = idx[idx < len(samples)]
+        samples = samples[idx]
+    return samples

--- a/arksim/speech/providers/kokoro.py
+++ b/arksim/speech/providers/kokoro.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import numpy as np
+
+from arksim.config import SpeechProviderConfig
+from arksim.speech.base import TTSProvider
+from arksim.speech.registry import register_tts
+from arksim.speech.types import AudioBuffer
+
+_KOKORO_SAMPLE_RATE = 24000
+
+
+@register_tts("kokoro")
+class KokoroTTS(TTSProvider):
+    """Local Kokoro TTS (Apache-2.0). Requires ``arksim[voice]``."""
+
+    def __init__(self, cfg: SpeechProviderConfig) -> None:
+        super().__init__(cfg)
+        try:
+            from kokoro import KPipeline
+        except ImportError as exc:
+            raise ImportError(
+                "Kokoro TTS requires: pip install 'arksim[voice]'"
+            ) from exc
+        self._voice = cfg.options.get("voice", "af_heart")
+        self._pipeline = KPipeline(lang_code=cfg.options.get("lang_code", "a"))
+
+    async def synthesize(self, text: str) -> AudioBuffer:
+        # KPipeline yields (graphemes, phonemes, audio) chunks; audio is a
+        # torch.float32 tensor at 24 kHz.
+        chunks = [chunk[-1] for chunk in self._pipeline(text, voice=self._voice)]
+        if not chunks:
+            raise RuntimeError(f"Kokoro produced no audio for text: {text!r}")
+        samples = np.concatenate(
+            [np.asarray(chunk, dtype=np.float32) for chunk in chunks]
+        )
+        return AudioBuffer(samples=samples, sample_rate=_KOKORO_SAMPLE_RATE)

--- a/arksim/speech/registry.py
+++ b/arksim/speech/registry.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from arksim.config import SpeechProviderConfig
+from arksim.speech.base import STTProvider, TTSProvider
+
+_TTS: dict[str, type[TTSProvider]] = {}
+_STT: dict[str, type[STTProvider]] = {}
+
+T = TypeVar("T", bound=TTSProvider)
+S = TypeVar("S", bound=STTProvider)
+
+
+def register_tts(name: str) -> Callable[[type[T]], type[T]]:
+    """Register a TTS provider class under ``name``."""
+
+    def deco(cls: type[T]) -> type[T]:
+        _TTS[name] = cls
+        return cls
+
+    return deco
+
+
+def register_stt(name: str) -> Callable[[type[S]], type[S]]:
+    """Register an STT provider class under ``name``."""
+
+    def deco(cls: type[S]) -> type[S]:
+        _STT[name] = cls
+        return cls
+
+    return deco
+
+
+def create_tts(cfg: SpeechProviderConfig) -> TTSProvider:
+    """Instantiate the registered TTS provider named ``cfg.provider``."""
+    if cfg.provider not in _TTS:
+        raise ValueError(
+            f"Unknown TTS provider '{cfg.provider}'. Registered: {sorted(_TTS)}"
+        )
+    return _TTS[cfg.provider](cfg)
+
+
+def create_stt(cfg: SpeechProviderConfig) -> STTProvider:
+    """Instantiate the registered STT provider named ``cfg.provider``."""
+    if cfg.provider not in _STT:
+        raise ValueError(
+            f"Unknown STT provider '{cfg.provider}'. Registered: {sorted(_STT)}"
+        )
+    return _STT[cfg.provider](cfg)

--- a/arksim/speech/types.py
+++ b/arksim/speech/types.py
@@ -17,6 +17,19 @@ class AudioBuffer:
     sample_rate: int
     num_channels: int = 1
 
+    def __post_init__(self) -> None:
+        """Normalize samples and reject malformed PCM metadata early."""
+        samples = np.asarray(self.samples, dtype=np.float32)
+        if samples.ndim != 1:
+            raise ValueError("Audio samples must be a one-dimensional array")
+        if self.sample_rate <= 0:
+            raise ValueError("Audio sample_rate must be positive")
+        if self.num_channels <= 0:
+            raise ValueError("Audio num_channels must be positive")
+        if len(samples) % self.num_channels:
+            raise ValueError("Audio sample count must be divisible by num_channels")
+        self.samples = samples
+
 
 def pcm16_bytes(audio: AudioBuffer) -> bytes:
     """Encode a float32 ``AudioBuffer`` as little-endian signed 16-bit PCM."""

--- a/arksim/speech/types.py
+++ b/arksim/speech/types.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class AudioBuffer:
+    """PCM audio interchange type for the voice loop.
+
+    ``samples`` is mono float32 in [-1, 1] unless ``num_channels`` > 1.
+    """
+
+    samples: np.ndarray
+    sample_rate: int
+    num_channels: int = 1

--- a/arksim/speech/types.py
+++ b/arksim/speech/types.py
@@ -16,3 +16,19 @@ class AudioBuffer:
     samples: np.ndarray
     sample_rate: int
     num_channels: int = 1
+
+
+def pcm16_bytes(audio: AudioBuffer) -> bytes:
+    """Encode a float32 ``AudioBuffer`` as little-endian signed 16-bit PCM."""
+    clipped = np.clip(np.asarray(audio.samples, dtype=np.float32), -1.0, 1.0)
+    return (clipped * 32767.0).astype("<i2").tobytes()
+
+
+def audio_from_pcm16(
+    data: bytes, sample_rate: int, num_channels: int = 1
+) -> AudioBuffer:
+    """Decode little-endian signed 16-bit PCM into a float32 ``AudioBuffer``."""
+    samples = np.frombuffer(data, dtype="<i2").astype(np.float32) / 32768.0
+    return AudioBuffer(
+        samples=samples, sample_rate=sample_rate, num_channels=num_channels
+    )

--- a/arksim/utils/module_loader.py
+++ b/arksim/utils/module_loader.py
@@ -18,7 +18,9 @@ import logging
 import sys
 import types
 import uuid
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -85,3 +87,27 @@ def load_module_from_file(file_path: str) -> types.ModuleType:
 
     _module_cache[cache_key] = module
     return module
+
+
+def load_callable(spec: str) -> Callable[..., Any]:
+    """Resolve a ``"module_or_path:attribute"`` pointer to a callable.
+
+    The left side is a dotted module path or a ``.py`` file path; the right
+    side is the attribute name to fetch from it. A Windows drive letter
+    (``C:\\...``) also contains a colon, so the split is on the last colon.
+    """
+    if ":" not in spec:
+        raise ValueError(
+            f"Factory pointer must be 'module_or_path:attribute', got: {spec!r}"
+        )
+    target, _, attr = spec.rpartition(":")
+    if target.endswith(".py") or "/" in target or "\\" in target:
+        module = load_module_from_file(target)
+    else:
+        module = importlib.import_module(target)
+    if not hasattr(module, attr):
+        raise AttributeError(f"Module '{target}' has no attribute '{attr}'")
+    fn = getattr(module, attr)
+    if not callable(fn):
+        raise TypeError(f"'{spec}' is not callable")
+    return fn

--- a/docs/main/integrations.mdx
+++ b/docs/main/integrations.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Integrations"
-description: "Use ArkSim with any agent framework. Browse working examples for 14 popular frameworks."
+description: "Use ArkSim with any agent framework. Browse working examples for 16 popular frameworks."
 ---
 
-ArkSim connects to your agent through one of three [connection types](./simulate-conversation#connection-types). The examples below show how to wire up each framework.
+ArkSim connects to your agent through one of four [connection types](./simulate-conversation#connection-types). The examples below show how to wire up each framework.
 
 ## Custom connector
 
@@ -42,6 +42,21 @@ These Python examples load your agent directly as a `BaseAgent` subclass. No HTT
   </Card>
   <Card icon="robot" href="https://github.com/arklexai/arksim/tree/main/examples/integrations/smolagents/" title="SmolAgents">
     Hugging Face's lightweight agent library.
+  </Card>
+</CardGroup>
+
+## Voice connector
+
+These examples exercise the agent's native STT, LLM, and TTS pipeline. ArkSim
+synthesizes the simulated user as audio and transcribes the agent's spoken
+reply for evaluation; no microphone, speaker, or hosted media room is required.
+
+<CardGroup cols={2}>
+  <Card icon="microphone" href="https://github.com/arklexai/arksim/tree/main/examples/integrations/pipecat-voice/" title="Pipecat Voice">
+    Evaluate a Pipecat pipeline through its real speech services.
+  </Card>
+  <Card icon="microphone" href="https://github.com/arklexai/arksim/tree/main/examples/integrations/livekit-voice/" title="LiveKit Voice">
+    Evaluate a LiveKit AgentSession through custom in-memory audio I/O.
   </Card>
 </CardGroup>
 

--- a/docs/main/schema-reference.mdx
+++ b/docs/main/schema-reference.mdx
@@ -226,7 +226,43 @@ The same YAML file can be used for `arksim simulate`, `arksim evaluate`, and `ar
 
 | Key              | Type   | Description                                                                                                    |
 | ---------------- | ------ | -------------------------------------------------------------------------------------------------------------- |
-| `agent_config`   | object | Inline agent configuration. See [Agent configuration](./simulate-conversation#agent-configuration) for `chat_completions` and `a2a`. |
+| `agent_config`   | object | Inline agent configuration. See [Agent configuration](./simulate-conversation#agent-configuration) for all connection types. |
+
+Voice agents use `agent_type: voice` and select either `pipecat` or `livekit`.
+The factory pointer is resolved relative to the config file. Pipecat factories
+return the framework's context and pipeline stages. LiveKit factories return
+`(AgentSession, Agent)` and must configure manual turn detection.
+
+| `voice_config` field | Type | Required | Description |
+| -------------------- | ---- | -------- | ----------- |
+| `framework` | string | Yes | `pipecat` or `livekit`. |
+| `agent_factory` | string | Yes | Zero-argument callable in `./file.py:callable` or `package.module:callable` form. |
+| `tts` | object | No | ArkSim-side provider that voices the simulated user. Defaults to `{provider: kokoro}`. |
+| `stt` | object | No | ArkSim-side provider that transcribes the agent reply. Defaults to `{provider: faster_whisper}`. |
+
+Both speech-provider objects accept `provider`, optional `model`, and an
+`options` mapping for provider-specific settings such as voice, language,
+device, and compute type.
+
+```yaml
+agent_config:
+  agent_type: voice
+  agent_name: support-voice
+  voice_config:
+    framework: livekit # or pipecat
+    agent_factory: ./agent.py:build
+    tts:
+      provider: kokoro
+    stt:
+      provider: faster_whisper
+      model: base.en
+```
+
+Use `arksim[voice]` for Pipecat, `arksim[livekit-voice]` for LiveKit Agents,
+or `arksim[voice-all]` for both. The framework-specific examples show the
+required factory contracts. `arksim[voice]` and `arksim[voice-all]` currently
+target Python 3.11–3.12; `arksim[livekit-voice]` targets Python 3.10–3.12.
+ArkSim core continues to support the full Python range declared by the package.
 
 ### Simulation keys
 

--- a/docs/main/simulate-conversation.mdx
+++ b/docs/main/simulate-conversation.mdx
@@ -129,19 +129,21 @@ Provide agent connection by defining `agent_config` inline in your config YAML.
 | Field        | Type   | Required | Description                                                                            |
 | ------------ | ------ | -------- | -------------------------------------------------------------------------------------- |
 | `agent_name` | string | Yes      | Unique identifier for your agent (e.g. lowercase, no spaces).                          |
-| `agent_type` | string | Yes      | One of `chat_completions`, `a2a`, or `custom`. See [Connection types](#connection-types). |
+| `agent_type` | string | Yes      | One of `chat_completions`, `a2a`, `custom`, or `voice`. See [Connection types](#connection-types). |
 | `api_config` | object | Conditional | Required for `chat_completions` and `a2a`. See [Connection types](#connection-types). |
 | `custom_config` | object | Conditional | Required for `custom`. See [Connection types](#connection-types). |
+| `voice_config` | object | Conditional | Required for `voice`. Selects Pipecat or LiveKit and the speech providers. |
 
 ### Connection types
 
-ArkSim supports three ways to connect your agent:
+ArkSim supports four ways to connect your agent:
 
 | Type                                                                                | When to use                                                                            |
 | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | [**Chat Completions**](https://developers.openai.com/api/reference/resources/chat/) | Any agent that accepts OpenAI-compatible requests (OpenAI or a custom wrapper) |
 | [**A2A**](https://a2a-protocol.org/latest/)                                         | Agents exposed via the Agent-to-Agent protocol                                         |
 | **Custom**                                                                          | Any Python agent loaded directly as a class — no HTTP server required                  |
+| **Voice**                                                                           | Pipecat or LiveKit Agents evaluated through their native STT → LLM → TTS pipeline      |
 
 <Tabs>
   <Tab title="Chat Completions">
@@ -237,11 +239,47 @@ ArkSim supports three ways to connect your agent:
     )
     ```
   </Tab>
+  <Tab title="Voice">
+    **Type:** `voice`
+
+    Drives a Pipecat or LiveKit agent through audio while keeping the existing
+    simulation and evaluation workflow. ArkSim voices each simulated-user turn,
+    captures the agent's spoken response, and transcribes it for evaluation.
+
+    **Required fields:** `framework` (`pipecat` or `livekit`) and
+    `agent_factory` (a zero-argument Python callable). **Optional:** `tts` and
+    `stt` provider configuration; they default to local Kokoro and
+    faster-whisper.
+
+    ```yaml
+    agent_config:
+      agent_type: voice
+      agent_name: support-voice
+      voice_config:
+        framework: livekit # or pipecat
+        agent_factory: ./agent.py:build
+        tts:
+          provider: kokoro
+        stt:
+          provider: faster_whisper
+          model: base.en
+    ```
+
+    Pipecat factories return `(LLMContext, [pipeline stages])`. LiveKit
+    factories return `(AgentSession, Agent)` with manual turn detection. Install
+    `arksim[voice]`, `arksim[livekit-voice]`, or `arksim[voice-all]`; see the
+    [Pipecat](https://github.com/arklexai/arksim/tree/main/examples/integrations/pipecat-voice)
+    and [LiveKit](https://github.com/arklexai/arksim/tree/main/examples/integrations/livekit-voice)
+    examples for complete factories.
+  </Tab>
 </Tabs>
 
 ### Environment variable support
 
-Both types support `${ENV_VAR}` substitution in header values (and in the endpoint URL for chat completions where applicable). At runtime the value is replaced; if unset, it becomes an empty string. You can mix static text and variables (e.g. `"Bearer ${API_KEY}"`).
+The API-based connection types support `${ENV_VAR}` substitution in header
+values (and in the endpoint URL for Chat Completions where applicable). At
+runtime the value is replaced; if unset, it becomes an empty string. You can
+mix static text and variables (for example, `"Bearer ${API_KEY}"`).
 
 <Tip>
   **Security:** Keep credentials in environment variables and out of committed config files.

--- a/examples/integrations/langfuse/README.md
+++ b/examples/integrations/langfuse/README.md
@@ -75,7 +75,11 @@ Or wire it yourself by passing arksim objects straight through:
 ```python
 import asyncio
 from arksim import (
-    Scenarios, SimulationInput, EvaluationInput, run_simulation, run_evaluation,
+    Scenarios,
+    SimulationInput,
+    EvaluationInput,
+    run_simulation,
+    run_evaluation,
 )
 from arksim.integrations.langfuse import export_to_langfuse
 
@@ -84,7 +88,9 @@ simulation = asyncio.run(run_simulation(sim_settings, scenarios=scenarios))
 evaluation = run_evaluation(eval_settings, simulation=simulation, scenarios=scenarios)
 
 export_to_langfuse(
-    scenarios, simulation, evaluation,
+    scenarios,
+    simulation,
+    evaluation,
     dataset_name="my-agent-regression",
     run_name="v1.2.3",
 )
@@ -96,10 +102,14 @@ export_to_langfuse(
 from arksim.integrations.langfuse import LangfuseExporter
 
 exporter = LangfuseExporter(
-    public_key="pk-lf-...", secret_key="sk-lf-...", host="http://localhost:3000",
+    public_key="pk-lf-...",
+    secret_key="sk-lf-...",
+    host="http://localhost:3000",
 )
 result = exporter.export(
-    scenarios, simulation, evaluation,
+    scenarios,
+    simulation,
+    evaluation,
     dataset_name="my-agent-regression",
     run_name="nightly",
 )

--- a/examples/integrations/livekit-voice/README.md
+++ b/examples/integrations/livekit-voice/README.md
@@ -1,0 +1,56 @@
+# LiveKit voice agent
+
+Evaluate a [LiveKit Agents](https://docs.livekit.io/agents/) voice agent with
+arksim's native `voice` agent type.
+
+## How it works
+
+arksim drives the agent through its real speech stack:
+
+```text
+simulated user TEXT -> [arksim TTS] -> AUDIO -> LiveKit STT -> LLM -> TTS
+  -> AUDIO -> [arksim STT] -> TEXT -> evaluator
+```
+
+- `agent.py:build()` returns the agent's own `(AgentSession, Agent)`, including
+  its real STT, LLM, TTS, and tools.
+- arksim installs in-memory audio input/output on the session. No microphone,
+  speaker, or LiveKit room is needed for an evaluation run.
+- Tool calls are captured from LiveKit's `function_tools_executed` event and
+  stored with source `livekit`.
+- The `AgentSession` must use manual turn detection. arksim commits each audio
+  turn after the simulated user's synthesized speech has been injected.
+
+This exercises the LiveKit Agents speech and orchestration pipeline. It does
+not test WebRTC room transport, packet loss, or client-side audio processing.
+
+## Setup
+
+```bash
+pip install 'arksim[livekit-voice]' 'livekit-agents[openai]>=1.5.9,<2.0'
+export OPENAI_API_KEY=...
+```
+
+`arksim[livekit-voice]` installs LiveKit Agents plus the arksim-side Kokoro TTS
+and faster-whisper STT.
+The LiveKit OpenAI plugin supplies the agent's own STT, LLM, and TTS services.
+This example currently targets Python 3.10–3.12 because Kokoro requires Python
+<3.13. Use a custom ArkSim-side speech provider if your environment differs.
+
+## Run
+
+From this directory:
+
+```bash
+arksim simulate-evaluate ./config.yaml
+```
+
+The evaluation path uses LiveKit's `AgentSession` orchestration with in-memory
+audio I/O. `LIVEKIT_URL`, `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET` are not
+needed unless you separately run the agent through a hosted LiveKit room.
+
+## Files
+
+- `agent.py` - LiveKit `AgentSession` and `Agent` behind `build()`.
+- `config.yaml` - voice framework, factory pointer, and arksim speech providers.
+- `scenarios.json` - phone-support scenarios.

--- a/examples/integrations/livekit-voice/agent.py
+++ b/examples/integrations/livekit-voice/agent.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A LiveKit Agents voice agent for arksim evaluation.
+
+Requires:
+    pip install 'arksim[livekit-voice]' 'livekit-agents[openai]>=1.5.9,<2.0'
+    export OPENAI_API_KEY=...
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def build() -> tuple[Any, Any]:
+    """Return the agent's own ``(AgentSession, Agent)``."""
+    from livekit.agents import Agent, AgentSession, TurnHandlingOptions
+    from livekit.plugins import openai
+
+    session = AgentSession(
+        stt=openai.STT(model="gpt-4o-mini-transcribe"),
+        llm=openai.LLM(model=os.environ.get("OPENAI_MODEL", "gpt-4o-mini")),
+        tts=openai.TTS(model="gpt-4o-mini-tts", voice="ash"),
+        vad=None,
+        turn_handling=TurnHandlingOptions(turn_detection="manual"),
+    )
+    agent = Agent(
+        instructions=(
+            "You are a friendly phone support agent for an online store. "
+            "Keep replies short and conversational."
+        )
+    )
+    return session, agent

--- a/examples/integrations/livekit-voice/config.yaml
+++ b/examples/integrations/livekit-voice/config.yaml
@@ -1,0 +1,26 @@
+# Simulate + Evaluate Configuration File
+
+agent_config:
+  agent_type: voice
+  agent_name: livekit-voice
+  voice_config:
+    framework: livekit
+    # Pointer to the zero-arg factory returning (AgentSession, Agent).
+    agent_factory: ./agent.py:build
+    # arksim voices the simulated user with this TTS.
+    tts:
+      provider: kokoro
+    # arksim transcribes the agent's spoken reply with this STT.
+    stt:
+      provider: faster_whisper
+      model: base.en
+
+scenario_file_path: ./scenarios.json
+num_conversations_per_scenario: 1
+max_turns: 5
+output_file_path: ./results/simulation/simulation.json
+simulated_user_prompt_template: null
+
+model: gpt-5.1
+provider: openai
+num_workers: 1

--- a/examples/integrations/livekit-voice/scenarios.json
+++ b/examples/integrations/livekit-voice/scenarios.json
@@ -1,0 +1,19 @@
+{
+    "schema_version": "v1",
+    "scenarios": [
+        {
+            "scenario_id": "order_status_inquiry",
+            "user_id": "user_0001",
+            "goal": "You placed an order last week and it has not arrived. Call support, explain the situation, and find out when it will be delivered.",
+            "agent_context": "You are a friendly phone support agent for an online store. Keep replies short and conversational.",
+            "user_profile": "You are Maria, a small business owner who is polite but in a hurry. You want a clear delivery date."
+        },
+        {
+            "scenario_id": "return_request",
+            "user_id": "user_0002",
+            "goal": "You received the wrong item and want to start a return. Ask how to send it back and get the correct item.",
+            "agent_context": "You are a friendly phone support agent for an online store. Keep replies short and conversational.",
+            "user_profile": "You are Devin, a first-time customer who is mildly frustrated but reasonable."
+        }
+    ]
+}

--- a/examples/integrations/pipecat-voice/README.md
+++ b/examples/integrations/pipecat-voice/README.md
@@ -32,9 +32,12 @@ export OPENAI_API_KEY=...
 ```
 
 `arksim[voice]` installs the arksim-side TTS/STT (Kokoro + faster-whisper). The
-pipecat extras install the agent's own STT/LLM/TTS services used in `agent.py`;
+Pipecat extras install the agent's own STT/LLM/TTS services used in `agent.py`;
 the Whisper backend is platform-specific (MLX on Apple Silicon). If you just
-want to see the loop run without keys or a backend, use `smoke_local.py` above.
+want to see the loop run without keys or a backend, use `smoke_local.py` below.
+
+This example currently targets Python 3.11–3.12 (Pipecat requires 3.11+, while
+Kokoro currently requires Python <3.13).
 
 ## Run
 

--- a/examples/integrations/pipecat-voice/README.md
+++ b/examples/integrations/pipecat-voice/README.md
@@ -38,6 +38,16 @@ pipecat extras install the agent's own STT/LLM/TTS services used in `agent.py`.
 arksim simulate-evaluate --config ./config.yaml
 ```
 
+## Try it without an API key
+
+`smoke_local.py` runs the full audio loop with real local ASR + TTS and a
+deterministic brain (no LLM key, no `OPENAI_API_KEY`):
+
+```bash
+pip install 'arksim[voice]'
+python smoke_local.py
+```
+
 ## Files
 
 - `agent.py` - your Pipecat voice pipeline behind a zero-arg `build()`.

--- a/examples/integrations/pipecat-voice/README.md
+++ b/examples/integrations/pipecat-voice/README.md
@@ -35,7 +35,7 @@ pipecat extras install the agent's own STT/LLM/TTS services used in `agent.py`.
 ## Run
 
 ```bash
-arksim simulate-evaluate --config ./config.yaml
+arksim simulate-evaluate ./config.yaml
 ```
 
 ## Try it without an API key

--- a/examples/integrations/pipecat-voice/README.md
+++ b/examples/integrations/pipecat-voice/README.md
@@ -1,0 +1,46 @@
+# Pipecat voice agent
+
+Evaluate a [Pipecat](https://github.com/pipecat-ai/pipecat) voice agent with
+arksim's native `voice` agent type.
+
+## How it works
+
+arksim drives your agent through its **real speech stack**:
+
+```
+simulated user TEXT -> [arksim TTS] -> AUDIO -> your agent (ASR -> LLM -> TTS) -> AUDIO -> [arksim STT] -> TEXT -> evaluator
+```
+
+- `agent.py:build()` returns your agent's own `(LLMContext, [stages])`, including
+  its real STT, LLM, and TTS services. Your agent code does not import arksim.
+- arksim synthesizes each simulated-user turn to audio (`voice_config.tts`,
+  default local Kokoro), injects it, captures the agent's spoken reply, and
+  transcribes it back to text (`voice_config.stt`, default local faster-whisper)
+  for the existing evaluator.
+- Tool calls your agent makes are captured automatically (source `pipecat`).
+
+Only the agent's own speech stack is under test. Accent, background-noise, and
+volume perturbation are a planned follow-on; this example uses a clean voice.
+
+## Setup
+
+```bash
+pip install 'arksim[voice]' 'pipecat-ai[openai,whisper,silero]'
+export OPENAI_API_KEY=...
+```
+
+`arksim[voice]` installs the arksim-side TTS/STT (Kokoro + faster-whisper). The
+pipecat extras install the agent's own STT/LLM/TTS services used in `agent.py`.
+
+## Run
+
+```bash
+arksim simulate-evaluate --config ./config.yaml
+```
+
+## Files
+
+- `agent.py` - your Pipecat voice pipeline behind a zero-arg `build()`.
+- `config.yaml` - `agent_type: voice`, framework, factory pointer, and the
+  arksim-side `tts`/`stt` providers.
+- `scenarios.json` - phone-support scenarios.

--- a/examples/integrations/pipecat-voice/README.md
+++ b/examples/integrations/pipecat-voice/README.md
@@ -25,12 +25,16 @@ volume perturbation are a planned follow-on; this example uses a clean voice.
 ## Setup
 
 ```bash
-pip install 'arksim[voice]' 'pipecat-ai[openai,whisper,silero]'
+# Apple Silicon (Whisper uses the MLX backend):
+pip install 'arksim[voice]' 'pipecat-ai[openai,mlx-whisper,silero]'
+# Linux / CUDA / CPU: use 'pipecat-ai[openai,whisper,silero]' instead.
 export OPENAI_API_KEY=...
 ```
 
 `arksim[voice]` installs the arksim-side TTS/STT (Kokoro + faster-whisper). The
-pipecat extras install the agent's own STT/LLM/TTS services used in `agent.py`.
+pipecat extras install the agent's own STT/LLM/TTS services used in `agent.py`;
+the Whisper backend is platform-specific (MLX on Apple Silicon). If you just
+want to see the loop run without keys or a backend, use `smoke_local.py` above.
 
 ## Run
 

--- a/examples/integrations/pipecat-voice/agent.py
+++ b/examples/integrations/pipecat-voice/agent.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A Pipecat voice agent for arksim evaluation.
+
+``build()`` returns the agent's own ``(LLMContext, [stages])`` including its
+real STT, LLM, and TTS services. arksim voices the simulated user with its own
+TTS, injects that audio into this pipeline, captures the agent's spoken reply,
+and transcribes it with its own STT. Only the agent's *own* speech stack is
+exercised; tool calls the agent makes are captured automatically.
+
+Requires:
+    pip install 'arksim[voice]' 'pipecat-ai[openai,whisper,silero]'
+    export OPENAI_API_KEY=...
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build() -> tuple[Any, list[Any]]:
+    from pipecat.processors.aggregators.llm_context import LLMContext
+    from pipecat.processors.aggregators.llm_response_universal import (
+        LLMContextAggregatorPair,
+    )
+    from pipecat.services.openai.llm import OpenAILLMService
+    from pipecat.services.openai.tts import OpenAITTSService
+    from pipecat.services.whisper.stt import WhisperSTTService
+
+    context = LLMContext(
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You are a friendly phone support agent for an online "
+                    "store. Keep replies short and conversational."
+                ),
+            }
+        ]
+    )
+    aggregators = LLMContextAggregatorPair(context)
+    stt = WhisperSTTService(model="base.en")
+    llm = OpenAILLMService(model="gpt-4o-mini")
+    tts = OpenAITTSService(voice="alloy")
+
+    return context, [
+        stt,
+        aggregators.user(),
+        llm,
+        tts,
+        aggregators.assistant(),
+    ]

--- a/examples/integrations/pipecat-voice/config.yaml
+++ b/examples/integrations/pipecat-voice/config.yaml
@@ -1,0 +1,33 @@
+# Simulate + Evaluate Configuration File
+# Configuration for 'arksim simulate-evaluate' command
+
+# ── AGENT CONFIGURATION ────────────────────────────────────────────────────
+
+agent_config:
+  agent_type: voice
+  agent_name: pipecat-voice
+  voice_config:
+    framework: pipecat
+    # Pointer to the zero-arg factory returning (LLMContext, [stages]).
+    agent_factory: ./agent.py:build
+    # arksim voices the simulated user with this TTS (defaults shown).
+    tts:
+      provider: kokoro
+    # arksim transcribes the agent's spoken reply with this STT.
+    stt:
+      provider: faster_whisper
+      model: base.en
+
+# ── SIMULATION SETTINGS ──────────────────────────────────────────────────────
+
+scenario_file_path: ./scenarios.json
+num_conversations_per_scenario: 1
+max_turns: 5
+output_file_path: ./results/simulation/simulation.json
+simulated_user_prompt_template: null
+
+# ── SHARED SETTINGS ──────────────────────────────────────────────────────────
+
+model: gpt-5.1
+provider: openai
+num_workers: 4

--- a/examples/integrations/pipecat-voice/scenarios.json
+++ b/examples/integrations/pipecat-voice/scenarios.json
@@ -1,0 +1,19 @@
+{
+    "schema_version": "v1",
+    "scenarios": [
+        {
+            "scenario_id": "order_status_inquiry",
+            "user_id": "user_0001",
+            "goal": "You placed an order last week and it has not arrived. Call the support line, explain the situation, give your order number when asked, and find out when it will be delivered.",
+            "agent_context": "You are a friendly phone support agent for an online store. Keep replies short and conversational.",
+            "user_profile": "You are Maria, a 42-year-old small business owner who is polite but in a hurry. You speak in short sentences and want a clear delivery date without a long back-and-forth."
+        },
+        {
+            "scenario_id": "return_request",
+            "user_id": "user_0002",
+            "goal": "You received the wrong item and want to start a return. Explain what you ordered versus what arrived, and ask how to send it back and get the correct item.",
+            "agent_context": "You are a friendly phone support agent for an online store. Keep replies short and conversational.",
+            "user_profile": "You are Devin, a 29-year-old first-time customer who is mildly frustrated but reasonable. You appreciate a calm, step-by-step explanation."
+        }
+    ]
+}

--- a/examples/integrations/pipecat-voice/smoke_local.py
+++ b/examples/integrations/pipecat-voice/smoke_local.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Key-free, fully-local smoke test of the native ``voice`` agent type.
+
+Runs the real arksim voice loop end to end with no API keys: a genuine Pipecat
+pipeline using real faster-whisper ASR + real Kokoro TTS, with a deterministic
+"brain" standing in for an LLM. Proves the audio path:
+
+    text -> arksim Kokoro TTS -> AUDIO -> agent ASR -> brain -> agent Kokoro TTS
+         -> AUDIO -> arksim faster-whisper STT -> text
+
+Usage:
+    pip install 'arksim[voice]'
+    python examples/integrations/pipecat-voice/smoke_local.py
+
+The first run downloads the small Whisper and Kokoro models. For a real LLM-
+backed agent, see ``agent.py`` / ``config.yaml`` in this directory instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+from pipecat.frames.frames import (
+    Frame,
+    InputAudioRawFrame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    TextFrame,
+    TranscriptionFrame,
+    TTSAudioRawFrame,
+    TTSStartedFrame,
+    TTSStoppedFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+_WHISPER_RATE = 16000
+_KOKORO_RATE = 24000
+
+
+def _to_16k_float(audio_bytes: bytes, sample_rate: int) -> np.ndarray:
+    samples = np.frombuffer(audio_bytes, dtype="<i2").astype(np.float32) / 32768.0
+    if sample_rate != _WHISPER_RATE:
+        ratio = _WHISPER_RATE / sample_rate
+        idx = np.round(np.arange(0, len(samples) * ratio) / ratio).astype(int)
+        samples = samples[idx[idx < len(samples)]]
+    return samples
+
+
+class RealWhisperSTT(FrameProcessor):
+    """The agent's own ASR: transcribes injected user audio with faster-whisper."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        from faster_whisper import WhisperModel
+
+        self._model = WhisperModel("tiny.en", device="cpu", compute_type="int8")
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, InputAudioRawFrame):
+            segments, _ = self._model.transcribe(
+                _to_16k_float(frame.audio, frame.sample_rate), language="en"
+            )
+            text = "".join(segment.text for segment in segments).strip()
+            await self.push_frame(
+                TranscriptionFrame(text, "sim-user", ""), FrameDirection.DOWNSTREAM
+            )
+        else:
+            await self.push_frame(frame, direction)
+
+
+class CannedBrain(FrameProcessor):
+    """Stands in for an LLM: echoes the transcript so ASR fidelity is visible."""
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, TranscriptionFrame):
+            reply = f"I heard you say: {frame.text}"
+            await self.push_frame(
+                LLMFullResponseStartFrame(), FrameDirection.DOWNSTREAM
+            )
+            await self.push_frame(TextFrame(reply), FrameDirection.DOWNSTREAM)
+            await self.push_frame(LLMFullResponseEndFrame(), FrameDirection.DOWNSTREAM)
+        else:
+            await self.push_frame(frame, direction)
+
+
+class RealKokoroTTS(FrameProcessor):
+    """The agent's own TTS: speaks the reply with Kokoro."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        from kokoro import KPipeline
+
+        self._pipeline = KPipeline(lang_code="a")
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, TextFrame):
+            chunks = [
+                chunk[-1] for chunk in self._pipeline(frame.text, voice="af_heart")
+            ]
+            samples = np.concatenate(
+                [np.asarray(chunk, dtype=np.float32) for chunk in chunks]
+            )
+            pcm = (np.clip(samples, -1.0, 1.0) * 32767.0).astype("<i2").tobytes()
+            await self.push_frame(TTSStartedFrame(), FrameDirection.DOWNSTREAM)
+            await self.push_frame(
+                TTSAudioRawFrame(audio=pcm, sample_rate=_KOKORO_RATE, num_channels=1),
+                FrameDirection.DOWNSTREAM,
+            )
+            await self.push_frame(TTSStoppedFrame(), FrameDirection.DOWNSTREAM)
+        else:
+            await self.push_frame(frame, direction)
+
+
+def build_demo_agent() -> tuple[None, list[FrameProcessor]]:
+    """Return a real Pipecat voice pipeline with a deterministic brain."""
+    return None, [RealWhisperSTT(), CannedBrain(), RealKokoroTTS()]
+
+
+async def _main() -> None:
+    from arksim.config import AgentConfig
+    from arksim.simulation_engine.agent.factory import create_agent
+
+    config = AgentConfig.model_validate(
+        {
+            "agent_name": "demo-voice",
+            "agent_type": "voice",
+            "voice_config": {
+                "framework": "pipecat",
+                "agent_factory": f"{__file__}:build_demo_agent",
+                "tts": {"provider": "kokoro"},
+                "stt": {"provider": "faster_whisper", "model": "tiny.en"},
+            },
+        }
+    )
+    agent = create_agent(config)
+    try:
+        for utterance in ["Hello, where is my order?", "Thanks, that is helpful."]:
+            response = await agent.execute(utterance)
+            print(f"\nUSER  (text -> speech): {utterance}")
+            print(f"AGENT (speech -> text): {response.content!r}")
+    finally:
+        await agent.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,10 @@ dev = [
     "pre-commit",
     "ruff",
     "numpy",
+    # Exercise optional voice drivers in unit-test coverage without installing
+    # heavyweight speech models. Pipecat itself requires Python 3.11+.
+    "livekit-agents>=1.5.9,<2.0",
+    "pipecat-ai>=1.4,<2.0; python_version >= '3.11'",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,13 @@ langfuse = [
     # (v4). Works against self-hosted instances; no hosted-only connector.
     "langfuse>=4,<5",
 ]
+livekit-agents = [
+    # The custom AgentSession audio I/O and manual turn APIs are v1 surfaces.
+    # Keep a major-version ceiling because LiveKit has announced v2 removals.
+    "livekit-agents>=1.5.9,<2.0",
+]
 pipecat = [
+    # Pipecat requires Python 3.11+.
     # <2.0: the PipelineRunner driver API used by the voice driver is removed
     # in pipecat 2.0; revisit the driver before widening this pin.
     "pipecat-ai>=1.4,<2.0",
@@ -68,10 +74,18 @@ pipecat = [
 speech = [
     "numpy",
     "faster-whisper>=1.2",
+    # Kokoro currently requires Python <3.13.
     "kokoro>=0.9",
 ]
 voice = [
+    # Backward-compatible Pipecat voice bundle.
     "arksim[pipecat,speech]",
+]
+livekit-voice = [
+    "arksim[livekit-agents,speech]",
+]
+voice-all = [
+    "arksim[livekit-voice,voice]",
 ]
 all = [
     "arksim[azure,anthropic,google,otel,claude]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,17 @@ langfuse = [
     # (v4). Works against self-hosted instances; no hosted-only connector.
     "langfuse>=4,<5",
 ]
+pipecat = [
+    "pipecat-ai>=1.4",
+]
+speech = [
+    "numpy",
+    "faster-whisper>=1.2",
+    "kokoro>=0.9",
+]
+voice = [
+    "arksim[pipecat,speech]",
+]
 all = [
     "arksim[azure,anthropic,google,otel,claude]",
 ]
@@ -70,6 +81,7 @@ dev = [
     "pytest-timeout",
     "pre-commit",
     "ruff",
+    "numpy",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,9 @@ langfuse = [
     "langfuse>=4,<5",
 ]
 pipecat = [
-    "pipecat-ai>=1.4",
+    # <2.0: the PipelineRunner driver API used by the voice driver is removed
+    # in pipecat 2.0; revisit the driver before widening this pin.
+    "pipecat-ai>=1.4,<2.0",
 ]
 speech = [
     "numpy",

--- a/tests/unit/test_livekit_voice_driver.py
+++ b/tests/unit/test_livekit_voice_driver.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ({"order_id": "A123"}, {"order_id": "A123"}),
+        ('{"order_id": "A123"}', {"order_id": "A123"}),
+        ("not-json", {"_value": "not-json"}),
+        ("[1, 2]", {"_value": [1, 2]}),
+        (7, {"_value": 7}),
+    ],
+)
+def test_parse_arguments_normalizes_livekit_payloads(
+    raw: object, expected: dict[str, object]
+) -> None:
+    pytest.importorskip("livekit.agents")
+
+    from arksim.integrations.livekit import _parse_arguments
+
+    assert _parse_arguments(raw) == expected
+
+
+async def test_driver_validates_factory_contract_before_starting() -> None:
+    pytest.importorskip("livekit.agents")
+
+    from arksim.integrations.livekit import LiveKitVoiceDriver
+
+    driver = LiveKitVoiceDriver(lambda: "not-a-tuple", tts=object(), stt=object())
+
+    with pytest.raises(TypeError, match=r"return \(AgentSession, Agent\)"):
+        await driver.run_turn("hello")
+
+
+async def test_driver_requires_manual_turn_detection() -> None:
+    pytest.importorskip("livekit.agents")
+    from livekit.agents import Agent, AgentSession
+
+    from arksim.integrations.livekit import LiveKitVoiceDriver
+
+    session = AgentSession(vad=None)
+    agent = Agent(instructions="Be concise.")
+    driver = LiveKitVoiceDriver(lambda: (session, agent), tts=object(), stt=object())
+
+    with pytest.raises(ValueError, match="manual turn detection"):
+        await driver.run_turn("hello")
+
+
+async def test_driver_runs_audio_turn_and_captures_tool_call() -> None:
+    pytest.importorskip("livekit.agents")
+    import numpy as np
+    from livekit.agents import Agent, AgentSession, TurnHandlingOptions
+    from livekit.agents.llm import FunctionCall, FunctionCallOutput
+    from livekit.agents.voice.events import FunctionToolsExecutedEvent
+
+    from arksim.integrations.livekit import LiveKitVoiceDriver
+    from arksim.simulation_engine.tool_types import ToolCallSource
+    from arksim.speech.types import AudioBuffer
+
+    class FakeSession(AgentSession):
+        def __init__(self) -> None:
+            super().__init__(
+                vad=None,
+                turn_handling=TurnHandlingOptions(turn_detection="manual"),
+            )
+            self.closed = False
+            self.frames: list[object] = []
+            self.committed_frames: list[object] = []
+            self.consumer: asyncio.Task[None] | None = None
+
+        async def start(
+            self,
+            agent: Agent,
+            *,
+            record: bool = False,
+        ) -> None:
+            async def consume_audio() -> None:
+                assert self.input.audio is not None
+                async for frame in self.input.audio:
+                    self.frames.append(frame)
+
+            self.consumer = asyncio.create_task(consume_audio())
+
+        async def wait_for_idle(self) -> object:
+            return object()
+
+        def commit_user_turn(
+            self,
+            *,
+            transcript_timeout: float = 2.0,
+            stt_flush_duration: float = 2.0,
+            skip_reply: bool = False,
+        ) -> asyncio.Future[str]:
+            self.committed_frames = list(self.frames)
+            future: asyncio.Future[str] = asyncio.Future()
+
+            async def respond() -> None:
+                assert self.output.audio is not None
+                assert self.frames
+                frame = self.frames[0]
+                self.frames.clear()
+                self.emit(
+                    "function_tools_executed",
+                    FunctionToolsExecutedEvent(
+                        function_calls=[
+                            FunctionCall(
+                                call_id="call-1",
+                                name="lookup_order",
+                                arguments='{"order_id": "A123"}',
+                            )
+                        ],
+                        function_call_outputs=[
+                            FunctionCallOutput(
+                                call_id="call-1",
+                                name="lookup_order",
+                                output="shipped",
+                                is_error=False,
+                            )
+                        ],
+                    ),
+                )
+                await self.output.audio.capture_frame(frame)
+                self.output.audio.flush()
+                future.set_result("hello agent")
+
+            asyncio.create_task(respond())
+            return future
+
+        async def aclose(self) -> None:
+            self.closed = True
+            if self.consumer is not None:
+                await self.consumer
+
+    class FakeTTS:
+        async def synthesize(self, text: str) -> AudioBuffer:
+            return AudioBuffer(np.zeros(960, dtype=np.float32), 24000)
+
+    class FakeSTT:
+        async def transcribe(self, audio: AudioBuffer) -> str:
+            assert audio.sample_rate == 24000
+            assert len(audio.samples) == 480
+            return "agent reply"
+
+    session = FakeSession()
+    agent = Agent(instructions="You are a concise support agent.")
+    driver = LiveKitVoiceDriver(lambda: (session, agent), tts=FakeTTS(), stt=FakeSTT())
+    try:
+        response = await driver.run_turn("where is my order?")
+        assert response.content == "agent reply"
+        assert sum(
+            frame.duration for frame in session.committed_frames
+        ) == pytest.approx(1.04)
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].id == "call-1"
+        assert response.tool_calls[0].arguments == {"order_id": "A123"}
+        assert response.tool_calls[0].result == "shipped"
+        assert response.tool_calls[0].source is ToolCallSource.LIVEKIT
+
+        second = await driver.run_turn("thanks")
+        assert second.content == "agent reply"
+    finally:
+        await driver.close()
+    assert session.closed
+
+
+def test_rtc_frames_preserve_pcm_and_chunk_duration() -> None:
+    pytest.importorskip("livekit.agents")
+    import numpy as np
+
+    from arksim.integrations.livekit import _rtc_frames
+    from arksim.speech.types import AudioBuffer, pcm16_bytes
+
+    audio = AudioBuffer(np.linspace(-0.5, 0.5, 1200, dtype=np.float32), 24000)
+    frames = list(_rtc_frames(audio))
+
+    assert [frame.samples_per_channel for frame in frames] == [480, 480, 240]
+    assert b"".join(bytes(frame.data) for frame in frames) == pcm16_bytes(audio)
+
+
+async def test_driver_closes_session_after_turn_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("livekit.agents")
+    import numpy as np
+    from livekit.agents import Agent, AgentSession, TurnHandlingOptions
+
+    import arksim.integrations.livekit as livekit_integration
+    from arksim.speech.types import AudioBuffer
+
+    class SilentSession(AgentSession):
+        def __init__(self) -> None:
+            super().__init__(
+                vad=None,
+                turn_handling=TurnHandlingOptions(turn_detection="manual"),
+            )
+            self.closed = False
+            self.consumer: asyncio.Task[None] | None = None
+
+        async def start(self, agent: Agent, *, record: bool = False) -> None:
+            async def consume_audio() -> None:
+                assert self.input.audio is not None
+                async for _ in self.input.audio:
+                    pass
+
+            self.consumer = asyncio.create_task(consume_audio())
+
+        async def wait_for_idle(self) -> object:
+            return object()
+
+        def commit_user_turn(
+            self,
+            *,
+            transcript_timeout: float = 2.0,
+            stt_flush_duration: float = 2.0,
+            skip_reply: bool = False,
+        ) -> asyncio.Future[str]:
+            future: asyncio.Future[str] = asyncio.Future()
+            future.set_result("hello")
+            return future
+
+        async def aclose(self) -> None:
+            self.closed = True
+            if self.consumer is not None:
+                await self.consumer
+
+    class FakeTTS:
+        async def synthesize(self, text: str) -> AudioBuffer:
+            return AudioBuffer(np.zeros(160), 16000)
+
+    class FakeSTT:
+        async def transcribe(self, audio: AudioBuffer) -> str:
+            return "unused"
+
+    monkeypatch.setattr(livekit_integration, "_TURN_TIMEOUT_S", 0.01)
+    session = SilentSession()
+    agent = Agent(instructions="Be concise.")
+    driver = livekit_integration.LiveKitVoiceDriver(
+        lambda: (session, agent), tts=FakeTTS(), stt=FakeSTT()
+    )
+
+    with pytest.raises(TimeoutError, match="did not complete"):
+        await driver.run_turn("hello")
+
+    assert session.closed
+    assert driver._session is None

--- a/tests/unit/test_module_loader.py
+++ b/tests/unit/test_module_loader.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 import pytest
 
-from arksim.utils.module_loader import _module_cache, load_module_from_file
+from arksim.utils.module_loader import (
+    _module_cache,
+    load_callable,
+    load_module_from_file,
+)
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -143,3 +147,39 @@ class TestLoadModuleErrors:
         arksim_modules_after = {k for k in sys.modules if k.startswith("_arksim_")}
         # No new _arksim_ entries should remain
         assert arksim_modules_after == arksim_modules_before
+
+
+# ── load_callable tests ──────────────────────────────────────────────────────
+
+
+class TestLoadCallable:
+    """Tests for resolving 'module_or_path:attribute' pointers to callables."""
+
+    def test_from_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "factory_mod.py"
+        p.write_text("def build():\n    return 'made'\n")
+        fn = load_callable(f"{p}:build")
+        assert callable(fn)
+        assert fn() == "made"
+
+    def test_from_dotted_module(self) -> None:
+        fn = load_callable("os.path:join")
+        assert fn("a", "b").endswith("b")
+
+    def test_missing_colon_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "factory_mod.py"
+        p.write_text("def build():\n    return 1\n")
+        with pytest.raises(ValueError, match="must be 'module_or_path:attribute'"):
+            load_callable(str(p))
+
+    def test_missing_attribute_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "factory_mod.py"
+        p.write_text("def build():\n    return 1\n")
+        with pytest.raises(AttributeError, match="has no attribute 'nope'"):
+            load_callable(f"{p}:nope")
+
+    def test_not_callable_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "factory_mod.py"
+        p.write_text("value = 42\n")
+        with pytest.raises(TypeError, match="is not callable"):
+            load_callable(f"{p}:value")

--- a/tests/unit/test_pipecat_voice_driver.py
+++ b/tests/unit/test_pipecat_voice_driver.py
@@ -43,3 +43,15 @@ async def test_driver_runs_one_turn_with_tool_call() -> None:
         assert resp2.content == "agent reply"
     finally:
         await driver.close()
+
+
+def test_resample_downsamples_to_target_rate() -> None:
+    pytest.importorskip("pipecat")
+    import numpy as np
+
+    from arksim.integrations.pipecat import _resample
+    from arksim.speech.types import AudioBuffer
+
+    out = _resample(AudioBuffer(np.zeros(2400, dtype=np.float32), 24000), 16000)
+    assert out.sample_rate == 16000
+    assert abs(len(out.samples) - 1600) <= 1

--- a/tests/unit/test_pipecat_voice_driver.py
+++ b/tests/unit/test_pipecat_voice_driver.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="pipecat requires 3.11+"
+)
+
+
+async def test_driver_runs_one_turn_with_tool_call() -> None:
+    pytest.importorskip("pipecat")
+    import numpy as np
+
+    from arksim.integrations.pipecat import (
+        PipecatVoiceDriver,
+        _build_echo_stages_for_test,
+    )
+    from arksim.simulation_engine.tool_types import ToolCallSource
+    from arksim.speech.types import AudioBuffer
+
+    class FakeTTS:
+        async def synthesize(self, text: str) -> AudioBuffer:
+            return AudioBuffer(np.zeros(2400, dtype=np.float32), 24000)
+
+    class FakeSTT:
+        async def transcribe(self, audio: AudioBuffer) -> str:
+            return "agent reply"
+
+    driver = PipecatVoiceDriver(
+        _build_echo_stages_for_test, tts=FakeTTS(), stt=FakeSTT()
+    )
+    try:
+        resp = await driver.run_turn("hello agent")
+        assert resp.content == "agent reply"
+        assert len(resp.tool_calls) == 1
+        assert resp.tool_calls[0].name == "lookup_order"
+        assert resp.tool_calls[0].source is ToolCallSource.PIPECAT
+        # second turn proves the worker is reused
+        resp2 = await driver.run_turn("again")
+        assert resp2.content == "agent reply"
+    finally:
+        await driver.close()

--- a/tests/unit/test_pipecat_voice_driver.py
+++ b/tests/unit/test_pipecat_voice_driver.py
@@ -45,6 +45,70 @@ async def test_driver_runs_one_turn_with_tool_call() -> None:
         await driver.close()
 
 
+async def test_driver_drives_vad_gated_stt() -> None:
+    """The driver must emit VAD speaking frames so a segmented STT transcribes.
+
+    Guards against regressions where the VAD bracket is dropped: a real pipecat
+    SegmentedSTTService only runs on VADUserStoppedSpeakingFrame, so without it
+    the turn would time out. No models needed.
+    """
+    pytest.importorskip("pipecat")
+    import numpy as np
+    from pipecat.frames.frames import (
+        Frame,
+        InputAudioRawFrame,
+        TTSAudioRawFrame,
+        TTSStartedFrame,
+        TTSStoppedFrame,
+        VADUserStoppedSpeakingFrame,
+    )
+    from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+    from arksim.integrations.pipecat import PipecatVoiceDriver
+    from arksim.speech.types import AudioBuffer
+
+    class VadGatedStt(FrameProcessor):
+        def __init__(self) -> None:
+            super().__init__()
+            self._got_audio = False
+
+        async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+            await super().process_frame(frame, direction)
+            if isinstance(frame, InputAudioRawFrame):
+                self._got_audio = True
+                await self.push_frame(frame, direction)
+            elif isinstance(frame, VADUserStoppedSpeakingFrame) and self._got_audio:
+                self._got_audio = False
+                await self.push_frame(TTSStartedFrame(), FrameDirection.DOWNSTREAM)
+                await self.push_frame(
+                    TTSAudioRawFrame(
+                        audio=b"\x00\x00" * 800, sample_rate=16000, num_channels=1
+                    ),
+                    FrameDirection.DOWNSTREAM,
+                )
+                await self.push_frame(TTSStoppedFrame(), FrameDirection.DOWNSTREAM)
+                await self.push_frame(frame, direction)
+            else:
+                await self.push_frame(frame, direction)
+
+    class FakeTTS:
+        async def synthesize(self, text: str) -> AudioBuffer:
+            return AudioBuffer(np.zeros(2400, dtype=np.float32), 24000)
+
+    class FakeSTT:
+        async def transcribe(self, audio: AudioBuffer) -> str:
+            return "vad reply"
+
+    driver = PipecatVoiceDriver(
+        lambda: (None, [VadGatedStt()]), tts=FakeTTS(), stt=FakeSTT()
+    )
+    try:
+        resp = await driver.run_turn("hi")
+        assert resp.content == "vad reply"
+    finally:
+        await driver.close()
+
+
 def test_resample_downsamples_to_target_rate() -> None:
     pytest.importorskip("pipecat")
     import numpy as np

--- a/tests/unit/test_pipecat_voice_driver.py
+++ b/tests/unit/test_pipecat_voice_driver.py
@@ -109,6 +109,42 @@ async def test_driver_drives_vad_gated_stt() -> None:
         await driver.close()
 
 
+async def test_driver_closes_pipeline_after_turn_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("pipecat")
+    import numpy as np
+    from pipecat.frames.frames import Frame
+    from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+    import arksim.integrations.pipecat as pipecat_integration
+    from arksim.speech.types import AudioBuffer
+
+    class FakeTTS:
+        async def synthesize(self, text: str) -> AudioBuffer:
+            return AudioBuffer(np.zeros(160), 16000)
+
+    class FakeSTT:
+        async def transcribe(self, audio: AudioBuffer) -> str:
+            return "unused"
+
+    class SilentStage(FrameProcessor):
+        async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+            await super().process_frame(frame, direction)
+            await self.push_frame(frame, direction)
+
+    monkeypatch.setattr(pipecat_integration, "_TURN_TIMEOUT_S", 0.01)
+    driver = pipecat_integration.PipecatVoiceDriver(
+        lambda: [SilentStage()], tts=FakeTTS(), stt=FakeSTT()
+    )
+
+    with pytest.raises(TimeoutError, match="produced no audio"):
+        await driver.run_turn("hello")
+
+    assert driver._task is None
+    assert driver._runner_run is None
+
+
 def test_resample_downsamples_to_target_rate() -> None:
     pytest.importorskip("pipecat")
     import numpy as np
@@ -119,3 +155,33 @@ def test_resample_downsamples_to_target_rate() -> None:
     out = _resample(AudioBuffer(np.zeros(2400, dtype=np.float32), 24000), 16000)
     assert out.sample_rate == 16000
     assert abs(len(out.samples) - 1600) <= 1
+
+
+def test_resample_downmixes_stereo_even_at_target_rate() -> None:
+    pytest.importorskip("pipecat")
+    import numpy as np
+
+    from arksim.integrations.pipecat import _resample
+    from arksim.speech.types import AudioBuffer
+
+    stereo = AudioBuffer(
+        np.array([1.0, -1.0, 0.5, 0.5], dtype=np.float32),
+        sample_rate=16000,
+        num_channels=2,
+    )
+
+    out = _resample(stereo, 16000)
+
+    assert out.num_channels == 1
+    assert out.samples == pytest.approx([0.0, 0.5])
+
+
+def test_resample_rejects_invalid_target_rate() -> None:
+    pytest.importorskip("pipecat")
+    import numpy as np
+
+    from arksim.integrations.pipecat import _resample
+    from arksim.speech.types import AudioBuffer
+
+    with pytest.raises(ValueError, match="target_rate"):
+        _resample(AudioBuffer(np.zeros(10), 16000), 0)

--- a/tests/unit/test_simulation_input.py
+++ b/tests/unit/test_simulation_input.py
@@ -96,3 +96,30 @@ class TestSimulationInputPathResolution:
             context=self._ctx(tmp_path),
         )
         assert si.agent_config_file_path == str(tmp_path / "agent.json")
+
+    def _voice_data(self, factory: str) -> dict:
+        return {
+            "agent_config": {
+                "agent_name": "v",
+                "agent_type": "voice",
+                "voice_config": {"framework": "pipecat", "agent_factory": factory},
+            }
+        }
+
+    def test_voice_agent_factory_file_resolves(self, tmp_path: Path) -> None:
+        """A file-path agent_factory is rebased to the config dir; attr kept."""
+        si = SimulationInput.model_validate(
+            self._voice_data("./agent.py:build"),
+            context=self._ctx(tmp_path),
+        )
+        assert si.agent_config.voice_config.agent_factory == (
+            f"{tmp_path / 'agent.py'}:build"
+        )
+
+    def test_voice_dotted_factory_not_rebased(self, tmp_path: Path) -> None:
+        """A dotted-module agent_factory is left unchanged (not a file path)."""
+        si = SimulationInput.model_validate(
+            self._voice_data("my_pkg.module:build"),
+            context=self._ctx(tmp_path),
+        )
+        assert si.agent_config.voice_config.agent_factory == "my_pkg.module:build"

--- a/tests/unit/test_speech_local_providers.py
+++ b/tests/unit/test_speech_local_providers.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from arksim.config import SpeechProviderConfig
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="kokoro/pipecat require 3.11+"
+)
+
+
+async def test_kokoro_to_whisper_roundtrip() -> None:
+    pytest.importorskip("kokoro")
+    pytest.importorskip("faster_whisper")
+    from arksim.speech import create_stt, create_tts
+
+    tts = create_tts(SpeechProviderConfig(provider="kokoro"))
+    stt = create_stt(SpeechProviderConfig(provider="faster_whisper", model="tiny.en"))
+    audio = await tts.synthesize("the quick brown fox")
+    assert audio.sample_rate == 24000
+    assert len(audio.samples) > 0
+    text = await stt.transcribe(audio)
+    assert "fox" in text.lower()

--- a/tests/unit/test_speech_registry.py
+++ b/tests/unit/test_speech_registry.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from arksim.config import SpeechProviderConfig
+from arksim.speech import (
+    AudioBuffer,
+    STTProvider,
+    TTSProvider,
+    create_stt,
+    create_tts,
+    register_stt,
+    register_tts,
+)
+
+
+@register_tts("fake")
+class _FakeTTS(TTSProvider):
+    async def synthesize(self, text: str) -> AudioBuffer:
+        return AudioBuffer(samples=np.zeros(16000, dtype=np.float32), sample_rate=16000)
+
+
+@register_stt("fake")
+class _FakeSTT(STTProvider):
+    async def transcribe(self, audio: AudioBuffer) -> str:
+        return f"len={len(audio.samples)}"
+
+
+async def test_create_and_roundtrip() -> None:
+    tts = create_tts(SpeechProviderConfig(provider="fake"))
+    stt = create_stt(SpeechProviderConfig(provider="fake"))
+    audio = await tts.synthesize("hello")
+    assert audio.sample_rate == 16000
+    assert await stt.transcribe(audio) == "len=16000"
+
+
+def test_unknown_tts_provider_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown TTS provider 'ghost'"):
+        create_tts(SpeechProviderConfig(provider="ghost"))
+
+
+def test_unknown_stt_provider_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown STT provider 'ghost'"):
+        create_stt(SpeechProviderConfig(provider="ghost"))

--- a/tests/unit/test_speech_types.py
+++ b/tests/unit/test_speech_types.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from arksim.speech.types import AudioBuffer, audio_from_pcm16, pcm16_bytes
+
+
+def test_audio_buffer_normalizes_samples_to_float32() -> None:
+    audio = AudioBuffer(samples=np.array([0, 1], dtype=np.int16), sample_rate=16000)
+
+    assert audio.samples.dtype == np.float32
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"samples": np.zeros((2, 2)), "sample_rate": 16000}, "one-dimensional"),
+        ({"samples": np.zeros(2), "sample_rate": 0}, "sample_rate"),
+        (
+            {"samples": np.zeros(2), "sample_rate": 16000, "num_channels": 0},
+            "num_channels",
+        ),
+        (
+            {"samples": np.zeros(3), "sample_rate": 16000, "num_channels": 2},
+            "divisible",
+        ),
+    ],
+)
+def test_audio_buffer_rejects_invalid_shape_or_metadata(
+    kwargs: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        AudioBuffer(**kwargs)
+
+
+def test_pcm16_roundtrip_clips_and_preserves_metadata() -> None:
+    original = AudioBuffer(
+        samples=np.array([-2.0, -0.5, 0.5, 2.0], dtype=np.float32),
+        sample_rate=24000,
+        num_channels=2,
+    )
+
+    decoded = audio_from_pcm16(
+        pcm16_bytes(original),
+        sample_rate=original.sample_rate,
+        num_channels=original.num_channels,
+    )
+
+    assert decoded.sample_rate == 24000
+    assert decoded.num_channels == 2
+    assert decoded.samples == pytest.approx(
+        [-1.0, -0.5, 0.5, 32767 / 32768], abs=1 / 32768
+    )

--- a/tests/unit/test_voice_agent.py
+++ b/tests/unit/test_voice_agent.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pytest
+
+from arksim.config import AgentConfig
+from arksim.simulation_engine.agent.clients.voice import VoiceAgent
+from arksim.simulation_engine.tool_types import AgentResponse
+
+
+def _cfg(framework: str = "pipecat") -> AgentConfig:
+    return AgentConfig.model_validate(
+        {
+            "agent_name": "v",
+            "agent_type": "voice",
+            "voice_config": {"framework": framework, "agent_factory": "os.path:join"},
+        }
+    )
+
+
+async def test_voice_agent_delegates_to_driver(monkeypatch: pytest.MonkeyPatch) -> None:
+    class StubDriver:
+        async def run_turn(self, q: str) -> AgentResponse:
+            return AgentResponse(content=f"heard: {q}")
+
+        async def get_chat_id(self) -> str:
+            return "chat-1"
+
+        async def close(self) -> None:
+            return None
+
+    import arksim.simulation_engine.agent.clients.voice as mod
+
+    monkeypatch.setattr(mod, "_build_driver_for", lambda cfg: StubDriver())
+
+    agent = VoiceAgent(_cfg())
+    resp = await agent.execute("hello")
+    assert isinstance(resp, AgentResponse)
+    assert resp.content == "heard: hello"
+    assert await agent.get_chat_id() == "chat-1"
+    await agent.close()
+
+
+async def test_livekit_not_implemented_in_v1() -> None:
+    agent = VoiceAgent(_cfg(framework="livekit"))
+    with pytest.raises(NotImplementedError, match="LiveKit"):
+        await agent.execute("hi")
+
+
+def test_factory_builds_voice_agent() -> None:
+    from arksim.simulation_engine.agent.factory import create_agent
+
+    agent = create_agent(_cfg())
+    assert isinstance(agent, VoiceAgent)

--- a/tests/unit/test_voice_agent.py
+++ b/tests/unit/test_voice_agent.py
@@ -41,12 +41,6 @@ async def test_voice_agent_delegates_to_driver(monkeypatch: pytest.MonkeyPatch) 
     await agent.close()
 
 
-async def test_livekit_not_implemented_in_v1() -> None:
-    agent = VoiceAgent(_cfg(framework="livekit"))
-    with pytest.raises(NotImplementedError, match="LiveKit"):
-        await agent.execute("hi")
-
-
 def test_factory_builds_voice_agent() -> None:
     from arksim.simulation_engine.agent.factory import create_agent
 

--- a/tests/unit/test_voice_agent.py
+++ b/tests/unit/test_voice_agent.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import sys
+from types import ModuleType, SimpleNamespace
+
 import pytest
 
 from arksim.config import AgentConfig
@@ -19,6 +22,8 @@ def _cfg(framework: str = "pipecat") -> AgentConfig:
 
 
 async def test_voice_agent_delegates_to_driver(monkeypatch: pytest.MonkeyPatch) -> None:
+    close_calls = 0
+
     class StubDriver:
         async def run_turn(self, q: str) -> AgentResponse:
             return AgentResponse(content=f"heard: {q}")
@@ -27,7 +32,8 @@ async def test_voice_agent_delegates_to_driver(monkeypatch: pytest.MonkeyPatch) 
             return "chat-1"
 
         async def close(self) -> None:
-            return None
+            nonlocal close_calls
+            close_calls += 1
 
     import arksim.simulation_engine.agent.clients.voice as mod
 
@@ -39,6 +45,8 @@ async def test_voice_agent_delegates_to_driver(monkeypatch: pytest.MonkeyPatch) 
     assert resp.content == "heard: hello"
     assert await agent.get_chat_id() == "chat-1"
     await agent.close()
+    await agent.close()
+    assert close_calls == 1
 
 
 def test_factory_builds_voice_agent() -> None:
@@ -46,3 +54,48 @@ def test_factory_builds_voice_agent() -> None:
 
     agent = create_agent(_cfg())
     assert isinstance(agent, VoiceAgent)
+
+
+@pytest.mark.parametrize(
+    ("framework", "module_name", "driver_name"),
+    [
+        ("pipecat", "arksim.integrations.pipecat", "PipecatVoiceDriver"),
+        ("livekit", "arksim.integrations.livekit", "LiveKitVoiceDriver"),
+    ],
+)
+def test_build_driver_selects_framework_without_eager_optional_imports(
+    monkeypatch: pytest.MonkeyPatch,
+    framework: str,
+    module_name: str,
+    driver_name: str,
+) -> None:
+    import arksim.simulation_engine.agent.clients.voice as voice_module
+    import arksim.speech as speech_module
+
+    created: dict[str, object] = {}
+
+    class StubDriver:
+        def __init__(self, factory: object, *, tts: object, stt: object) -> None:
+            created.update(factory=factory, tts=tts, stt=stt)
+
+    integration_module = ModuleType(module_name)
+    setattr(integration_module, driver_name, StubDriver)
+    monkeypatch.setitem(sys.modules, module_name, integration_module)
+
+    factory = object()
+    monkeypatch.setattr(voice_module, "load_callable", lambda pointer: factory)
+    monkeypatch.setattr(speech_module, "create_tts", lambda config: "tts")
+    monkeypatch.setattr(speech_module, "create_stt", lambda config: "stt")
+
+    driver = voice_module._build_driver_for(_cfg(framework))
+
+    assert isinstance(driver, StubDriver)
+    assert created == {"factory": factory, "tts": "tts", "stt": "stt"}
+
+
+def test_build_driver_rejects_missing_voice_config() -> None:
+    import arksim.simulation_engine.agent.clients.voice as voice_module
+
+    config = SimpleNamespace(voice_config=None)
+    with pytest.raises(ValueError, match="requires voice_config"):
+        voice_module._build_driver_for(config)

--- a/tests/unit/test_voice_config.py
+++ b/tests/unit/test_voice_config.py
@@ -40,6 +40,11 @@ def test_voice_config_accepts_explicit_providers() -> None:
     assert cfg.voice_config.tts.options == {"voice": "af_heart"}
 
 
+def test_voice_config_accepts_livekit_framework() -> None:
+    cfg = AgentConfig.model_validate(_voice_dict(framework="livekit"))
+    assert cfg.voice_config.framework is VoiceFramework.LIVEKIT
+
+
 def test_voice_agent_requires_voice_config() -> None:
     with pytest.raises(ValueError, match="requires 'voice_config'"):
         AgentConfig(agent_name="x", agent_type="voice")

--- a/tests/unit/test_voice_config.py
+++ b/tests/unit/test_voice_config.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from arksim.config import AgentConfig, VoiceConfig, VoiceFramework
+
+
+def _voice_dict(**over: object) -> dict:
+    base = {
+        "agent_name": "support-bot",
+        "agent_type": "voice",
+        "voice_config": {
+            "framework": "pipecat",
+            "agent_factory": "./agent.py:build",
+        },
+    }
+    base["voice_config"].update(over)
+    return base
+
+
+def test_voice_config_parses_and_defaults_local_providers() -> None:
+    cfg = AgentConfig.model_validate(_voice_dict())
+    assert cfg.agent_type == "voice"
+    assert cfg.voice_config.framework is VoiceFramework.PIPECAT
+    assert cfg.voice_config.agent_factory == "./agent.py:build"
+    assert cfg.voice_config.tts.provider == "kokoro"
+    assert cfg.voice_config.stt.provider == "faster_whisper"
+
+
+def test_voice_config_accepts_explicit_providers() -> None:
+    cfg = AgentConfig.model_validate(
+        _voice_dict(
+            tts={"provider": "kokoro", "options": {"voice": "af_heart"}},
+            stt={"provider": "faster_whisper", "model": "base.en"},
+        )
+    )
+    assert cfg.voice_config.stt.model == "base.en"
+    assert cfg.voice_config.tts.options == {"voice": "af_heart"}
+
+
+def test_voice_agent_requires_voice_config() -> None:
+    with pytest.raises(ValueError, match="requires 'voice_config'"):
+        AgentConfig(agent_name="x", agent_type="voice")
+
+
+def test_unknown_framework_rejected() -> None:
+    with pytest.raises(ValidationError):
+        AgentConfig.model_validate(_voice_dict(framework="nope"))
+
+
+def test_voice_config_constructed_directly() -> None:
+    vc = VoiceConfig(framework=VoiceFramework.PIPECAT, agent_factory="m:build")
+    assert vc.tts.provider == "kokoro"
+    assert vc.stt.provider == "faster_whisper"


### PR DESCRIPTION
## Summary

Adds a native `voice` agent type for evaluating Pipecat and LiveKit Agents through their real speech pipelines. ArkSim synthesizes each simulated-user turn, injects audio into the framework's STT → LLM → TTS stack, captures the spoken reply, and transcribes it for the existing simulation and evaluation workflow.

The evaluation adapters use in-memory audio I/O, so CI and batch simulations do not require a microphone, speaker, Pipecat transport, or LiveKit room.

## Changes

- Adds `agent_type: voice` with a `framework` discriminator for `pipecat` and `livekit`.
- Adds pluggable ArkSim-side speech providers with local Kokoro TTS and faster-whisper STT defaults.
- Adds a Pipecat driver that injects VAD-bracketed 16 kHz audio, runs the framework pipeline, captures TTS frames, and records tool calls with source `pipecat`.
- Adds a LiveKit driver that attaches custom `AgentSession` audio I/O, controls manual turn boundaries, flushes streaming STT with explicit silence, captures complete playback segments, and records tool events with source `livekit`.
- Validates PCM metadata, safely downmixes stereo Pipecat input, and closes failed sessions/pipelines after timeouts or empty replies.
- Resolves file-based `agent_factory` pointers relative to the simulation config.
- Adds optional extras:
  - `arksim[voice]` — Pipecat + local speech providers
  - `arksim[livekit-voice]` — LiveKit Agents + local speech providers
  - `arksim[voice-all]` — both frameworks
- Adds complete Pipecat and LiveKit examples, including a key-free local Pipecat smoke test.
- Documents voice as a first-class connection type in the README, integration catalog, simulation guide, schema reference, and changelog.

## Factory contracts

```yaml
agent_config:
  agent_type: voice
  agent_name: support-voice
  voice_config:
    framework: livekit # or pipecat
    agent_factory: ./agent.py:build
    tts:
      provider: kokoro
    stt:
      provider: faster_whisper
      model: base.en
```

- Pipecat factories return `(LLMContext, [pipeline stages])`.
- LiveKit factories return `(AgentSession, Agent)` and configure manual turn detection.

## Validation

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `pre-commit run --all-files`
- [x] `pytest tests/` — 954 passed, 8 skipped
- [x] Coverage — 79.42% overall; 94% Pipecat driver and 89% LiveKit driver locally
- [x] Isolated wheel build; both integration modules are present in the wheel
- [x] Pipecat in-memory soak — 5/5 conversations, 14 voice turns, 101.96 seconds, no execution failures
- [x] LiveKit in-memory soak — 5/5 conversations, 12 voice turns, 87.54 seconds, no execution failures
- [x] Pipecat SmallWebRTC browser test — real microphone input and human-audible agent reply
- [x] LiveKit Cloud browser test — real room transport, microphone input, subscribed agent audio track, and human-audible reply

The browser transport tests used temporary room/transport runners around the same STT/LLM/TTS stack. ArkSim's production evaluation path remains intentionally transport-independent.

## Scope and compatibility

- This PR evaluates conversational behavior through real speech services. Network impairment, word-error-rate scoring, interruption metrics, and accent/noise/volume perturbations remain follow-up work.
- Local Whisper `base.en` is suitable for reproducible smoke testing but is not presented as production-grade transcription quality.
- `arksim[voice]` and `arksim[voice-all]` currently target Python 3.11–3.12. `arksim[livekit-voice]` targets Python 3.10–3.12 because of the current Kokoro dependency range.

## Reviewers

/cc @arklexai/arksim-maintainers
